### PR TITLE
feat: add opencodego.freeOnly to expose paid Zen models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the **OpenCode Go BYOK Provider** extension are documente
 
 ## Unreleased
 
+### Added
+
+- Added `opencodego.freeOnly` to control whether the OpenCode Zen provider exposes only free models or the full Zen catalog.
+
 ### Fixed
 
 - Filter deprecated OpenCode models using the models.dev registry before registering them with VS Code, with a local safety list for free models that now return provider 404s (`ring-2.6-1t-free`, `trinity-large-preview-free`).

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This lets you pick and use OpenCode models directly from the Copilot Chat model 
 ## ✨ Features
 
 - **BYOK** — configure OpenCode Go and OpenCode Zen independently with separate API keys, both active at the same time
-- **Live model list** — fetches available Go models and Zen free models directly from OpenCode on every startup
+- **Live model list** — fetches available Go models and Zen models directly from OpenCode on every startup
 - **Bundled fallback** — works offline or if the API is unreachable, using a curated model table with accurate token limits
 - **Per-model token limits** — precise context window and max output token values per model, not a single global cap
 - **Tool-calling support** — forwards tool schemas using OpenAI-compatible or Anthropic-compatible request shapes automatically based on the model endpoint
@@ -72,7 +72,7 @@ For advanced usage, you can also run these commands via the Command Palette (`Cm
 | `OpenCode Go: Manage Provider` | Manage legacy fallback API key, refresh models, or test connection |
 | `OpenCode Go: Set API Key` | Store or update a legacy fallback OpenCode Go API key |
 | `OpenCode Go: Diagnostics` | Show a markdown report of all registered OpenCode Go models |
-| `OpenCode Zen: Diagnostics` | Show a markdown report of all registered OpenCode Zen free models |
+| `OpenCode Zen: Diagnostics` | Show a markdown report of all registered OpenCode Zen models |
 
 > **Note:** The native BYOK flow via **Language Models** (gear icon ⚙) is recommended. VS Code will ask for a group name, then the matching API key. Go and Zen are separate provider groups, so both can be active at the same time.
 
@@ -86,6 +86,7 @@ For advanced usage, you can also run these commands via the Command Palette (`Cm
 | `opencodego.maxTokens` | `number` | `0` | Max output token override — `0` uses the per-model bundled maximum |
 | `opencodego.maxInputTokens` | `number` | `0` | Context window override — `0` uses the per-model bundled context size |
 | `opencodego.debugReasoning` | `boolean` | `false` | Write provider `reasoning_content` to **Output → OpenCode** for debugging |
+| `opencodego.freeOnly`      | `boolean` | `true`  | Limit OpenCode Zen to free models only. Disable to include paid Zen models in the picker |
 
 ---
 
@@ -98,7 +99,7 @@ https://opencode.ai/zen/go/v1/models   (OpenCode Go — paid)
 https://opencode.ai/zen/v1/models       (OpenCode Zen — free)
 ```
 
-The **Go provider** exposes all OpenCode Go models. The **Zen provider** filters the live Zen list to free chat-completions-compatible models (`*-free` plus `big-pickle`) so paid Zen models do not appear unless support is added intentionally.
+The **Go provider** exposes all OpenCode Go models. The **Zen provider** filters the live Zen list to free chat-completions-compatible models (`*-free` plus `big-pickle`) by default. Set `opencodego.freeOnly` to `false` to include paid Zen models in the picker.
 
 Because the endpoints return model IDs only, a bundled metadata table provides context window and max output tokens per model. Deprecated or known-unavailable models are filtered using the models.dev registry plus a small local safety list, so stale free models do not remain visible just because OpenCode still returns them from `/models`. If the live fetch fails, the bundled list is used as a fallback.
 

--- a/package.json
+++ b/package.json
@@ -90,6 +90,11 @@
           "type": "boolean",
           "default": false,
           "description": "Write provider reasoning_content to the OpenCode output channel for debugging. Reasoning is not shown in Copilot Chat."
+        },
+        "opencodego.freeOnly": {
+          "type": "boolean",
+          "default": true,
+          "description": "When enabled, only free OpenCode Zen models are shown in the Copilot model selector. Disable to include paid Zen models as well."
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -72,7 +72,7 @@ const PROVIDERS: Record<ProviderDefinition["vendor"], ProviderDefinition> = {
       "qwen3.6-plus-free",
       "big-pickle"
     ],
-    filterModel: (modelId) => modelId.endsWith("-free") || FREE_ZEN_MODEL_IDS.has(modelId)
+    filterModel: (modelId) => vscode.workspace.getConfiguration("opencodego").get("freeOnly", true) ? modelId.endsWith("-free") || FREE_ZEN_MODEL_IDS.has(modelId) : true
   }
 };
 


### PR DESCRIPTION
## Summary

Adds a user-controllable boolean setting `opencodego.freeOnly` (default: `true`) that
controls whether the **OpenCode Zen** provider filters models to only free
(`*-free` + `big-pickle`) entries. Setting it to `false` exposes the full Zen
model catalog — including paid models — in the Copilot model selector.

## Changes

- **`package.json`** — registers `opencodego.freeOnly` under `contributes.configuration.properties`
- **`src/extension.ts`** — `PROVIDERS[ZEN_VENDOR].filterModel` now reads
  `vscode.workspace.getConfiguration("opencodego").get("freeOnly", true)`
- **`README.md`** — documents the new setting in the settings table and updates
  the Zen filtering description
- **`CHANGELOG.md`** — adds `[Unreleased]` entry

## Why `opencodego.freeOnly`?

The VS Code Settings UI groups all extension settings under a single title
("OpenCode"), so keeping the setting name under the `opencodego` namespace
matches the existing pattern used by `temperature`, `maxTokens`, and
`debugReasoning`.