### PR TITLE
Add dynamic OpenCode metadata and Zen GPT/Gemini routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ All notable changes to the **OpenCode Go BYOK Provider** extension are documente
 - Added a TTL-cached models.dev metadata snapshot, merged with live `/models` metadata and a bundled fallback catalog for offline picker registration.
 - Added native Zen GPT routing through `/responses` and Zen Gemini routing through the documented Google-style `/models/{model}:streamGenerateContent?alt=sse` endpoint.
 
+### Changed
+
+- Corrected fallback-advertised model limits to follow `models.dev` whenever the live `/models` payload does not provide limit metadata, fixing earlier Go/Zen cross-provider mix-ups in the bundled table.
+- This reduces several previously overstated fallback values, notably `deepseek-v4-flash-free` to `200000 / 128000`, `glm-5` and `glm-5.1` to `202752 / 32768`, and Go `minimax-m2.5` to `204800 / 65536`.
+
 ### Fixed
 
 - Updated bundled fallback limits and capability hints so the picker stays usable when neither `/models` nor models.dev can be refreshed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to the **OpenCode Go BYOK Provider** extension are documente
 
 ## Unreleased
 
+## [0.1.6] — 2026-05-21
+
+### Added
+
+- Added configurable OpenCode request and streaming idle timeouts so Copilot Chat requests fail clearly instead of hanging indefinitely.
+- Added sticky OpenCode request headers (`x-opencode-session`, `x-opencode-request`, `x-opencode-client`) so Go and Zen requests preserve gateway affinity behavior.
+- Added clearer rate-limit and quota handling, including retry/quota details from response headers when available.
+- Added a TTL-cached models.dev metadata snapshot, merged with live `/models` metadata and a bundled fallback catalog for offline picker registration.
+- Added native Zen GPT routing through `/responses` and Zen Gemini routing through the documented Google-style `/models/{model}:streamGenerateContent?alt=sse` endpoint.
+
+### Fixed
+
+- Updated bundled fallback limits and capability hints so the picker stays usable when neither `/models` nor models.dev can be refreshed.
+- Zen Claude, Zen GPT, Zen Gemini, and Go MiniMax families now use the correct transport automatically instead of being forced through a single OpenAI-compatible route.
+
 ## [0.1.4] — 2026-05-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ This lets you pick and use OpenCode models directly from the Copilot Chat model 
 
 - **BYOK** — configure OpenCode Go and OpenCode Zen independently with separate API keys, both active at the same time
 - **Live model list** — fetches available Go models and Zen models directly from OpenCode on every startup
-- **Bundled fallback** — works offline or if the API is unreachable, using a curated model table with accurate token limits
-- **Per-model token limits** — precise context window and max output token values per model, not a single global cap
-- **Tool-calling support** — forwards tool schemas using OpenAI-compatible or Anthropic-compatible request shapes automatically based on the model endpoint
-- **Dual endpoint routing** — routes standard models to `/chat/completions` and MiniMax M2 models to `/messages` transparently
+- **TTL-cached metadata** — merges live `/models` metadata with a 6-hour models.dev snapshot to resolve context window, output limits, image support, and deprecation state
+- **Bundled fallback** — keeps the picker usable offline with an internal fallback catalog when live metadata cannot be refreshed yet
+- **Tool-calling support** — forwards tool schemas using the request shape each routed model family expects
+- **Native transport compatibility** — routes Zen GPT to `/responses`, Zen Gemini to the documented Google-style endpoint, Zen Claude to `/messages`, Go MiniMax to `/messages`, and the remaining models to `/chat/completions`
+- **Safer requests** — adds sticky routing headers plus request and stream idle timeouts with clearer rate-limit/quota errors in VS Code
 - **Diagnostics command** — one-click markdown report showing exactly which models VS Code has registered
 
 ---
@@ -86,6 +87,8 @@ For advanced usage, you can also run these commands via the Command Palette (`Cm
 | `opencodego.maxTokens` | `number` | `0` | Max output token override — `0` uses the per-model bundled maximum |
 | `opencodego.maxInputTokens` | `number` | `0` | Context window override — `0` uses the per-model bundled context size |
 | `opencodego.debugReasoning` | `boolean` | `false` | Write provider `reasoning_content` to **Output → OpenCode** for debugging |
+| `opencodego.requestTimeoutSeconds` | `number` | `600` | Total request timeout for OpenCode Go and Zen API calls |
+| `opencodego.streamIdleTimeoutSeconds` | `number` | `120` | Cancels a request if the response stream stops sending chunks for too long |
 | `opencodego.freeOnly`      | `boolean` | `true`  | Limit OpenCode Zen to free models only. Disable to include paid Zen models in the picker |
 
 ---
@@ -99,11 +102,17 @@ https://opencode.ai/zen/go/v1/models   (OpenCode Go — paid)
 https://opencode.ai/zen/v1/models       (OpenCode Zen — free)
 ```
 
-The **Go provider** exposes all OpenCode Go models. The **Zen provider** filters the live Zen list to free chat-completions-compatible models (`*-free` plus `big-pickle`) by default. Set `opencodego.freeOnly` to `false` to include paid Zen models in the picker.
+The **Go provider** exposes all OpenCode Go models. The **Zen provider** filters the live Zen list to free models (`*-free` plus `big-pickle`) by default. Set `opencodego.freeOnly` to `false` to include paid Zen models in the picker.
 
-Because the endpoints return model IDs only, a bundled metadata table provides context window and max output tokens per model. Deprecated or known-unavailable models are filtered using the models.dev registry plus a small local safety list, so stale free models do not remain visible just because OpenCode still returns them from `/models`. If the live fetch fails, the bundled list is used as a fallback.
+Model limits and capabilities are resolved in this order:
 
-VS Code and Copilot read separate input/output metadata fields for UI display. The extension advertises the exact context window from the official [models.dev](https://models.dev) registry so the **Language Models** table, model picker tooltip, and chat context indicator all show accurate values. All limits are sourced from the models.dev registry (the same registry used by OpenCode itself).
+1. Live metadata returned by OpenCode `/models` when available.
+2. A 6-hour models.dev snapshot cached in VS Code global state.
+3. The bundled fallback catalog shipped with the extension.
+
+Deprecated or known-unavailable models are filtered before registration, so stale Zen entries do not remain visible just because they still appear in `/models`.
+
+VS Code and Copilot read separate input/output metadata fields for UI display. The extension advertises the resolved context window so the **Language Models** table, model picker tooltip, and chat context indicator stay aligned with the latest metadata it can reach.
 
 ### Bundled model limits
 
@@ -115,23 +124,26 @@ All limits are sourced from the [models.dev](https://models.dev) registry. Per-p
 |---|---:|---:|
 | `deepseek-v4-pro` / `deepseek-v4-flash` | 1,000,000 | 384,000 |
 | `mimo-v2.5-pro` / `mimo-v2-pro` | 1,048,576 | 128,000 |
-| `mimo-v2.5` | 1,000,000 | 128,000 |
-| `kimi-k2.6` / `kimi-k2.5` | 262,144 | 65,536 |
+| `mimo-v2.5` | 1,048,576 | 131,072 |
+| `kimi-k2.6` | 262,144 | 262,144 |
+| `kimi-k2.5` | 262,144 | 65,536 |
 | `qwen3.6-plus` / `qwen3.5-plus` | 262,144 | 65,536 |
 | `mimo-v2-omni` | 262,144 | 128,000 |
 | `hy3-preview` | 256,000 | 64,000 |
-| `minimax-m2.7` / `minimax-m2.5` | 204,800 | 131,072 |
-| `glm-5.1` / `glm-5` | 204,800 | 131,072 |
+| `minimax-m2.7` | 204,800 | 131,072 |
+| `minimax-m2.5` | 204,800 | 65,536 |
+| `glm-5.1` | 200,000 | 131,072 |
+| `glm-5` | 202,752 | 202,752 |
 
 **OpenCode Zen (free models)**
 
 | Model | Context window | Max output tokens |
 |---|---:|---:|
-| `deepseek-v4-flash-free` | 1,000,000 | 384,000 |
-| `qwen3.6-plus-free` | 262,144 | 65,536 |
+| `deepseek-v4-flash-free` | 200,000 | 128,000 |
+| `qwen3.6-plus-free` | 200,000 | 128,000 |
 | `minimax-m2.5-free` | 204,800 | 131,072 |
-| `nemotron-3-super-free` | 204,800 | 128,000 |
-| `big-pickle` | 200,000 | 128,000 |
+| `nemotron-3-super-free` | 256,000 | 256,000 |
+| `big-pickle` | 128,000 | 64,000 |
 
 Set `opencodego.maxInputTokens` or `opencodego.maxTokens` to a non-zero value to override the bundled defaults globally.
 
@@ -144,11 +156,21 @@ https://opencode.ai/zen/go/v1/chat/completions   (Go)
 https://opencode.ai/zen/v1/chat/completions       (Zen)
 ```
 
-OpenCode Go MiniMax M2 models (`minimax-m2.*`) are automatically routed to the Anthropic-compatible messages endpoint:
+The extension also routes these families automatically:
+
+- OpenCode Go MiniMax M2 models (`minimax-m2.*`) → `/messages`
+- OpenCode Zen Claude models (`claude-*`) → `/messages`
+- OpenCode Zen GPT models (`gpt-*`) → `/responses`
+- OpenCode Zen Gemini models (`gemini-*`) → `/models/{model}:streamGenerateContent?alt=sse`
 
 ```
 https://opencode.ai/zen/go/v1/messages
+https://opencode.ai/zen/v1/messages
+https://opencode.ai/zen/v1/responses
+https://opencode.ai/zen/v1/models/gemini-3.5-flash:streamGenerateContent?alt=sse
 ```
+
+Qwen chat models remain on `/chat/completions` with the hybrid stream parser already used by the extension, preserving the working tool/reasoning behavior from previous releases.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ VS Code and Copilot read separate input/output metadata fields for UI display. T
 
 ### Bundled model limits
 
-All limits are sourced from the [models.dev](https://models.dev) registry. Per-provider limits are tracked separately (Go vs Zen) so models shared across providers use the correct values for each.
+Limits are taken from the current [models.dev](https://models.dev) registry when available, with bundled fallback values retained for legacy entries that are no longer published there. Per-provider limits are tracked separately (Go vs Zen) so models shared across providers use the correct values for each.
 
 **OpenCode Go**
 
@@ -124,26 +124,26 @@ All limits are sourced from the [models.dev](https://models.dev) registry. Per-p
 |---|---:|---:|
 | `deepseek-v4-pro` / `deepseek-v4-flash` | 1,000,000 | 384,000 |
 | `mimo-v2.5-pro` / `mimo-v2-pro` | 1,048,576 | 128,000 |
-| `mimo-v2.5` | 1,048,576 | 131,072 |
-| `kimi-k2.6` | 262,144 | 262,144 |
+| `mimo-v2.5` | 1,000,000 | 128,000 |
+| `kimi-k2.6` | 262,144 | 65,536 |
 | `kimi-k2.5` | 262,144 | 65,536 |
 | `qwen3.6-plus` / `qwen3.5-plus` | 262,144 | 65,536 |
 | `mimo-v2-omni` | 262,144 | 128,000 |
 | `hy3-preview` | 256,000 | 64,000 |
 | `minimax-m2.7` | 204,800 | 131,072 |
 | `minimax-m2.5` | 204,800 | 65,536 |
-| `glm-5.1` | 200,000 | 131,072 |
-| `glm-5` | 202,752 | 202,752 |
+| `glm-5.1` | 202,752 | 32,768 |
+| `glm-5` | 202,752 | 32,768 |
 
 **OpenCode Zen (free models)**
 
 | Model | Context window | Max output tokens |
 |---|---:|---:|
 | `deepseek-v4-flash-free` | 200,000 | 128,000 |
-| `qwen3.6-plus-free` | 200,000 | 128,000 |
+| `qwen3.6-plus-free` | 262,144 | 65,536 |
 | `minimax-m2.5-free` | 204,800 | 131,072 |
-| `nemotron-3-super-free` | 256,000 | 256,000 |
-| `big-pickle` | 128,000 | 64,000 |
+| `nemotron-3-super-free` | 204,800 | 128,000 |
+| `big-pickle` | 200,000 | 128,000 |
 
 Set `opencodego.maxInputTokens` or `opencodego.maxTokens` to a non-zero value to override the bundled defaults globally.
 

--- a/package.json
+++ b/package.json
@@ -191,6 +191,7 @@
   },
   "scripts": {
     "compile": "tsc -p ./",
+    "test": "npm run compile && node --test",
     "watch": "tsc -watch -p ./",
     "package": "vsce package",
     "vscode:prepublish": "npm run compile"

--- a/package.json
+++ b/package.json
@@ -100,6 +100,18 @@
           "default": false,
           "description": "Write provider reasoning_content to the OpenCode output channel for debugging. Reasoning is not shown in Copilot Chat."
         },
+        "opencodego.requestTimeoutSeconds": {
+          "type": "number",
+          "default": 600,
+          "minimum": 1,
+          "description": "Total request timeout in seconds for OpenCode Go and Zen chat requests. Prevents long-running Copilot requests from hanging indefinitely."
+        },
+        "opencodego.streamIdleTimeoutSeconds": {
+          "type": "number",
+          "default": 120,
+          "minimum": 1,
+          "description": "Streaming idle timeout in seconds. If OpenCode stops sending response chunks for this long, the request is cancelled with a clear error."
+        },
         "opencodego.freeOnly": {
           "type": "boolean",
           "default": true,

--- a/package.json
+++ b/package.json
@@ -37,6 +37,12 @@
   ],
   "activationEvents": [
     "onStartupFinished",
+    "onCommand:opencodego.manage",
+    "onCommand:opencodego.diagnostics",
+    "onCommand:opencodego.setApiKey",
+    "onCommand:opencodezen.diagnostics",
+    "onCommand:opencodego.modelPickerDiagnostics",
+    "onCommand:opencodego.setThinkingEffort",
     "onLanguageModelChatProvider:opencodego",
     "onLanguageModelChatProvider:opencodezen"
   ],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "opencode-copilot-chat",
   "displayName": "OpenCode Copilot Chat",
   "description": "Bring your own OpenCode API key to VS Code Copilot Chat. Adds OpenCode Go and OpenCode Zen models through the Language Model Chat Provider API.",
-  "version": "0.1.4",
+  "version": "0.1.6",
   "publisher": "ltmoerdani",
   "license": "MIT",
   "icon": "media/opencodego.png",
@@ -37,11 +37,6 @@
   ],
   "activationEvents": [
     "onStartupFinished",
-    "onCommand:opencodego.manage",
-    "onCommand:opencodego.diagnostics",
-    "onCommand:opencodego.setApiKey",
-    "onCommand:opencodezen.diagnostics",
-    "onCommand:opencodego.setThinkingEffort",
     "onLanguageModelChatProvider:opencodego",
     "onLanguageModelChatProvider:opencodezen"
   ],

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,311 @@
+interface ParsedApiError {
+  message?: string;
+  code?: string;
+  type?: string;
+  retryIn?: string;
+}
+
+interface RateLimitInfo {
+  retryAfterMs?: number;
+  resetAfterMs?: number;
+  requestLimit?: string;
+  requestRemaining?: string;
+  tokenLimit?: string;
+  tokenRemaining?: string;
+}
+
+export class OpenCodeRequestError extends Error {
+  constructor(
+    message: string,
+    readonly userMessage: string = message,
+  ) {
+    super(message);
+    this.name = "OpenCodeRequestError";
+  }
+}
+
+export function buildOpenCodeRequestError(
+  providerDisplayName: string,
+  response: Response,
+  rawDetail: string,
+  modelId: string | undefined,
+  payloadBytes: number,
+  capacityHint: string,
+): OpenCodeRequestError {
+  const apiError = parseApiError(rawDetail);
+  const rateLimitInfo = readRateLimitInfo(response.headers);
+  const modelHint = modelId ? ` model=${modelId}` : "";
+  const sizeHint = ` payloadBytes=${payloadBytes}`;
+  const apiMessage =
+    (apiError.message ?? rawDetail.trim()) || response.statusText;
+  const isLimit = isRateLimitResponse(response.status, apiError);
+
+  if (isLimit) {
+    const waitText =
+      apiError.retryIn ??
+      formatWaitText(rateLimitInfo.retryAfterMs ?? rateLimitInfo.resetAfterMs);
+    const quotaText = formatRateLimitSummary(rateLimitInfo);
+    const reason = classifyRateLimit(apiError, response.status);
+    const details = [
+      shouldIncludeApiMessage(apiMessage, reason) ? apiMessage : undefined,
+      waitText ? `Retry after ${waitText}.` : undefined,
+      quotaText ? `Quota: ${quotaText}.` : undefined,
+    ].filter((part): part is string => Boolean(part));
+    const userMessage = `${providerDisplayName}: ${reason}${
+      modelHint ? ` (${modelId})` : ""
+    }. ${details.join(" ")}`.trim();
+    return new OpenCodeRequestError(
+      `${providerDisplayName} API rate/quota limit (${response.status})${modelHint}${sizeHint}: ${apiMessage}; ${quotaText || "no quota headers"}`,
+      userMessage,
+    );
+  }
+
+  const userMessage = `${providerDisplayName} API request failed (HTTP ${response.status})${modelHint ? ` for ${modelId}` : ""}: ${apiMessage}${capacityHint}`;
+  return new OpenCodeRequestError(
+    `${providerDisplayName} API request failed (${response.status})${modelHint}${sizeHint}${capacityHint}: ${apiMessage}`,
+    userMessage,
+  );
+}
+
+export function truncateForLog(value: string, max = 1200): string {
+  const collapsed = value.replace(/\s+/g, " ").trim();
+  return collapsed.length > max
+    ? `${collapsed.slice(0, max)}… (+${collapsed.length - max} chars)`
+    : collapsed;
+}
+
+function parseApiError(rawDetail: string): ParsedApiError {
+  const fallback = rawDetail.trim();
+  if (!fallback) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(fallback) as unknown;
+    if (!isRecord(parsed)) {
+      return { message: fallback };
+    }
+
+    const error = isRecord(parsed.error) ? parsed.error : parsed;
+    return {
+      message: firstString(error.message, parsed.message, fallback),
+      code: firstString(error.code, parsed.code),
+      type: firstString(error.type, parsed.type),
+      retryIn: firstString(
+        error.retryIn,
+        parsed.retryIn,
+        error.retry_in,
+        parsed.retry_in,
+      ),
+    };
+  } catch {
+    return { message: fallback };
+  }
+}
+
+export function readRateLimitInfo(headers: Headers): RateLimitInfo {
+  const retryAfter = firstHeader(headers, ["retry-after"]);
+  const requestLimit = firstHeader(headers, [
+    "x-ratelimit-limit-requests",
+    "anthropic-ratelimit-requests-limit",
+    "x-ratelimit-limit",
+    "ratelimit-limit",
+  ]);
+  const requestRemaining = firstHeader(headers, [
+    "x-ratelimit-remaining-requests",
+    "anthropic-ratelimit-requests-remaining",
+    "x-ratelimit-remaining",
+    "ratelimit-remaining",
+  ]);
+  const tokenLimit = firstHeader(headers, [
+    "x-ratelimit-limit-tokens",
+    "anthropic-ratelimit-tokens-limit",
+  ]);
+  const tokenRemaining = firstHeader(headers, [
+    "x-ratelimit-remaining-tokens",
+    "anthropic-ratelimit-tokens-remaining",
+  ]);
+  const reset = firstHeader(headers, [
+    "x-ratelimit-reset-requests",
+    "x-ratelimit-reset-tokens",
+    "anthropic-ratelimit-requests-reset",
+    "anthropic-ratelimit-tokens-reset",
+    "x-ratelimit-reset",
+    "ratelimit-reset",
+  ]);
+
+  return {
+    retryAfterMs: parseRetryAfter(retryAfter),
+    resetAfterMs: parseResetAfter(reset),
+    requestLimit,
+    requestRemaining,
+    tokenLimit,
+    tokenRemaining,
+  };
+}
+
+export function formatRateLimitSummary(info: RateLimitInfo): string | undefined {
+  const parts = [
+    info.requestRemaining || info.requestLimit
+      ? `requests remaining=${info.requestRemaining ?? "?"}${info.requestLimit ? `/${info.requestLimit}` : ""}`
+      : undefined,
+    info.tokenRemaining || info.tokenLimit
+      ? `tokens remaining=${info.tokenRemaining ?? "?"}${info.tokenLimit ? `/${info.tokenLimit}` : ""}`
+      : undefined,
+    info.retryAfterMs !== undefined
+      ? `retry-after=${formatDuration(info.retryAfterMs)}`
+      : undefined,
+    info.resetAfterMs !== undefined
+      ? `reset=${formatDuration(info.resetAfterMs)}`
+      : undefined,
+  ].filter((part): part is string => Boolean(part));
+
+  return parts.length ? parts.join("; ") : undefined;
+}
+
+function classifyRateLimit(apiError: ParsedApiError, status: number): string {
+  const code = `${apiError.code ?? ""} ${apiError.type ?? ""} ${apiError.message ?? ""}`.toLowerCase();
+  const compactCode = compactErrorCode(code);
+  if (compactCode.includes("gosubscriptionrollinglimitexceeded")) {
+    return "5-hour OpenCode Go usage limit reached";
+  }
+  if (compactCode.includes("gosubscriptionweeklylimitexceeded")) {
+    return "weekly OpenCode Go usage limit reached";
+  }
+  if (compactCode.includes("gosubscriptionmonthlylimitexceeded")) {
+    return "monthly OpenCode Go usage limit reached";
+  }
+  if (code.includes("subscriptionquota") || code.includes("quota")) {
+    return "OpenCode quota exceeded";
+  }
+  return status === 429
+    ? "rate limit exceeded"
+    : "OpenCode usage limit reached";
+}
+
+function isRateLimitResponse(
+  status: number,
+  apiError: ParsedApiError,
+): boolean {
+  const code = `${apiError.code ?? ""} ${apiError.type ?? ""} ${apiError.message ?? ""}`.toLowerCase();
+  const compactCode = compactErrorCode(code);
+  return (
+    status === 429 ||
+    compactCode.includes("ratelimit") ||
+    code.includes("rate_limit") ||
+    code.includes("quota") ||
+    compactCode.includes("limitexceeded")
+  );
+}
+
+function compactErrorCode(value: string): string {
+  return value.replace(/[^a-z0-9]/g, "");
+}
+
+function shouldIncludeApiMessage(apiMessage: string, reason: string): boolean {
+  const normalizedMessage = compactErrorCode(apiMessage.toLowerCase());
+  const normalizedReason = compactErrorCode(reason.toLowerCase());
+  return (
+    Boolean(normalizedMessage) && !normalizedMessage.startsWith(normalizedReason)
+  );
+}
+
+function firstHeader(headers: Headers, names: string[]): string | undefined {
+  for (const name of names) {
+    const value = headers.get(name);
+    if (value?.trim()) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function parseRetryAfter(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return seconds * 1000;
+  }
+  const dateMs = Date.parse(value);
+  return Number.isFinite(dateMs)
+    ? Math.max(0, dateMs - Date.now())
+    : parseDurationLike(value);
+}
+
+function parseResetAfter(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const numeric = Number(value);
+  if (Number.isFinite(numeric) && numeric >= 0) {
+    if (numeric > 1_000_000_000_000) {
+      return Math.max(0, numeric - Date.now());
+    }
+    if (numeric > 1_000_000_000) {
+      return Math.max(0, numeric * 1000 - Date.now());
+    }
+    return numeric * 1000;
+  }
+  const durationMs = parseDurationLike(value);
+  if (durationMs !== undefined) {
+    return durationMs;
+  }
+  return parseRetryAfter(value);
+}
+
+function parseDurationLike(value: string): number | undefined {
+  const matches = value.trim().toLowerCase().matchAll(/(\d+(?:\.\d+)?)(ms|s|m|h)/g);
+  let totalMs = 0;
+  let found = false;
+  for (const match of matches) {
+    found = true;
+    const amount = Number(match[1]);
+    const unit = match[2];
+    if (!Number.isFinite(amount)) {
+      continue;
+    }
+    if (unit === "ms") {
+      totalMs += amount;
+    } else if (unit === "s") {
+      totalMs += amount * 1000;
+    } else if (unit === "m") {
+      totalMs += amount * 60 * 1000;
+    } else if (unit === "h") {
+      totalMs += amount * 60 * 60 * 1000;
+    }
+  }
+  return found ? Math.max(0, Math.ceil(totalMs)) : undefined;
+}
+
+function formatWaitText(value: number | undefined): string | undefined {
+  return value === undefined ? undefined : formatDuration(value);
+}
+
+export function formatDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.ceil(ms / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  if (hours) {
+    return `${hours}h ${minutes}m`;
+  }
+  if (minutes) {
+    return `${minutes}m ${seconds}s`;
+  }
+  return `${seconds}s`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,35 @@
 import * as vscode from "vscode";
+import {
+  buildOpenCodeRequestError,
+  formatDuration,
+  formatRateLimitSummary,
+  OpenCodeRequestError,
+  readRateLimitInfo,
+  truncateForLog,
+} from "./errors";
+import {
+  MODEL_METADATA_CACHE_KEY,
+  MODEL_METADATA_REVISION,
+  MODELS_DEV_API_URL,
+  bundledModelMetadataSnapshot,
+  fallbackModelMetadata,
+  hasExplicitModelLimits,
+  isFreshModelMetadata,
+  normalizeLiveModelMetadata,
+  normalizeModelsDevSnapshot,
+  resolveModelMetadata,
+  toEffectiveModelId,
+  type ModelsDevResponse,
+} from "./metadata";
+import {
+  normalizeGoogleFullResponse,
+  normalizeGoogleStreamEvent,
+  normalizeResponsesFullResponse,
+  normalizeResponsesStreamEvent,
+  resolveModelRouting,
+} from "./routing";
+import { GO_VENDOR, ZEN_VENDOR } from "./providerTypes";
 
-const GO_VENDOR = "opencodego";
-const ZEN_VENDOR = "opencodezen";
 const SECRET_KEY = "opencodego.apiKey";
 
 interface ProviderDefinition {
@@ -25,7 +53,6 @@ type ModelEndpointKind =
   | "google";
 
 const FREE_ZEN_MODEL_IDS = new Set(["big-pickle"]);
-const MODELS_DEV_API_URL = "https://models.dev/api.json";
 const KNOWN_UNAVAILABLE_MODEL_IDS = new Set([
   "ring-2.6-1t",
   "ring-2.6-1t-free",
@@ -35,8 +62,6 @@ const DEFAULT_REQUEST_TIMEOUT_MS = 10 * 60 * 1000;
 const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 2 * 60 * 1000;
 const OPEN_CODE_CLIENT = "vscode-copilot-chat";
 const OPEN_CODE_USER_AGENT = "opencode-copilot-chat/0.1.6 VSCode";
-// Bump this when we need to force VS Code picker metadata refresh.
-const MODEL_METADATA_REVISION = "session-2026-05-21-b";
 
 const PROVIDERS: Record<ProviderDefinition["vendor"], ProviderDefinition> = {
   [GO_VENDOR]: {
@@ -127,29 +152,6 @@ interface ModelListEntry {
 
 interface ModelListResponse {
   data?: ModelListEntry[];
-}
-
-interface ModelsDevModelRecord {
-  status?: string;
-  limit?: {
-    context?: number;
-    output?: number;
-  };
-  attachment?: boolean;
-  reasoning?: boolean;
-  modalities?: {
-    input?: string[];
-    output?: string[];
-  };
-}
-
-interface ModelsDevProviderRecord {
-  models?: Record<string, ModelsDevModelRecord>;
-}
-
-interface ModelsDevResponse {
-  opencode?: ModelsDevProviderRecord;
-  "opencode-go"?: ModelsDevProviderRecord;
 }
 
 interface ApiMessage {
@@ -256,55 +258,6 @@ interface ModelRoutingFields {
 // Copilot surfaces combine input/output metadata differently across views.
 // Reserve a modest UI output budget, while requests still use the real model max.
 const UI_OUTPUT_TOKEN_RESERVE = 8192;
-const MODEL_METADATA_CACHE_KEY = "opencodego.modelMetadataCache.v3";
-const MODEL_METADATA_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
-
-const DEFAULT_MODEL_LIMITS: BaseModelLimits = {
-  contextWindow: 262144,
-  maxOutputTokens: 65536
-};
-
-const MODELS_DEV_PROVIDER_BY_VENDOR: Record<
-  ProviderDefinition["vendor"],
-  keyof ModelsDevResponse
-> = {
-  [GO_VENDOR]: "opencode-go",
-  [ZEN_VENDOR]: "opencode",
-};
-
-// Context limits sourced from models.dev (official OpenCode model registry).
-// Keep limits per provider to avoid cross-provider contamination in VS Code's
-// picker metadata cache.
-const MODEL_LIMITS_BY_PROVIDER: Record<ProviderDefinition["vendor"], Record<string, BaseModelLimits>> = {
-  [GO_VENDOR]: {
-    "deepseek-v4-flash": { contextWindow: 1000000, maxOutputTokens: 384000 },
-    "deepseek-v4-pro": { contextWindow: 1000000, maxOutputTokens: 384000 },
-    "mimo-v2.5": { contextWindow: 1000000, maxOutputTokens: 128000 },
-    "mimo-v2.5-pro": { contextWindow: 1048576, maxOutputTokens: 128000 },
-    "mimo-v2-omni": { contextWindow: 262144, maxOutputTokens: 128000 },
-    "mimo-v2-pro": { contextWindow: 1048576, maxOutputTokens: 128000 },
-    "kimi-k2.6": { contextWindow: 262144, maxOutputTokens: 65536 },
-    "kimi-k2.5": { contextWindow: 262144, maxOutputTokens: 65536 },
-    "glm-5.1": { contextWindow: 202752, maxOutputTokens: 32768 },
-    "glm-5": { contextWindow: 202752, maxOutputTokens: 32768 },
-    "minimax-m2.7": { contextWindow: 204800, maxOutputTokens: 131072 },
-    "minimax-m2.5": { contextWindow: 204800, maxOutputTokens: 65536 },
-    "qwen3.6-plus": { contextWindow: 262144, maxOutputTokens: 65536 },
-    "qwen3.5-plus": { contextWindow: 262144, maxOutputTokens: 65536 },
-    "hy3-preview": { contextWindow: 256000, maxOutputTokens: 64000 },
-    "ring-2.6-1t": { contextWindow: 262000, maxOutputTokens: 66000 }
-  },
-  [ZEN_VENDOR]: {
-    "deepseek-v4-flash-free": { contextWindow: 200000, maxOutputTokens: 128000 },
-    "minimax-m2.5-free": { contextWindow: 204800, maxOutputTokens: 131072 },
-    "qwen3.6-plus": { contextWindow: 262144, maxOutputTokens: 65536 },
-    "qwen3.6-plus-free": { contextWindow: 262144, maxOutputTokens: 65536 },
-    "qwen3.5-plus": { contextWindow: 262144, maxOutputTokens: 65536 },
-    "trinity-large-preview-free": { contextWindow: 131072, maxOutputTokens: 131072 },
-    "nemotron-3-super-free": { contextWindow: 204800, maxOutputTokens: 128000 },
-    "big-pickle": { contextWindow: 200000, maxOutputTokens: 128000 }
-  }
-};
 
 type CopilotCompatibleCapabilities = vscode.LanguageModelChatCapabilities & {
   supportsToolCalling: boolean;
@@ -323,23 +276,6 @@ const CAPACITY_LIMITED_MODEL_NOTES: Record<string, string> = {
 
 let modelMetadataSnapshot: CachedModelMetadataSnapshot | undefined;
 let modelMetadataRefreshPromise: Promise<CachedModelMetadataSnapshot> | undefined;
-
-const VISION_CAPABLE_MODELS = new Set([
-  "minimax-m2.7",
-  "minimax-m2.5",
-  "minimax-m2.5-free",
-  "kimi-k2.6",
-  "kimi-k2.5",
-  "glm-5.1",
-  "glm-5",
-  "mimo-v2.5",
-  "mimo-v2.5-pro",
-  "mimo-v2-omni",
-  "mimo-v2-pro",
-  "qwen3.6-plus",
-  "qwen3.6-plus-free",
-  "qwen3.5-plus"
-]);
 
 interface OpenAiToolDefinition {
   type: "function";
@@ -475,43 +411,12 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
     modelId: string,
     snapshot: CachedModelMetadataSnapshot,
   ): ResolvedModelMetadata {
-    const cachedMetadata = snapshot.providers[this.definition.vendor][modelId];
-    const liveMetadata = this.liveModelMetadataById.get(modelId);
-    const fallbackMetadata = fallbackModelMetadata(modelId, this.definition.vendor);
-
-    return {
-      contextWindow:
-        liveMetadata?.contextWindow ??
-        cachedMetadata?.contextWindow ??
-        fallbackMetadata?.contextWindow ??
-        DEFAULT_MODEL_LIMITS.contextWindow,
-      maxOutputTokens:
-        liveMetadata?.maxOutputTokens ??
-        cachedMetadata?.maxOutputTokens ??
-        fallbackMetadata?.maxOutputTokens ??
-        DEFAULT_MODEL_LIMITS.maxOutputTokens,
-      supportsVision:
-        liveMetadata?.supportsVision ??
-        cachedMetadata?.supportsVision ??
-        fallbackMetadata?.supportsVision ??
-        false,
-      reasoning:
-        liveMetadata?.reasoning ??
-        cachedMetadata?.reasoning ??
-        fallbackMetadata?.reasoning ??
-        Boolean(thinkingFamily(modelId)),
-      status:
-        liveMetadata?.status ??
-        cachedMetadata?.status ??
-        fallbackMetadata?.status,
-      source: liveMetadata
-        ? "live"
-        : cachedMetadata
-          ? "models.dev"
-          : fallbackMetadata
-            ? "fallback"
-            : "default",
-    };
+    return resolveModelMetadata(
+      modelId,
+      this.definition.vendor,
+      snapshot,
+      this.liveModelMetadataById,
+    );
   }
 
   private replaceLiveModelMetadata(entries: ModelListEntry[] | undefined): void {
@@ -920,10 +825,6 @@ function getConfiguredApiKey(options?: { configuration?: LanguageModelConfigurat
   return typeof configuredApiKey === "string" && configuredApiKey.trim() ? configuredApiKey.trim() : undefined;
 }
 
-function isFreshModelMetadata(snapshot: CachedModelMetadataSnapshot): boolean {
-  return Date.now() - snapshot.fetchedAt < MODEL_METADATA_CACHE_TTL_MS;
-}
-
 async function clearOpenCodeModelMetadataCache(
   context: vscode.ExtensionContext,
 ): Promise<void> {
@@ -962,7 +863,9 @@ async function refreshOpenCodeModelMetadata(
   }
 
   modelMetadataRefreshPromise = (async () => {
-    const response = await fetch(MODELS_DEV_API_URL);
+    const response = await fetch(MODELS_DEV_API_URL, {
+      signal: AbortSignal.timeout(10_000)
+    });
 
     if (!response.ok) {
       throw new Error(`models.dev request failed (${response.status}): ${response.statusText}`);
@@ -1378,196 +1281,6 @@ function responsesAssistantText(content: ApiMessage["content"]): string {
     .join("");
 }
 
-function normalizeResponsesStreamEvent(data: unknown): unknown {
-  if (!isRecord(data)) {
-    return data;
-  }
-
-  const eventType = typeof data.type === "string" ? data.type : undefined;
-  if (!eventType) {
-    return data;
-  }
-
-  if (eventType === "response.output_text.delta") {
-    const delta = firstString(data.delta, data.text, data.output_text_delta);
-    return delta ? { choices: [{ index: 0, delta: { content: delta }, finish_reason: null }] } : { choices: [] };
-  }
-
-  if (eventType === "response.output_item.added") {
-    const item = data.item;
-    if (isRecord(item) && item.type === "function_call" && typeof item.name === "string") {
-      return {
-        choices: [{
-          index: 0,
-          delta: {
-            tool_calls: [{
-              index: typeof data.output_index === "number" ? data.output_index : 0,
-              id: firstString(item.call_id, item.id) ?? "",
-              type: "function",
-              function: { name: item.name, arguments: "" },
-            }],
-          },
-          finish_reason: null,
-        }],
-      };
-    }
-  }
-
-  if (eventType === "response.function_call_arguments.delta") {
-    const delta = firstString(data.delta, data.arguments_delta);
-    return delta ? {
-      choices: [{
-        index: 0,
-        delta: {
-          tool_calls: [{
-            index: typeof data.output_index === "number" ? data.output_index : 0,
-            function: { arguments: delta },
-          }],
-        },
-        finish_reason: null,
-      }],
-    } : { choices: [] };
-  }
-
-  if (eventType.includes("reasoning")) {
-    const reasoning = extractResponsesReasoningText(data);
-    return reasoning ? { choices: [{ index: 0, delta: { reasoning_content: reasoning }, finish_reason: null }] } : { choices: [] };
-  }
-
-  if (eventType === "response.completed") {
-    const response = isRecord(data.response) ? data.response : data;
-    const usage = normalizeResponsesUsage(response.usage);
-    return {
-      choices: [{
-        index: 0,
-        delta: {},
-        finish_reason: normalizeResponsesFinishReason(firstString(response.stop_reason, data.stop_reason)),
-      }],
-      ...(usage ? { usage } : {}),
-    };
-  }
-
-  return { choices: [] };
-}
-
-function normalizeResponsesFullResponse(data: unknown): unknown {
-  if (!isRecord(data) || Array.isArray(data.choices)) {
-    return data;
-  }
-
-  const response = isRecord(data.response) ? data.response : data;
-  const output = Array.isArray(response.output) ? response.output : [];
-  let text = "";
-  const toolCalls: Array<Record<string, unknown>> = [];
-
-  for (const item of output) {
-    if (!isRecord(item)) {
-      continue;
-    }
-
-    if (item.type === "message" && Array.isArray(item.content)) {
-      for (const part of item.content) {
-        if (isRecord(part) && part.type === "output_text" && typeof part.text === "string") {
-          text += part.text;
-        }
-      }
-      continue;
-    }
-
-    if (item.type === "function_call" && typeof item.name === "string") {
-      toolCalls.push({
-        id: firstString(item.call_id, item.id) ?? "",
-        type: "function",
-        function: {
-          name: item.name,
-          arguments: typeof item.arguments === "string" ? item.arguments : JSON.stringify(item.arguments ?? {}),
-        },
-      });
-    }
-  }
-
-  return {
-    choices: [{
-      index: 0,
-      message: {
-        ...(text ? { content: text } : {}),
-        ...(toolCalls.length ? { tool_calls: toolCalls } : {}),
-      },
-      finish_reason: normalizeResponsesFinishReason(firstString(response.stop_reason, response.finish_reason)),
-    }],
-    ...(normalizeResponsesUsage(response.usage) ? { usage: normalizeResponsesUsage(response.usage) } : {}),
-  };
-}
-
-function normalizeResponsesFinishReason(value: string | undefined): "stop" | "tool_calls" | "length" | "content_filter" | null {
-  if (!value) {
-    return null;
-  }
-
-  if (value === "completed" || value === "stop") {
-    return "stop";
-  }
-  if (value === "tool_call" || value === "tool_calls") {
-    return "tool_calls";
-  }
-  if (value === "max_output_tokens" || value === "length") {
-    return "length";
-  }
-  if (value.includes("filter") || value.includes("safety")) {
-    return "content_filter";
-  }
-
-  return null;
-}
-
-function normalizeResponsesUsage(usage: unknown): Record<string, unknown> | undefined {
-  if (!isRecord(usage)) {
-    return undefined;
-  }
-
-  const promptTokens = typeof usage.input_tokens === "number" ? usage.input_tokens : undefined;
-  const completionTokens = typeof usage.output_tokens === "number" ? usage.output_tokens : undefined;
-  const cachedTokens = isRecord(usage.input_tokens_details) && typeof usage.input_tokens_details.cached_tokens === "number"
-    ? usage.input_tokens_details.cached_tokens
-    : undefined;
-
-  if (promptTokens === undefined && completionTokens === undefined) {
-    return undefined;
-  }
-
-  return {
-    prompt_tokens: promptTokens,
-    completion_tokens: completionTokens,
-    total_tokens: promptTokens !== undefined && completionTokens !== undefined ? promptTokens + completionTokens : undefined,
-    ...(cachedTokens !== undefined ? { prompt_tokens_details: { cached_tokens: cachedTokens } } : {}),
-  };
-}
-
-function extractResponsesReasoningText(data: Record<string, unknown>): string {
-  const direct = firstString(data.delta, data.text, data.summary_text, data.output_text_delta);
-  if (direct) {
-    return direct;
-  }
-
-  const item = data.item;
-  if (!isRecord(item)) {
-    return "";
-  }
-
-  if (typeof item.text === "string") {
-    return item.text;
-  }
-
-  if (Array.isArray(item.summary)) {
-    return item.summary
-      .filter((part): part is Record<string, unknown> => isRecord(part) && typeof part.text === "string")
-      .map((part) => part.text as string)
-      .join("");
-  }
-
-  return "";
-}
-
 function buildGoogleGenerateContentBody(
   messages: ApiMessage[],
   options: vscode.ProvideLanguageModelChatResponseOptions,
@@ -1685,157 +1398,6 @@ function dataUrlToInlineData(url: string): { mimeType: string; data: string } | 
     mimeType: match[1],
     data: match[2],
   };
-}
-
-function normalizeGoogleStreamEvent(data: unknown): unknown {
-  if (!isRecord(data)) {
-    return data;
-  }
-
-  const candidate = Array.isArray(data.candidates) && isRecord(data.candidates[0]) ? data.candidates[0] : undefined;
-  const parts = isRecord(candidate?.content) && Array.isArray(candidate.content.parts)
-    ? candidate.content.parts.filter(isRecord)
-    : [];
-  const text = parts
-    .filter((part) => typeof part.text === "string" && part.thought !== true)
-    .map((part) => part.text as string)
-    .join("");
-  const reasoning = parts
-    .filter((part) => typeof part.text === "string" && part.thought === true)
-    .map((part) => part.text as string)
-    .join("");
-  const toolCalls = parts.flatMap((part, index) => {
-    if (!isRecord(part.functionCall) || typeof part.functionCall.name !== "string") {
-      return [];
-    }
-
-    return [{
-      index,
-      id: "",
-      type: "function",
-      function: {
-        name: part.functionCall.name,
-        arguments: JSON.stringify(part.functionCall.args ?? {}),
-      },
-    }];
-  });
-  const usage = normalizeGoogleUsage(data.usageMetadata);
-
-  if (!text && !reasoning && !toolCalls.length && !candidate?.finishReason && !usage) {
-    return { choices: [] };
-  }
-
-  return {
-    choices: [{
-      index: 0,
-      delta: {
-        ...(text ? { content: text } : {}),
-        ...(reasoning ? { reasoning_content: reasoning } : {}),
-        ...(toolCalls.length ? { tool_calls: toolCalls } : {}),
-      },
-      finish_reason: normalizeGoogleFinishReason(
-        typeof candidate?.finishReason === "string" ? candidate.finishReason : undefined,
-        toolCalls.length > 0,
-      ),
-    }],
-    ...(usage ? { usage } : {}),
-  };
-}
-
-function normalizeGoogleFullResponse(data: unknown): unknown {
-  if (!isRecord(data) || Array.isArray(data.choices)) {
-    return data;
-  }
-
-  const candidate = Array.isArray(data.candidates) && isRecord(data.candidates[0]) ? data.candidates[0] : undefined;
-  const parts = isRecord(candidate?.content) && Array.isArray(candidate.content.parts)
-    ? candidate.content.parts.filter(isRecord)
-    : [];
-  const text = parts
-    .filter((part) => typeof part.text === "string" && part.thought !== true)
-    .map((part) => part.text as string)
-    .join("");
-  const reasoning = parts
-    .filter((part) => typeof part.text === "string" && part.thought === true)
-    .map((part) => part.text as string)
-    .join("");
-  const toolCalls = parts.flatMap((part) => {
-    if (!isRecord(part.functionCall) || typeof part.functionCall.name !== "string") {
-      return [];
-    }
-
-    return [{
-      id: "",
-      type: "function",
-      function: {
-        name: part.functionCall.name,
-        arguments: JSON.stringify(part.functionCall.args ?? {}),
-      },
-    }];
-  });
-  const usage = normalizeGoogleUsage(data.usageMetadata);
-
-  return {
-    choices: [{
-      index: 0,
-      message: {
-        ...(text ? { content: text } : {}),
-        ...(reasoning ? { reasoning_content: reasoning } : {}),
-        ...(toolCalls.length ? { tool_calls: toolCalls } : {}),
-      },
-      finish_reason: normalizeGoogleFinishReason(
-        typeof candidate?.finishReason === "string" ? candidate.finishReason : undefined,
-        toolCalls.length > 0,
-      ),
-    }],
-    ...(usage ? { usage } : {}),
-  };
-}
-
-function normalizeGoogleUsage(usage: unknown): Record<string, unknown> | undefined {
-  if (!isRecord(usage)) {
-    return undefined;
-  }
-
-  const promptTokens = typeof usage.promptTokenCount === "number" ? usage.promptTokenCount : undefined;
-  const candidatesTokens = typeof usage.candidatesTokenCount === "number" ? usage.candidatesTokenCount : undefined;
-  const thoughtsTokens = typeof usage.thoughtsTokenCount === "number" ? usage.thoughtsTokenCount : undefined;
-  const cachedTokens = typeof usage.cachedContentTokenCount === "number" ? usage.cachedContentTokenCount : undefined;
-  const completionTokens = candidatesTokens !== undefined ? candidatesTokens + (thoughtsTokens ?? 0) : undefined;
-
-  if (promptTokens === undefined && completionTokens === undefined) {
-    return undefined;
-  }
-
-  return {
-    prompt_tokens: promptTokens,
-    completion_tokens: completionTokens,
-    total_tokens: typeof usage.totalTokenCount === "number"
-      ? usage.totalTokenCount
-      : promptTokens !== undefined && completionTokens !== undefined
-        ? promptTokens + completionTokens
-        : undefined,
-    ...(cachedTokens !== undefined ? { prompt_tokens_details: { cached_tokens: cachedTokens } } : {}),
-  };
-}
-
-function normalizeGoogleFinishReason(
-  finishReason: string | undefined,
-  hasToolCalls: boolean,
-): "stop" | "tool_calls" | "length" | "content_filter" | null {
-  if (!finishReason) {
-    return null;
-  }
-  if (finishReason === "STOP") {
-    return hasToolCalls ? "tool_calls" : "stop";
-  }
-  if (finishReason === "MAX_TOKENS") {
-    return "length";
-  }
-  if (["IMAGE_SAFETY", "RECITATION", "SAFETY", "BLOCKLIST", "PROHIBITED_CONTENT", "SPII"].includes(finishReason)) {
-    return "content_filter";
-  }
-  return null;
 }
 
 // The official OpenCode client sends these headers on every request. The Zen
@@ -2203,317 +1765,6 @@ async function streamOpenCodeResponse(
     }
     cancellation.dispose();
   }
-}
-
-class OpenCodeRequestError extends Error {
-  constructor(
-    message: string,
-    readonly userMessage: string = message,
-  ) {
-    super(message);
-    this.name = "OpenCodeRequestError";
-  }
-}
-
-interface ParsedApiError {
-  message?: string;
-  code?: string;
-  type?: string;
-  retryIn?: string;
-}
-
-interface RateLimitInfo {
-  retryAfterMs?: number;
-  resetAfterMs?: number;
-  requestLimit?: string;
-  requestRemaining?: string;
-  tokenLimit?: string;
-  tokenRemaining?: string;
-}
-
-function buildOpenCodeRequestError(
-  providerDisplayName: string,
-  response: Response,
-  rawDetail: string,
-  modelId: string | undefined,
-  payloadBytes: number,
-  capacityHint: string,
-): OpenCodeRequestError {
-  const apiError = parseApiError(rawDetail);
-  const rateLimitInfo = readRateLimitInfo(response.headers);
-  const modelHint = modelId ? ` model=${modelId}` : "";
-  const sizeHint = ` payloadBytes=${payloadBytes}`;
-  const apiMessage =
-    (apiError.message ?? rawDetail.trim()) || response.statusText;
-  const isLimit = isRateLimitResponse(response.status, apiError);
-
-  if (isLimit) {
-    const waitText =
-      apiError.retryIn ??
-      formatWaitText(rateLimitInfo.retryAfterMs ?? rateLimitInfo.resetAfterMs);
-    const quotaText = formatRateLimitSummary(rateLimitInfo);
-    const reason = classifyRateLimit(apiError, response.status);
-    const details = [
-      shouldIncludeApiMessage(apiMessage, reason) ? apiMessage : undefined,
-      waitText ? `Retry after ${waitText}.` : undefined,
-      quotaText ? `Quota: ${quotaText}.` : undefined,
-    ].filter((part): part is string => Boolean(part));
-    const userMessage =
-      `${providerDisplayName}: ${reason}${modelHint ? ` (${modelId})` : ""}. ${details.join(" ")}`.trim();
-    return new OpenCodeRequestError(
-      `${providerDisplayName} API rate/quota limit (${response.status})${modelHint}${sizeHint}: ${apiMessage}; ${quotaText || "no quota headers"}`,
-      userMessage,
-    );
-  }
-
-  const userMessage = `${providerDisplayName} API request failed (HTTP ${response.status})${modelHint ? ` for ${modelId}` : ""}: ${apiMessage}${capacityHint}`;
-  return new OpenCodeRequestError(
-    `${providerDisplayName} API request failed (${response.status})${modelHint}${sizeHint}${capacityHint}: ${apiMessage}`,
-    userMessage,
-  );
-}
-
-function parseApiError(rawDetail: string): ParsedApiError {
-  const fallback = rawDetail.trim();
-  if (!fallback) {
-    return {};
-  }
-
-  try {
-    const parsed = JSON.parse(fallback) as unknown;
-    if (!isRecord(parsed)) {
-      return { message: fallback };
-    }
-
-    const error = isRecord(parsed.error) ? parsed.error : parsed;
-    return {
-      message: firstString(error.message, parsed.message, fallback),
-      code: firstString(error.code, parsed.code),
-      type: firstString(error.type, parsed.type),
-      retryIn: firstString(
-        error.retryIn,
-        parsed.retryIn,
-        error.retry_in,
-        parsed.retry_in,
-      ),
-    };
-  } catch {
-    return { message: fallback };
-  }
-}
-
-function readRateLimitInfo(headers: Headers): RateLimitInfo {
-  const retryAfter = firstHeader(headers, ["retry-after"]);
-  const requestLimit = firstHeader(headers, [
-    "x-ratelimit-limit-requests",
-    "anthropic-ratelimit-requests-limit",
-    "x-ratelimit-limit",
-    "ratelimit-limit",
-  ]);
-  const requestRemaining = firstHeader(headers, [
-    "x-ratelimit-remaining-requests",
-    "anthropic-ratelimit-requests-remaining",
-    "x-ratelimit-remaining",
-    "ratelimit-remaining",
-  ]);
-  const tokenLimit = firstHeader(headers, [
-    "x-ratelimit-limit-tokens",
-    "anthropic-ratelimit-tokens-limit",
-  ]);
-  const tokenRemaining = firstHeader(headers, [
-    "x-ratelimit-remaining-tokens",
-    "anthropic-ratelimit-tokens-remaining",
-  ]);
-  const reset = firstHeader(headers, [
-    "x-ratelimit-reset-requests",
-    "x-ratelimit-reset-tokens",
-    "anthropic-ratelimit-requests-reset",
-    "anthropic-ratelimit-tokens-reset",
-    "x-ratelimit-reset",
-    "ratelimit-reset",
-  ]);
-
-  return {
-    retryAfterMs: parseRetryAfter(retryAfter),
-    resetAfterMs: parseResetAfter(reset),
-    requestLimit,
-    requestRemaining,
-    tokenLimit,
-    tokenRemaining,
-  };
-}
-
-function formatRateLimitSummary(info: RateLimitInfo): string | undefined {
-  const parts = [
-    info.requestRemaining || info.requestLimit
-      ? `requests remaining=${info.requestRemaining ?? "?"}${info.requestLimit ? `/${info.requestLimit}` : ""}`
-      : undefined,
-    info.tokenRemaining || info.tokenLimit
-      ? `tokens remaining=${info.tokenRemaining ?? "?"}${info.tokenLimit ? `/${info.tokenLimit}` : ""}`
-      : undefined,
-    info.retryAfterMs !== undefined
-      ? `retry-after=${formatDuration(info.retryAfterMs)}`
-      : undefined,
-    info.resetAfterMs !== undefined
-      ? `reset=${formatDuration(info.resetAfterMs)}`
-      : undefined,
-  ].filter((part): part is string => Boolean(part));
-
-  return parts.length ? parts.join("; ") : undefined;
-}
-
-function classifyRateLimit(apiError: ParsedApiError, status: number): string {
-  const code =
-    `${apiError.code ?? ""} ${apiError.type ?? ""} ${apiError.message ?? ""}`.toLowerCase();
-  const compactCode = compactErrorCode(code);
-  if (compactCode.includes("gosubscriptionrollinglimitexceeded")) {
-    return "5-hour OpenCode Go usage limit reached";
-  }
-  if (compactCode.includes("gosubscriptionweeklylimitexceeded")) {
-    return "weekly OpenCode Go usage limit reached";
-  }
-  if (compactCode.includes("gosubscriptionmonthlylimitexceeded")) {
-    return "monthly OpenCode Go usage limit reached";
-  }
-  if (code.includes("subscriptionquota") || code.includes("quota")) {
-    return "OpenCode quota exceeded";
-  }
-  return status === 429
-    ? "rate limit exceeded"
-    : "OpenCode usage limit reached";
-}
-
-function isRateLimitResponse(
-  status: number,
-  apiError: ParsedApiError,
-): boolean {
-  const code =
-    `${apiError.code ?? ""} ${apiError.type ?? ""} ${apiError.message ?? ""}`.toLowerCase();
-  const compactCode = compactErrorCode(code);
-  return (
-    status === 429 ||
-    compactCode.includes("ratelimit") ||
-    code.includes("rate_limit") ||
-    code.includes("quota") ||
-    compactCode.includes("limitexceeded")
-  );
-}
-
-function compactErrorCode(value: string): string {
-  return value.replace(/[^a-z0-9]/g, "");
-}
-
-function shouldIncludeApiMessage(apiMessage: string, reason: string): boolean {
-  const normalizedMessage = compactErrorCode(apiMessage.toLowerCase());
-  const normalizedReason = compactErrorCode(reason.toLowerCase());
-  return (
-    Boolean(normalizedMessage) &&
-    !normalizedMessage.startsWith(normalizedReason)
-  );
-}
-
-function firstHeader(headers: Headers, names: string[]): string | undefined {
-  for (const name of names) {
-    const value = headers.get(name);
-    if (value?.trim()) {
-      return value.trim();
-    }
-  }
-  return undefined;
-}
-
-function firstString(...values: unknown[]): string | undefined {
-  for (const value of values) {
-    if (typeof value === "string" && value.trim()) {
-      return value.trim();
-    }
-  }
-  return undefined;
-}
-
-function parseRetryAfter(value: string | undefined): number | undefined {
-  if (!value) {
-    return undefined;
-  }
-  const seconds = Number(value);
-  if (Number.isFinite(seconds) && seconds >= 0) {
-    return seconds * 1000;
-  }
-  const dateMs = Date.parse(value);
-  return Number.isFinite(dateMs)
-    ? Math.max(0, dateMs - Date.now())
-    : parseDurationLike(value);
-}
-
-function parseResetAfter(value: string | undefined): number | undefined {
-  if (!value) {
-    return undefined;
-  }
-  const numeric = Number(value);
-  if (Number.isFinite(numeric) && numeric >= 0) {
-    if (numeric > 1_000_000_000_000) {
-      return Math.max(0, numeric - Date.now());
-    }
-    if (numeric > 1_000_000_000) {
-      return Math.max(0, numeric * 1000 - Date.now());
-    }
-    return numeric * 1000;
-  }
-  const durationMs = parseDurationLike(value);
-  if (durationMs !== undefined) {
-    return durationMs;
-  }
-  return parseRetryAfter(value);
-}
-
-function parseDurationLike(value: string): number | undefined {
-  const matches = value
-    .trim()
-    .toLowerCase()
-    .matchAll(/(\d+(?:\.\d+)?)(ms|s|m|h)/g);
-  let totalMs = 0;
-  let found = false;
-  for (const match of matches) {
-    found = true;
-    const amount = Number(match[1]);
-    const unit = match[2];
-    if (!Number.isFinite(amount)) {
-      continue;
-    }
-    if (unit === "ms") {
-      totalMs += amount;
-    } else if (unit === "s") {
-      totalMs += amount * 1000;
-    } else if (unit === "m") {
-      totalMs += amount * 60 * 1000;
-    } else if (unit === "h") {
-      totalMs += amount * 60 * 60 * 1000;
-    }
-  }
-  return found ? Math.max(0, Math.ceil(totalMs)) : undefined;
-}
-
-function formatWaitText(value: number | undefined): string | undefined {
-  return value === undefined ? undefined : formatDuration(value);
-}
-
-function formatDuration(ms: number): string {
-  const totalSeconds = Math.max(0, Math.ceil(ms / 1000));
-  const hours = Math.floor(totalSeconds / 3600);
-  const minutes = Math.floor((totalSeconds % 3600) / 60);
-  const seconds = totalSeconds % 60;
-  if (hours) {
-    return `${hours}h ${minutes}m`;
-  }
-  if (minutes) {
-    return `${minutes}m ${seconds}s`;
-  }
-  return `${seconds}s`;
-}
-
-function truncateForLog(value: string, max = 1200): string {
-  const collapsed = value.replace(/\s+/g, " ").trim();
-  return collapsed.length > max ? `${collapsed.slice(0, max)}… (+${collapsed.length - max} chars)` : collapsed;
 }
 
 function parseServerSentEvent(
@@ -3275,12 +2526,6 @@ function positiveOverride(value: number): number | undefined {
   return Number.isFinite(value) && value > 0 ? Math.floor(value) : undefined;
 }
 
-function positiveNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) && value > 0
-    ? Math.floor(value)
-    : undefined;
-}
-
 function modelCapabilities(metadata: ResolvedModelMetadata): CopilotCompatibleCapabilities {
   const supportsVision = metadata.supportsVision;
   return {
@@ -3289,178 +2534,6 @@ function modelCapabilities(metadata: ResolvedModelMetadata): CopilotCompatibleCa
     supportsImageToText: supportsVision,
     supportsToolCalling: true
   };
-}
-
-function resolveModelRouting(modelId: string, provider: ProviderDefinition): ModelRoutingFields {
-  if (provider.vendor === ZEN_VENDOR && /^gpt-/i.test(modelId)) {
-    return {
-      endpointKind: "responses",
-      endpointUrl: provider.responsesUrl ?? provider.chatCompletionsUrl,
-      sdkPackage: "@ai-sdk/openai",
-    };
-  }
-
-  if (/^claude-/i.test(modelId) || (provider.vendor === GO_VENDOR && /^minimax-m2\./i.test(modelId))) {
-    return {
-      endpointKind: "messages",
-      endpointUrl: provider.messagesUrl,
-      sdkPackage: "@ai-sdk/anthropic",
-    };
-  }
-
-  if (provider.vendor === ZEN_VENDOR && /^gemini-/i.test(modelId)) {
-    return {
-      endpointKind: "google",
-      endpointUrl: `${provider.modelsUrl}/${modelId}`,
-      sdkPackage: "@ai-sdk/google",
-    };
-  }
-
-  return {
-    endpointKind: "chat-completions",
-    endpointUrl: provider.chatCompletionsUrl,
-    sdkPackage: "@ai-sdk/openai-compatible",
-  };
-}
-
-function toEffectiveModelId(modelId: string, vendor: ProviderDefinition["vendor"]): string {
-  return `${vendor}:${modelId}::${MODEL_METADATA_REVISION}`;
-}
-
-function bundledModelMetadataSnapshot(): CachedModelMetadataSnapshot {
-  return {
-    fetchedAt: 0,
-    providers: {
-      [GO_VENDOR]: bundledModelMetadataForProvider(GO_VENDOR),
-      [ZEN_VENDOR]: bundledModelMetadataForProvider(ZEN_VENDOR),
-    },
-  };
-}
-
-function bundledModelMetadataForProvider(
-  vendor: ProviderDefinition["vendor"],
-): Record<string, ModelMetadataFields> {
-  return Object.fromEntries(
-    Object.keys(MODEL_LIMITS_BY_PROVIDER[vendor]).flatMap((modelId) => {
-      const metadata = fallbackModelMetadata(modelId, vendor);
-      return metadata ? [[modelId, metadata] as const] : [];
-    }),
-  );
-}
-
-function fallbackModelMetadata(
-  modelId: string,
-  vendor: ProviderDefinition["vendor"],
-): ModelMetadataFields | undefined {
-  const limits = MODEL_LIMITS_BY_PROVIDER[vendor][modelId];
-  const supportsVision = VISION_CAPABLE_MODELS.has(modelId);
-  const status =
-    vendor === ZEN_VENDOR && modelId === "minimax-m2.5-free"
-      ? "deprecated"
-      : undefined;
-
-  if (!limits && !supportsVision && !status && !thinkingFamily(modelId)) {
-    return undefined;
-  }
-
-  return {
-    contextWindow: limits?.contextWindow,
-    maxOutputTokens: limits?.maxOutputTokens,
-    supportsVision: supportsVision || undefined,
-    reasoning: Boolean(thinkingFamily(modelId)) || undefined,
-    status,
-  };
-}
-
-function normalizeModelsDevSnapshot(
-  data: ModelsDevResponse,
-): CachedModelMetadataSnapshot {
-  return {
-    fetchedAt: Date.now(),
-    providers: {
-      [GO_VENDOR]: normalizeModelsDevProvider(
-        data[MODELS_DEV_PROVIDER_BY_VENDOR[GO_VENDOR]]?.models ?? {},
-      ),
-      [ZEN_VENDOR]: normalizeModelsDevProvider(
-        data[MODELS_DEV_PROVIDER_BY_VENDOR[ZEN_VENDOR]]?.models ?? {},
-      ),
-    },
-  };
-}
-
-function normalizeModelsDevProvider(
-  models: Record<string, ModelsDevModelRecord>,
-): Record<string, ModelMetadataFields> {
-  const normalized: Record<string, ModelMetadataFields> = {};
-
-  for (const [modelId, model] of Object.entries(models)) {
-    const metadata = normalizeModelMetadataFields({
-      contextWindow: positiveNumber(model.limit?.context),
-      maxOutputTokens: positiveNumber(model.limit?.output),
-      supportsVision: detectVisionSupport(model.modalities, model.attachment),
-      reasoning:
-        typeof model.reasoning === "boolean" ? model.reasoning : undefined,
-      status: typeof model.status === "string" ? model.status : undefined,
-    });
-
-    if (metadata) {
-      normalized[modelId] = metadata;
-    }
-  }
-
-  return normalized;
-}
-
-function normalizeLiveModelMetadata(
-  model: ModelListEntry,
-): ModelMetadataFields | undefined {
-  return normalizeModelMetadataFields({
-    contextWindow: positiveNumber(
-      model.contextWindow ?? model.context_window ?? model.limit?.context,
-    ),
-    maxOutputTokens: positiveNumber(
-      model.maxOutputTokens ?? model.max_output_tokens ?? model.limit?.output,
-    ),
-    supportsVision: detectVisionSupport(
-      model.modalities,
-      model.imageInput ?? model.image_input ?? model.attachment,
-    ),
-    reasoning:
-      typeof model.reasoning === "boolean" ? model.reasoning : undefined,
-    status: model.deprecated
-      ? "deprecated"
-      : typeof model.status === "string"
-        ? model.status
-        : undefined,
-  });
-}
-
-function normalizeModelMetadataFields(
-  metadata: ModelMetadataFields,
-): ModelMetadataFields | undefined {
-  if (
-    metadata.contextWindow === undefined &&
-    metadata.maxOutputTokens === undefined &&
-    metadata.supportsVision === undefined &&
-    metadata.reasoning === undefined &&
-    metadata.status === undefined
-  ) {
-    return undefined;
-  }
-  return metadata;
-}
-
-function detectVisionSupport(
-  modalities: { input?: string[]; output?: string[] } | undefined,
-  attachmentHint: boolean | undefined,
-): boolean | undefined {
-  const inputModalities = Array.isArray(modalities?.input)
-    ? modalities.input
-    : undefined;
-  if (inputModalities?.length) {
-    return inputModalities.some((modality) => modality !== "text");
-  }
-  return typeof attachmentHint === "boolean" ? attachmentHint : undefined;
 }
 
 function shouldHideDeprecatedModel(
@@ -3485,10 +2558,6 @@ function resolveRawModelId(modelId: string): string {
     return base.slice(zenPrefix.length);
   }
   return base;
-}
-
-function hasExplicitModelLimits(modelId: string, vendor: ProviderDefinition["vendor"]): boolean {
-  return Boolean(fallbackModelMetadata(modelId, vendor));
 }
 
 function isFreeZenModel(modelId: string): boolean {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,6 +24,10 @@ const KNOWN_UNAVAILABLE_MODEL_IDS = new Set([
   "ring-2.6-1t-free",
   "trinity-large-preview-free"
 ]);
+const DEFAULT_REQUEST_TIMEOUT_MS = 10 * 60 * 1000;
+const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 2 * 60 * 1000;
+const OPEN_CODE_CLIENT = "vscode-copilot-chat";
+const OPEN_CODE_USER_AGENT = "opencode-copilot-chat/0.1.6 VSCode";
 // Bump this when we need to force VS Code picker metadata refresh.
 const MODEL_METADATA_REVISION = "naming-2026-05-17-a";
 
@@ -149,6 +153,8 @@ interface ApiSettings {
   maxOutputTokensOverride: number;
   maxInputTokensOverride: number;
   debugReasoning: boolean;
+  requestTimeoutMs: number;
+  streamIdleTimeoutMs: number;
   thinking: ThinkingSettings;
 }
 
@@ -605,15 +611,20 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
     };
     const limits = modelLimits(rawModelId, settings, model.provider.vendor);
     const thinkingPayload = buildThinkingPayload(rawModelId, settings.thinking);
+    const requestHeaders = buildOpenCodeRequestHeaders(
+      messages,
+      options,
+      rawModelId,
+    );
 
-    this.log(`Request: model=${model.id} rawModel=${rawModelId} endpoint=${model.endpointKind} messages=${apiMessages.length} modelConfiguration=${JSON.stringify(pickThinkingModelConfiguration(requestOverride))} thinking=${JSON.stringify(settings.thinking)} thinkingPayload=${JSON.stringify(thinkingPayload)}`);
+    this.log(`Request: model=${model.id} rawModel=${rawModelId} endpoint=${model.endpointKind} messages=${apiMessages.length} session=${requestHeaders["x-opencode-session"]} request=${requestHeaders["x-opencode-request"]} modelConfiguration=${JSON.stringify(pickThinkingModelConfiguration(requestOverride))} thinking=${JSON.stringify(settings.thinking)} thinkingPayload=${JSON.stringify(thinkingPayload)}`);
     if (settings.debugReasoning) {
       this.log("Reasoning debug is enabled. Provider reasoning_content will be written to this output channel when available.");
     }
 
     try {
       if (model.endpointKind === "messages") {
-        await streamAnthropicMessages(this.definition.messagesUrl, this.definition.displayName, apiKey, rawModelId, apiMessages, options, settings, limits, progress, token, this.getOutputChannel());
+        await streamAnthropicMessages(this.definition.messagesUrl, this.definition.displayName, apiKey, rawModelId, apiMessages, options, settings, limits, requestHeaders, progress, token, this.getOutputChannel());
         return;
       }
 
@@ -627,6 +638,7 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
           options,
           settings,
           limits,
+          requestHeaders,
           progress,
           token,
           this.getOutputChannel()
@@ -644,6 +656,7 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
         options,
         settings,
         limits,
+        requestHeaders,
         progress,
         token,
         this.getOutputChannel(),
@@ -658,6 +671,9 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
       const message = error instanceof Error ? error.message : String(error);
       this.log(`ERROR model=${model.id}: ${message}`);
       this.getOutputChannel().show(true);
+      if (error instanceof OpenCodeRequestError) {
+        vscode.window.showErrorMessage(error.userMessage);
+      }
       throw error;
     }
   }
@@ -756,6 +772,7 @@ async function streamChatCompletions(
   options: vscode.ProvideLanguageModelChatResponseOptions,
   settings: ApiSettings,
   limits: ModelLimits,
+  requestHeaders: Record<string, string>,
   progress: vscode.Progress<vscode.LanguageModelResponsePart>,
   token: vscode.CancellationToken,
   output: vscode.OutputChannel,
@@ -788,12 +805,15 @@ async function streamChatCompletions(
       ...thinkingPayload,
       ...(tools.length ? { tools, tool_choice: toolChoice(options.toolMode) } : {})
     },
+    requestHeaders,
     progress,
     token,
     (data) => extractor.extractStreamParts(data),
     extractChatCompletionParts,
     output,
-    settings.debugReasoning
+    settings.debugReasoning,
+    settings.requestTimeoutMs,
+    settings.streamIdleTimeoutMs,
   );
 
   extractor.flushReasoningFallback(progress);
@@ -813,6 +833,7 @@ async function streamChatCompletionsWithAnthropicStream(
   options: vscode.ProvideLanguageModelChatResponseOptions,
   settings: ApiSettings,
   limits: ModelLimits,
+  requestHeaders: Record<string, string>,
   progress: vscode.Progress<vscode.LanguageModelResponsePart>,
   token: vscode.CancellationToken,
   output: vscode.OutputChannel
@@ -841,6 +862,7 @@ async function streamChatCompletionsWithAnthropicStream(
       ...thinkingPayload,
       ...(tools.length ? { tools, tool_choice: toolChoice(options.toolMode) } : {})
     },
+    requestHeaders,
     progress,
     token,
     (data) => {
@@ -852,7 +874,9 @@ async function streamChatCompletionsWithAnthropicStream(
       return openAiParts.length ? openAiParts : extractAnthropicParts(data);
     },
     output,
-    settings.debugReasoning
+    settings.debugReasoning,
+    settings.requestTimeoutMs,
+    settings.streamIdleTimeoutMs,
   );
 
   openAiExtractor.flushReasoningFallback(progress);
@@ -873,6 +897,7 @@ async function streamAnthropicMessages(
   options: vscode.ProvideLanguageModelChatResponseOptions,
   settings: ApiSettings,
   limits: ModelLimits,
+  requestHeaders: Record<string, string>,
   progress: vscode.Progress<vscode.LanguageModelResponsePart>,
   token: vscode.CancellationToken,
   output?: vscode.OutputChannel
@@ -898,13 +923,109 @@ async function streamAnthropicMessages(
       ...thinkingPayload,
       ...(tools.length ? { tools, tool_choice: anthropicToolChoice(options.toolMode) } : {})
     },
+    requestHeaders,
     progress,
     token,
     (data) => extractor.extractStreamParts(data),
     extractAnthropicParts,
     output,
-    settings.debugReasoning
+    settings.debugReasoning,
+    settings.requestTimeoutMs,
+    settings.streamIdleTimeoutMs,
   );
+}
+
+// The official OpenCode client sends these headers on every request. The Zen
+// gateway reads x-opencode-session first, then converts that sticky identifier
+// into provider-specific affinity headers such as x-session-affinity upstream.
+//
+// VS Code's provider API does not currently expose a guaranteed public session
+// identifier everywhere, so we first probe a few known internal fields and then
+// fall back to a stable hash of the first messages in the conversation. That
+// preserves sticky routing and cache affinity without depending on hidden state.
+function buildOpenCodeRequestHeaders(
+  messages: readonly vscode.LanguageModelChatRequestMessage[],
+  options: vscode.ProvideLanguageModelChatResponseOptions,
+  modelId: string,
+): Record<string, string> {
+  const sessionId = cleanHeaderValue(
+    findStringOption(options, [
+      "sessionId",
+      "sessionID",
+      "chatSessionId",
+      "chatSessionID",
+      "conversationId",
+      "conversationID",
+      "threadId",
+      "threadID",
+      "session.id",
+      "chatSession.id",
+    ]) ?? `vscode-${stableHash(conversationAnchor(messages, modelId))}`,
+  );
+  const requestId = cleanHeaderValue(
+    findStringOption(options, [
+      "requestId",
+      "requestID",
+      "messageId",
+      "messageID",
+    ]) ??
+      `req-${stableHash(`${Date.now()}-${Math.random()}-${sessionId}-${modelId}`)}`,
+  );
+
+  return {
+    "x-opencode-session": sessionId,
+    "x-opencode-request": requestId,
+    "x-opencode-client": OPEN_CODE_CLIENT,
+    "User-Agent": OPEN_CODE_USER_AGENT,
+  };
+}
+
+function findStringOption(
+  options: unknown,
+  paths: string[],
+): string | undefined {
+  for (const path of paths) {
+    const value = readPath(options, path.split("."));
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function readPath(value: unknown, path: string[]): unknown {
+  let current = value;
+  for (const segment of path) {
+    if (!isRecord(current)) {
+      return undefined;
+    }
+    current = current[segment];
+  }
+  return current;
+}
+
+function conversationAnchor(
+  messages: readonly vscode.LanguageModelChatRequestMessage[],
+  modelId: string,
+): string {
+  const anchorMessages = messages
+    .slice(0, 3)
+    .map((message) => `${message.role}:${messageText(message).slice(0, 2048)}`);
+  return anchorMessages.length ? anchorMessages.join("\n") : modelId;
+}
+
+function cleanHeaderValue(value: string): string {
+  const cleaned = value.replace(/[\r\n]/g, " ").trim();
+  return cleaned ? cleaned.slice(0, 256) : "unknown";
+}
+
+function stableHash(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index++) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
 }
 
 function mapOpenAiTools(tools: readonly vscode.LanguageModelChatTool[] | undefined): OpenAiToolDefinition[] {
@@ -1022,38 +1143,76 @@ async function streamOpenCodeResponse(
   providerDisplayName: string,
   apiKey: string,
   body: unknown,
+  requestHeaders: Record<string, string>,
   progress: vscode.Progress<vscode.LanguageModelResponsePart>,
   token: vscode.CancellationToken,
   extractStreamParts: (data: unknown) => vscode.LanguageModelResponsePart[],
   extractFullParts: (data: unknown) => vscode.LanguageModelResponsePart[],
   output?: vscode.OutputChannel,
-  verbose: boolean = false
+  verbose: boolean = false,
+  requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
+  streamIdleTimeoutMs = DEFAULT_STREAM_IDLE_TIMEOUT_MS,
 ): Promise<void> {
   const controller = new AbortController();
-  const cancellation = token.onCancellationRequested(() => controller.abort());
+  let abortReason:
+    | "request-timeout"
+    | "stream-idle-timeout"
+    | "cancelled"
+    | undefined;
+  const abort = (reason: typeof abortReason) => {
+    abortReason ??= reason;
+    controller.abort();
+  };
+  const cancellation = token.onCancellationRequested(() => abort("cancelled"));
+  const requestTimeout = setTimeout(
+    () => abort("request-timeout"),
+    requestTimeoutMs,
+  );
+  let streamIdleTimeout: ReturnType<typeof setTimeout> | undefined;
+  const resetStreamIdleTimeout = () => {
+    if (streamIdleTimeout) {
+      clearTimeout(streamIdleTimeout);
+    }
+    streamIdleTimeout = setTimeout(
+      () => abort("stream-idle-timeout"),
+      streamIdleTimeoutMs,
+    );
+  };
 
   try {
     const payload = JSON.stringify(body);
-    output?.appendLine(`[request] url=${url} payloadBytes=${payload.length}`);
+    output?.appendLine(`[request] url=${url} payloadBytes=${payload.length} requestTimeoutMs=${requestTimeoutMs} streamIdleTimeoutMs=${streamIdleTimeoutMs}`);
     const response = await fetch(url, {
       method: "POST",
       headers: {
         "Authorization": `Bearer ${apiKey}`,
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
+        ...requestHeaders,
       },
       body: payload,
       signal: controller.signal
     });
 
     output?.appendLine(`[http] ${response.status} ${response.statusText} content-type=${response.headers.get("content-type") ?? "<none>"}`);
+    const rateLimitSummary = formatRateLimitSummary(
+      readRateLimitInfo(response.headers),
+    );
+    if (rateLimitSummary) {
+      output?.appendLine(`[rate-limit] ${rateLimitSummary}`);
+    }
 
     if (!response.ok) {
       const detail = await response.text();
       const modelId = (isRecord(body) && typeof (body as { model?: unknown }).model === "string") ? (body as { model: string }).model : undefined;
-      const modelHint = modelId ? ` model=${modelId}` : "";
-      const sizeHint = ` payloadBytes=${payload.length}`;
       const capacityHint = (modelId && CAPACITY_LIMITED_MODEL_NOTES[modelId] && response.status >= 500) ? ` — ${CAPACITY_LIMITED_MODEL_NOTES[modelId]}` : "";
-      throw new Error(`${providerDisplayName} API request failed (${response.status})${modelHint}${sizeHint}${capacityHint}: ${detail || response.statusText}`);
+      throw buildOpenCodeRequestError(
+        providerDisplayName,
+        response,
+        detail,
+        modelId,
+        payload.length,
+        capacityHint,
+      );
     }
 
     const contentType = response.headers.get("content-type") ?? "";
@@ -1075,12 +1234,14 @@ async function streamOpenCodeResponse(
     let buffer = "";
     let totalBytes = 0;
     let totalEvents = 0;
+    resetStreamIdleTimeout();
 
     while (!token.isCancellationRequested) {
       const { value, done } = await reader.read();
       if (done) {
         break;
       }
+      resetStreamIdleTimeout();
 
       totalBytes += value?.byteLength ?? 0;
       const chunk = decoder.decode(value, { stream: true });
@@ -1114,9 +1275,336 @@ async function streamOpenCodeResponse(
     if (output) {
       output.appendLine(`[sse-stats] totalBytes=${totalBytes} totalEvents=${totalEvents} bufferTailLen=${buffer.length}`);
     }
+  } catch (error) {
+    if (abortReason === "cancelled") {
+      return;
+    }
+    if (abortReason === "request-timeout") {
+      throw new OpenCodeRequestError(
+        `${providerDisplayName} request timed out after ${formatDuration(requestTimeoutMs)}.`,
+        `${providerDisplayName} did not start or finish the request within ${formatDuration(requestTimeoutMs)}. Try again later or reduce the request size.`,
+      );
+    }
+    if (abortReason === "stream-idle-timeout") {
+      throw new OpenCodeRequestError(
+        `${providerDisplayName} stream stalled for ${formatDuration(streamIdleTimeoutMs)} without new data.`,
+        `${providerDisplayName} stopped sending stream data for ${formatDuration(streamIdleTimeoutMs)}, so the request was cancelled to avoid leaving Copilot stuck.`,
+      );
+    }
+    throw error;
   } finally {
+    clearTimeout(requestTimeout);
+    if (streamIdleTimeout) {
+      clearTimeout(streamIdleTimeout);
+    }
     cancellation.dispose();
   }
+}
+
+class OpenCodeRequestError extends Error {
+  constructor(
+    message: string,
+    readonly userMessage: string = message,
+  ) {
+    super(message);
+    this.name = "OpenCodeRequestError";
+  }
+}
+
+interface ParsedApiError {
+  message?: string;
+  code?: string;
+  type?: string;
+  retryIn?: string;
+}
+
+interface RateLimitInfo {
+  retryAfterMs?: number;
+  resetAfterMs?: number;
+  requestLimit?: string;
+  requestRemaining?: string;
+  tokenLimit?: string;
+  tokenRemaining?: string;
+}
+
+function buildOpenCodeRequestError(
+  providerDisplayName: string,
+  response: Response,
+  rawDetail: string,
+  modelId: string | undefined,
+  payloadBytes: number,
+  capacityHint: string,
+): OpenCodeRequestError {
+  const apiError = parseApiError(rawDetail);
+  const rateLimitInfo = readRateLimitInfo(response.headers);
+  const modelHint = modelId ? ` model=${modelId}` : "";
+  const sizeHint = ` payloadBytes=${payloadBytes}`;
+  const apiMessage =
+    (apiError.message ?? rawDetail.trim()) || response.statusText;
+  const isLimit = isRateLimitResponse(response.status, apiError);
+
+  if (isLimit) {
+    const waitText =
+      apiError.retryIn ??
+      formatWaitText(rateLimitInfo.retryAfterMs ?? rateLimitInfo.resetAfterMs);
+    const quotaText = formatRateLimitSummary(rateLimitInfo);
+    const reason = classifyRateLimit(apiError, response.status);
+    const details = [
+      shouldIncludeApiMessage(apiMessage, reason) ? apiMessage : undefined,
+      waitText ? `Retry after ${waitText}.` : undefined,
+      quotaText ? `Quota: ${quotaText}.` : undefined,
+    ].filter((part): part is string => Boolean(part));
+    const userMessage =
+      `${providerDisplayName}: ${reason}${modelHint ? ` (${modelId})` : ""}. ${details.join(" ")}`.trim();
+    return new OpenCodeRequestError(
+      `${providerDisplayName} API rate/quota limit (${response.status})${modelHint}${sizeHint}: ${apiMessage}; ${quotaText || "no quota headers"}`,
+      userMessage,
+    );
+  }
+
+  const userMessage = `${providerDisplayName} API request failed (HTTP ${response.status})${modelHint ? ` for ${modelId}` : ""}: ${apiMessage}${capacityHint}`;
+  return new OpenCodeRequestError(
+    `${providerDisplayName} API request failed (${response.status})${modelHint}${sizeHint}${capacityHint}: ${apiMessage}`,
+    userMessage,
+  );
+}
+
+function parseApiError(rawDetail: string): ParsedApiError {
+  const fallback = rawDetail.trim();
+  if (!fallback) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(fallback) as unknown;
+    if (!isRecord(parsed)) {
+      return { message: fallback };
+    }
+
+    const error = isRecord(parsed.error) ? parsed.error : parsed;
+    return {
+      message: firstString(error.message, parsed.message, fallback),
+      code: firstString(error.code, parsed.code),
+      type: firstString(error.type, parsed.type),
+      retryIn: firstString(
+        error.retryIn,
+        parsed.retryIn,
+        error.retry_in,
+        parsed.retry_in,
+      ),
+    };
+  } catch {
+    return { message: fallback };
+  }
+}
+
+function readRateLimitInfo(headers: Headers): RateLimitInfo {
+  const retryAfter = firstHeader(headers, ["retry-after"]);
+  const requestLimit = firstHeader(headers, [
+    "x-ratelimit-limit-requests",
+    "anthropic-ratelimit-requests-limit",
+    "x-ratelimit-limit",
+    "ratelimit-limit",
+  ]);
+  const requestRemaining = firstHeader(headers, [
+    "x-ratelimit-remaining-requests",
+    "anthropic-ratelimit-requests-remaining",
+    "x-ratelimit-remaining",
+    "ratelimit-remaining",
+  ]);
+  const tokenLimit = firstHeader(headers, [
+    "x-ratelimit-limit-tokens",
+    "anthropic-ratelimit-tokens-limit",
+  ]);
+  const tokenRemaining = firstHeader(headers, [
+    "x-ratelimit-remaining-tokens",
+    "anthropic-ratelimit-tokens-remaining",
+  ]);
+  const reset = firstHeader(headers, [
+    "x-ratelimit-reset-requests",
+    "x-ratelimit-reset-tokens",
+    "anthropic-ratelimit-requests-reset",
+    "anthropic-ratelimit-tokens-reset",
+    "x-ratelimit-reset",
+    "ratelimit-reset",
+  ]);
+
+  return {
+    retryAfterMs: parseRetryAfter(retryAfter),
+    resetAfterMs: parseResetAfter(reset),
+    requestLimit,
+    requestRemaining,
+    tokenLimit,
+    tokenRemaining,
+  };
+}
+
+function formatRateLimitSummary(info: RateLimitInfo): string | undefined {
+  const parts = [
+    info.requestRemaining || info.requestLimit
+      ? `requests remaining=${info.requestRemaining ?? "?"}${info.requestLimit ? `/${info.requestLimit}` : ""}`
+      : undefined,
+    info.tokenRemaining || info.tokenLimit
+      ? `tokens remaining=${info.tokenRemaining ?? "?"}${info.tokenLimit ? `/${info.tokenLimit}` : ""}`
+      : undefined,
+    info.retryAfterMs !== undefined
+      ? `retry-after=${formatDuration(info.retryAfterMs)}`
+      : undefined,
+    info.resetAfterMs !== undefined
+      ? `reset=${formatDuration(info.resetAfterMs)}`
+      : undefined,
+  ].filter((part): part is string => Boolean(part));
+
+  return parts.length ? parts.join("; ") : undefined;
+}
+
+function classifyRateLimit(apiError: ParsedApiError, status: number): string {
+  const code =
+    `${apiError.code ?? ""} ${apiError.type ?? ""} ${apiError.message ?? ""}`.toLowerCase();
+  const compactCode = compactErrorCode(code);
+  if (compactCode.includes("gosubscriptionrollinglimitexceeded")) {
+    return "5-hour OpenCode Go usage limit reached";
+  }
+  if (compactCode.includes("gosubscriptionweeklylimitexceeded")) {
+    return "weekly OpenCode Go usage limit reached";
+  }
+  if (compactCode.includes("gosubscriptionmonthlylimitexceeded")) {
+    return "monthly OpenCode Go usage limit reached";
+  }
+  if (code.includes("subscriptionquota") || code.includes("quota")) {
+    return "OpenCode quota exceeded";
+  }
+  return status === 429
+    ? "rate limit exceeded"
+    : "OpenCode usage limit reached";
+}
+
+function isRateLimitResponse(
+  status: number,
+  apiError: ParsedApiError,
+): boolean {
+  const code =
+    `${apiError.code ?? ""} ${apiError.type ?? ""} ${apiError.message ?? ""}`.toLowerCase();
+  const compactCode = compactErrorCode(code);
+  return (
+    status === 429 ||
+    compactCode.includes("ratelimit") ||
+    code.includes("rate_limit") ||
+    code.includes("quota") ||
+    compactCode.includes("limitexceeded")
+  );
+}
+
+function compactErrorCode(value: string): string {
+  return value.replace(/[^a-z0-9]/g, "");
+}
+
+function shouldIncludeApiMessage(apiMessage: string, reason: string): boolean {
+  const normalizedMessage = compactErrorCode(apiMessage.toLowerCase());
+  const normalizedReason = compactErrorCode(reason.toLowerCase());
+  return (
+    Boolean(normalizedMessage) &&
+    !normalizedMessage.startsWith(normalizedReason)
+  );
+}
+
+function firstHeader(headers: Headers, names: string[]): string | undefined {
+  for (const name of names) {
+    const value = headers.get(name);
+    if (value?.trim()) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function parseRetryAfter(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return seconds * 1000;
+  }
+  const dateMs = Date.parse(value);
+  return Number.isFinite(dateMs)
+    ? Math.max(0, dateMs - Date.now())
+    : parseDurationLike(value);
+}
+
+function parseResetAfter(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const numeric = Number(value);
+  if (Number.isFinite(numeric) && numeric >= 0) {
+    if (numeric > 1_000_000_000_000) {
+      return Math.max(0, numeric - Date.now());
+    }
+    if (numeric > 1_000_000_000) {
+      return Math.max(0, numeric * 1000 - Date.now());
+    }
+    return numeric * 1000;
+  }
+  const durationMs = parseDurationLike(value);
+  if (durationMs !== undefined) {
+    return durationMs;
+  }
+  return parseRetryAfter(value);
+}
+
+function parseDurationLike(value: string): number | undefined {
+  const matches = value
+    .trim()
+    .toLowerCase()
+    .matchAll(/(\d+(?:\.\d+)?)(ms|s|m|h)/g);
+  let totalMs = 0;
+  let found = false;
+  for (const match of matches) {
+    found = true;
+    const amount = Number(match[1]);
+    const unit = match[2];
+    if (!Number.isFinite(amount)) {
+      continue;
+    }
+    if (unit === "ms") {
+      totalMs += amount;
+    } else if (unit === "s") {
+      totalMs += amount * 1000;
+    } else if (unit === "m") {
+      totalMs += amount * 60 * 1000;
+    } else if (unit === "h") {
+      totalMs += amount * 60 * 60 * 1000;
+    }
+  }
+  return found ? Math.max(0, Math.ceil(totalMs)) : undefined;
+}
+
+function formatWaitText(value: number | undefined): string | undefined {
+  return value === undefined ? undefined : formatDuration(value);
+}
+
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.ceil(ms / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  if (hours) {
+    return `${hours}h ${minutes}m`;
+  }
+  if (minutes) {
+    return `${minutes}m ${seconds}s`;
+  }
+  return `${seconds}s`;
 }
 
 function truncateForLog(value: string, max = 1200): string {
@@ -1776,6 +2264,16 @@ function getSettings(): ApiSettings {
     maxOutputTokensOverride: config.get("maxTokens", 0),
     maxInputTokensOverride: config.get("maxInputTokens", 0),
     debugReasoning: config.get("debugReasoning", false),
+    requestTimeoutMs:
+      Math.max(config.get("requestTimeoutSeconds", DEFAULT_REQUEST_TIMEOUT_MS / 1000), 1) * 1000,
+    streamIdleTimeoutMs:
+      Math.max(
+        config.get(
+          "streamIdleTimeoutSeconds",
+          DEFAULT_STREAM_IDLE_TIMEOUT_MS / 1000,
+        ),
+        1,
+      ) * 1000,
     thinking: {
       deepseek: config.get<ThinkingSettings["deepseek"]>("thinking.deepseek", "off"),
       glm: config.get<ThinkingSettings["glm"]>("thinking.glm", "off"),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -279,14 +279,14 @@ const MODEL_LIMITS_BY_PROVIDER: Record<ProviderDefinition["vendor"], Record<stri
   [GO_VENDOR]: {
     "deepseek-v4-flash": { contextWindow: 1000000, maxOutputTokens: 384000 },
     "deepseek-v4-pro": { contextWindow: 1000000, maxOutputTokens: 384000 },
-    "mimo-v2.5": { contextWindow: 1048576, maxOutputTokens: 131072 },
+    "mimo-v2.5": { contextWindow: 1000000, maxOutputTokens: 128000 },
     "mimo-v2.5-pro": { contextWindow: 1048576, maxOutputTokens: 128000 },
     "mimo-v2-omni": { contextWindow: 262144, maxOutputTokens: 128000 },
     "mimo-v2-pro": { contextWindow: 1048576, maxOutputTokens: 128000 },
-    "kimi-k2.6": { contextWindow: 262144, maxOutputTokens: 262144 },
+    "kimi-k2.6": { contextWindow: 262144, maxOutputTokens: 65536 },
     "kimi-k2.5": { contextWindow: 262144, maxOutputTokens: 65536 },
-    "glm-5.1": { contextWindow: 200000, maxOutputTokens: 131072 },
-    "glm-5": { contextWindow: 202752, maxOutputTokens: 202752 },
+    "glm-5.1": { contextWindow: 202752, maxOutputTokens: 32768 },
+    "glm-5": { contextWindow: 202752, maxOutputTokens: 32768 },
     "minimax-m2.7": { contextWindow: 204800, maxOutputTokens: 131072 },
     "minimax-m2.5": { contextWindow: 204800, maxOutputTokens: 65536 },
     "qwen3.6-plus": { contextWindow: 262144, maxOutputTokens: 65536 },
@@ -298,11 +298,11 @@ const MODEL_LIMITS_BY_PROVIDER: Record<ProviderDefinition["vendor"], Record<stri
     "deepseek-v4-flash-free": { contextWindow: 200000, maxOutputTokens: 128000 },
     "minimax-m2.5-free": { contextWindow: 204800, maxOutputTokens: 131072 },
     "qwen3.6-plus": { contextWindow: 262144, maxOutputTokens: 65536 },
-    "qwen3.6-plus-free": { contextWindow: 200000, maxOutputTokens: 128000 },
+    "qwen3.6-plus-free": { contextWindow: 262144, maxOutputTokens: 65536 },
     "qwen3.5-plus": { contextWindow: 262144, maxOutputTokens: 65536 },
     "trinity-large-preview-free": { contextWindow: 131072, maxOutputTokens: 131072 },
-    "nemotron-3-super-free": { contextWindow: 256000, maxOutputTokens: 256000 },
-    "big-pickle": { contextWindow: 128000, maxOutputTokens: 64000 }
+    "nemotron-3-super-free": { contextWindow: 204800, maxOutputTokens: 128000 },
+    "big-pickle": { contextWindow: 200000, maxOutputTokens: 128000 }
   }
 };
 
@@ -1176,6 +1176,11 @@ async function streamAnthropicMessages(
     settings.debugReasoning,
     settings.requestTimeoutMs,
     settings.streamIdleTimeoutMs,
+    {
+      Authorization: `Bearer ${apiKey}`,
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01"
+    },
   );
 }
 
@@ -1259,7 +1264,10 @@ async function streamGoogleGenerateContent(
     settings.debugReasoning,
     settings.requestTimeoutMs,
     settings.streamIdleTimeoutMs,
-    { "x-goog-api-key": apiKey },
+    {
+      Authorization: `Bearer ${apiKey}`,
+      "x-goog-api-key": apiKey
+    },
   );
 
   extractor.flushReasoningFallback(progress);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ interface ProviderDefinition {
   modelsUrl: string;
   chatCompletionsUrl: string;
   messagesUrl: string;
+  responsesUrl?: string;
   categoryOrder: number;
   testModelId: string;
   fallbackModels: string[];
@@ -29,7 +30,7 @@ const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 2 * 60 * 1000;
 const OPEN_CODE_CLIENT = "vscode-copilot-chat";
 const OPEN_CODE_USER_AGENT = "opencode-copilot-chat/0.1.6 VSCode";
 // Bump this when we need to force VS Code picker metadata refresh.
-const MODEL_METADATA_REVISION = "naming-2026-05-17-a";
+const MODEL_METADATA_REVISION = "session-2026-05-21-b";
 
 const PROVIDERS: Record<ProviderDefinition["vendor"], ProviderDefinition> = {
   [GO_VENDOR]: {
@@ -67,6 +68,7 @@ const PROVIDERS: Record<ProviderDefinition["vendor"], ProviderDefinition> = {
     modelsUrl: "https://opencode.ai/zen/v1/models",
     chatCompletionsUrl: "https://opencode.ai/zen/v1/chat/completions",
     messagesUrl: "https://opencode.ai/zen/v1/messages",
+    responsesUrl: "https://opencode.ai/zen/v1/responses",
     categoryOrder: 3,
     testModelId: "deepseek-v4-flash-free",
     fallbackModels: [
@@ -94,19 +96,54 @@ interface OpenCodeModel extends vscode.LanguageModelChatInformation {
   configurationSchema?: vscode.LanguageModelConfigurationSchema;
 }
 
+interface ModelListEntry {
+  id?: string;
+  owned_by?: string;
+  status?: string;
+  deprecated?: boolean;
+  limit?: {
+    context?: number;
+    output?: number;
+  };
+  context_window?: number;
+  contextWindow?: number;
+  max_output_tokens?: number;
+  maxOutputTokens?: number;
+  attachment?: boolean;
+  image_input?: boolean;
+  imageInput?: boolean;
+  reasoning?: boolean;
+  modalities?: {
+    input?: string[];
+    output?: string[];
+  };
+}
+
 interface ModelListResponse {
-  data?: Array<{
-    id?: string;
-    owned_by?: string;
-  }>;
+  data?: ModelListEntry[];
+}
+
+interface ModelsDevModelRecord {
+  status?: string;
+  limit?: {
+    context?: number;
+    output?: number;
+  };
+  attachment?: boolean;
+  reasoning?: boolean;
+  modalities?: {
+    input?: string[];
+    output?: string[];
+  };
+}
+
+interface ModelsDevProviderRecord {
+  models?: Record<string, ModelsDevModelRecord>;
 }
 
 interface ModelsDevResponse {
-  opencode?: {
-    models?: Record<string, {
-      status?: string;
-    }>;
-  };
+  opencode?: ModelsDevProviderRecord;
+  "opencode-go"?: ModelsDevProviderRecord;
 }
 
 interface ApiMessage {
@@ -181,13 +218,46 @@ interface ModelLimits extends BaseModelLimits {
   advertisedMaxOutputTokens: number;
 }
 
+interface ModelMetadataFields {
+  contextWindow?: number;
+  maxOutputTokens?: number;
+  supportsVision?: boolean;
+  reasoning?: boolean;
+  status?: string;
+}
+
+interface CachedModelMetadataSnapshot {
+  fetchedAt: number;
+  providers: Record<
+    ProviderDefinition["vendor"],
+    Record<string, ModelMetadataFields>
+  >;
+}
+
+interface ResolvedModelMetadata extends BaseModelLimits {
+  supportsVision: boolean;
+  reasoning: boolean;
+  status?: string;
+  source: "models.dev" | "live" | "fallback" | "default";
+}
+
 // Copilot surfaces combine input/output metadata differently across views.
 // Reserve a modest UI output budget, while requests still use the real model max.
 const UI_OUTPUT_TOKEN_RESERVE = 8192;
+const MODEL_METADATA_CACHE_KEY = "opencodego.modelMetadataCache.v3";
+const MODEL_METADATA_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
 
 const DEFAULT_MODEL_LIMITS: BaseModelLimits = {
   contextWindow: 262144,
   maxOutputTokens: 65536
+};
+
+const MODELS_DEV_PROVIDER_BY_VENDOR: Record<
+  ProviderDefinition["vendor"],
+  keyof ModelsDevResponse
+> = {
+  [GO_VENDOR]: "opencode-go",
+  [ZEN_VENDOR]: "opencode",
 };
 
 // Context limits sourced from models.dev (official OpenCode model registry).
@@ -197,30 +267,30 @@ const MODEL_LIMITS_BY_PROVIDER: Record<ProviderDefinition["vendor"], Record<stri
   [GO_VENDOR]: {
     "deepseek-v4-flash": { contextWindow: 1000000, maxOutputTokens: 384000 },
     "deepseek-v4-pro": { contextWindow: 1000000, maxOutputTokens: 384000 },
-    "mimo-v2.5": { contextWindow: 1000000, maxOutputTokens: 128000 },
+    "mimo-v2.5": { contextWindow: 1048576, maxOutputTokens: 131072 },
     "mimo-v2.5-pro": { contextWindow: 1048576, maxOutputTokens: 128000 },
     "mimo-v2-omni": { contextWindow: 262144, maxOutputTokens: 128000 },
     "mimo-v2-pro": { contextWindow: 1048576, maxOutputTokens: 128000 },
-    "kimi-k2.6": { contextWindow: 262144, maxOutputTokens: 65536 },
+    "kimi-k2.6": { contextWindow: 262144, maxOutputTokens: 262144 },
     "kimi-k2.5": { contextWindow: 262144, maxOutputTokens: 65536 },
-    "glm-5.1": { contextWindow: 204800, maxOutputTokens: 131072 },
-    "glm-5": { contextWindow: 204800, maxOutputTokens: 131072 },
+    "glm-5.1": { contextWindow: 200000, maxOutputTokens: 131072 },
+    "glm-5": { contextWindow: 202752, maxOutputTokens: 202752 },
     "minimax-m2.7": { contextWindow: 204800, maxOutputTokens: 131072 },
-    "minimax-m2.5": { contextWindow: 204800, maxOutputTokens: 131072 },
+    "minimax-m2.5": { contextWindow: 204800, maxOutputTokens: 65536 },
     "qwen3.6-plus": { contextWindow: 262144, maxOutputTokens: 65536 },
     "qwen3.5-plus": { contextWindow: 262144, maxOutputTokens: 65536 },
     "hy3-preview": { contextWindow: 256000, maxOutputTokens: 64000 },
     "ring-2.6-1t": { contextWindow: 262000, maxOutputTokens: 66000 }
   },
   [ZEN_VENDOR]: {
-    "deepseek-v4-flash-free": { contextWindow: 1000000, maxOutputTokens: 384000 },
+    "deepseek-v4-flash-free": { contextWindow: 200000, maxOutputTokens: 128000 },
     "minimax-m2.5-free": { contextWindow: 204800, maxOutputTokens: 131072 },
     "qwen3.6-plus": { contextWindow: 262144, maxOutputTokens: 65536 },
-    "qwen3.6-plus-free": { contextWindow: 262144, maxOutputTokens: 65536 },
+    "qwen3.6-plus-free": { contextWindow: 200000, maxOutputTokens: 128000 },
     "qwen3.5-plus": { contextWindow: 262144, maxOutputTokens: 65536 },
     "trinity-large-preview-free": { contextWindow: 131072, maxOutputTokens: 131072 },
-    "nemotron-3-super-free": { contextWindow: 204800, maxOutputTokens: 128000 },
-    "big-pickle": { contextWindow: 200000, maxOutputTokens: 128000 }
+    "nemotron-3-super-free": { contextWindow: 256000, maxOutputTokens: 256000 },
+    "big-pickle": { contextWindow: 128000, maxOutputTokens: 64000 }
   }
 };
 
@@ -236,10 +306,11 @@ type CopilotCompatibleCapabilities = vscode.LanguageModelChatCapabilities & {
 // catalogs can still hit 5xx during traffic bursts. Surface this so users know
 // to retry or fall back to another free model if the request fails.
 const CAPACITY_LIMITED_MODEL_NOTES: Record<string, string> = {
-  "qwen3.6-plus-free": "Free relaunch with limited GPU capacity. Stable for short prompts; bursty traffic or very large tool catalogs may return 5xx — retry or fall back to 'deepseek-v4-flash-free' / 'minimax-m2.5-free'. Paid 'qwen3.6-plus' has no quota."
+  "qwen3.6-plus-free": "Free relaunch with limited GPU capacity. Stable for short prompts; bursty traffic or very large tool catalogs may return 5xx - retry or fall back to 'deepseek-v4-flash-free' / 'big-pickle'. Paid 'qwen3.6-plus' has no quota."
 };
 
-let deprecatedOpenCodeModelIdsPromise: Promise<Set<string>> | undefined;
+let modelMetadataSnapshot: CachedModelMetadataSnapshot | undefined;
+let modelMetadataRefreshPromise: Promise<CachedModelMetadataSnapshot> | undefined;
 
 const VISION_CAPABLE_MODELS = new Set([
   "minimax-m2.7",
@@ -364,6 +435,7 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
   readonly onDidChangeLanguageModelChatInformation = this.changeEmitter.event;
   private readonly apiKeysByModelId = new Map<string, string>();
   private readonly reasoningContentByToolCallId = new Map<string, string>();
+  private readonly liveModelMetadataById = new Map<string, ModelMetadataFields>();
   private outputChannel: vscode.OutputChannel | undefined;
 
   constructor(
@@ -381,6 +453,71 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
 
   private log(message: string): void {
     this.getOutputChannel().appendLine(`[${new Date().toISOString()}] ${message}`);
+  }
+
+  private async getMetadataSnapshot(): Promise<CachedModelMetadataSnapshot> {
+    return getOpenCodeModelMetadata(this.context, this.getOutputChannel());
+  }
+
+  private resolveModelMetadata(
+    modelId: string,
+    snapshot: CachedModelMetadataSnapshot,
+  ): ResolvedModelMetadata {
+    const cachedMetadata = snapshot.providers[this.definition.vendor][modelId];
+    const liveMetadata = this.liveModelMetadataById.get(modelId);
+    const fallbackMetadata = fallbackModelMetadata(modelId, this.definition.vendor);
+
+    return {
+      contextWindow:
+        liveMetadata?.contextWindow ??
+        cachedMetadata?.contextWindow ??
+        fallbackMetadata?.contextWindow ??
+        DEFAULT_MODEL_LIMITS.contextWindow,
+      maxOutputTokens:
+        liveMetadata?.maxOutputTokens ??
+        cachedMetadata?.maxOutputTokens ??
+        fallbackMetadata?.maxOutputTokens ??
+        DEFAULT_MODEL_LIMITS.maxOutputTokens,
+      supportsVision:
+        liveMetadata?.supportsVision ??
+        cachedMetadata?.supportsVision ??
+        fallbackMetadata?.supportsVision ??
+        false,
+      reasoning:
+        liveMetadata?.reasoning ??
+        cachedMetadata?.reasoning ??
+        fallbackMetadata?.reasoning ??
+        Boolean(thinkingFamily(modelId)),
+      status:
+        liveMetadata?.status ??
+        cachedMetadata?.status ??
+        fallbackMetadata?.status,
+      source: liveMetadata
+        ? "live"
+        : cachedMetadata
+          ? "models.dev"
+          : fallbackMetadata
+            ? "fallback"
+            : "default",
+    };
+  }
+
+  private replaceLiveModelMetadata(entries: ModelListEntry[] | undefined): void {
+    this.liveModelMetadataById.clear();
+    for (const entry of entries ?? []) {
+      if (typeof entry.id !== "string" || !entry.id) {
+        continue;
+      }
+      const metadata = normalizeLiveModelMetadata(entry);
+      if (metadata) {
+        this.liveModelMetadataById.set(entry.id, metadata);
+      }
+    }
+  }
+
+  private async refreshMetadataAndModels(): Promise<void> {
+    await clearOpenCodeModelMetadataCache(this.context);
+    await this.fetchModels();
   }
 
   async manage(): Promise<void> {
@@ -425,6 +562,7 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
       return;
     }
 
+    await this.refreshMetadataAndModels();
     this.changeEmitter.fire();
     vscode.window.showInformationMessage(`${this.definition.displayName} models refreshed.`);
   }
@@ -492,9 +630,11 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
 
   async showDiagnostics(): Promise<void> {
     const models = await vscode.lm.selectChatModels({ vendor: this.definition.vendor });
+    const metadataSnapshot = await this.getMetadataSnapshot();
     const lines = models.map((model) => {
       const rawModelId = resolveRawModelId(model.id);
-      const limits = modelLimits(rawModelId, undefined, this.definition.vendor);
+      const metadata = this.resolveModelMetadata(rawModelId, metadataSnapshot);
+      const limits = modelLimits(metadata);
       return [
       `- ${rawModelId}`,
       `  rawModelId: ${rawModelId}`,
@@ -506,9 +646,12 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
       `  advertisedMaxOutputTokens: ${limits.advertisedMaxOutputTokens}`,
       `  advertisedContextWindow: ${limits.advertisedContextWindow}`,
       `  apiMaxOutputTokens: ${limits.maxOutputTokens}`,
+      `  metadataSource: ${metadata.source}`,
+      `  supportsVision: ${metadata.supportsVision}`,
+      `  status: ${metadata.status ?? "active"}`,
       `  thinkingFamily: ${thinkingFamily(rawModelId) ?? "none"}`,
       `  configurationSchema: ${JSON.stringify((model as unknown as { configurationSchema?: unknown }).configurationSchema ?? null)}`,
-      ...(hasExplicitModelLimits(rawModelId, this.definition.vendor) ? [] : ["  limits: using default fallback"])
+      ...(hasExplicitModelLimits(rawModelId, this.definition.vendor) ? [] : ["  limits: using bundled fallback"])
       ].join("\n");
     });
 
@@ -540,10 +683,12 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
 
     const models = await this.fetchModels();
     const settings = getSettings();
+    const metadataSnapshot = await this.getMetadataSnapshot();
 
     return models.map((modelId) => {
+      const metadata = this.resolveModelMetadata(modelId, metadataSnapshot);
       const effectiveModelId = toEffectiveModelId(modelId, this.definition.vendor);
-      const limits = modelLimits(modelId, settings, this.definition.vendor);
+      const limits = modelLimits(metadata, settings);
       this.apiKeysByModelId.set(modelId, apiKey);
       this.apiKeysByModelId.set(effectiveModelId, apiKey);
 
@@ -569,7 +714,7 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
         isUserSelectable: true,
         maxInputTokens: limits.advertisedMaxInputTokens,
         maxOutputTokens: limits.advertisedMaxOutputTokens,
-        capabilities: modelCapabilities(modelId),
+        capabilities: modelCapabilities(metadata),
         endpointKind: modelEndpointKind(modelId, this.definition),
         provider: this.definition,
         // Inline so Copilot Chat picks up the Thinking submenu directly
@@ -577,7 +722,7 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
         ...(configurationSchema ? { configurationSchema } : {})
       };
 
-      this.log(`Model registered: id=${info.id} family=${info.family} configurationSchema=${configurationSchema ? JSON.stringify(configurationSchema) : "none"}`);
+      this.log(`Model registered: id=${info.id} family=${info.family} metadataSource=${metadata.source} configurationSchema=${configurationSchema ? JSON.stringify(configurationSchema) : "none"}`);
 
       return info;
     });
@@ -609,7 +754,9 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
       ...baseSettings,
       thinking: applyRequestThinkingOverride(rawModelId, baseSettings.thinking, requestOverride)
     };
-    const limits = modelLimits(rawModelId, settings, model.provider.vendor);
+    const metadataSnapshot = await this.getMetadataSnapshot();
+    const metadata = this.resolveModelMetadata(rawModelId, metadataSnapshot);
+    const limits = modelLimits(metadata, settings);
     const thinkingPayload = buildThinkingPayload(rawModelId, settings.thinking);
     const requestHeaders = buildOpenCodeRequestHeaders(
       messages,
@@ -617,7 +764,7 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
       rawModelId,
     );
 
-    this.log(`Request: model=${model.id} rawModel=${rawModelId} endpoint=${model.endpointKind} messages=${apiMessages.length} session=${requestHeaders["x-opencode-session"]} request=${requestHeaders["x-opencode-request"]} modelConfiguration=${JSON.stringify(pickThinkingModelConfiguration(requestOverride))} thinking=${JSON.stringify(settings.thinking)} thinkingPayload=${JSON.stringify(thinkingPayload)}`);
+    this.log(`Request: model=${model.id} rawModel=${rawModelId} endpoint=${model.endpointKind} metadataSource=${metadata.source} messages=${apiMessages.length} session=${requestHeaders["x-opencode-session"]} request=${requestHeaders["x-opencode-request"]} modelConfiguration=${JSON.stringify(pickThinkingModelConfiguration(requestOverride))} thinking=${JSON.stringify(settings.thinking)} thinkingPayload=${JSON.stringify(thinkingPayload)}`);
     if (settings.debugReasoning) {
       this.log("Reasoning debug is enabled. Provider reasoning_content will be written to this output channel when available.");
     }
@@ -696,6 +843,7 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
       }
 
       const data = await response.json() as ModelListResponse;
+      this.replaceLiveModelMetadata(data.data);
       const ids = data.data
         ?.map((model) => model.id)
         .filter((id): id is string => typeof id === "string" && id.length > 0)
@@ -713,10 +861,10 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
     const uniqueModelIds = [...new Set(modelIds)];
 
     try {
-      const deprecatedModelIds = await fetchDeprecatedOpenCodeModelIds();
+      const metadataSnapshot = await this.getMetadataSnapshot();
       const filteredModelIds = uniqueModelIds.filter((modelId) =>
         !KNOWN_UNAVAILABLE_MODEL_IDS.has(modelId)
-        && !deprecatedModelIds.has(modelId)
+        && !shouldHideDeprecatedModel(modelId, this.definition.vendor, metadataSnapshot)
       );
 
       const removedModelIds = uniqueModelIds.filter((modelId) => !filteredModelIds.includes(modelId));
@@ -739,8 +887,48 @@ function getConfiguredApiKey(options?: { configuration?: LanguageModelConfigurat
   return typeof configuredApiKey === "string" && configuredApiKey.trim() ? configuredApiKey.trim() : undefined;
 }
 
-async function fetchDeprecatedOpenCodeModelIds(): Promise<Set<string>> {
-  deprecatedOpenCodeModelIdsPromise ??= (async () => {
+function isFreshModelMetadata(snapshot: CachedModelMetadataSnapshot): boolean {
+  return Date.now() - snapshot.fetchedAt < MODEL_METADATA_CACHE_TTL_MS;
+}
+
+async function clearOpenCodeModelMetadataCache(
+  context: vscode.ExtensionContext,
+): Promise<void> {
+  modelMetadataSnapshot = undefined;
+  modelMetadataRefreshPromise = undefined;
+  await context.globalState.update(MODEL_METADATA_CACHE_KEY, undefined);
+}
+
+async function getOpenCodeModelMetadata(
+  context: vscode.ExtensionContext,
+  output?: vscode.OutputChannel,
+): Promise<CachedModelMetadataSnapshot> {
+  const cached =
+    modelMetadataSnapshot ??
+    context.globalState.get<CachedModelMetadataSnapshot>(
+      MODEL_METADATA_CACHE_KEY,
+    );
+  if (cached) {
+    modelMetadataSnapshot = cached;
+    if (isFreshModelMetadata(cached)) {
+      return cached;
+    }
+    void refreshOpenCodeModelMetadata(context, output);
+    return cached;
+  }
+
+  return refreshOpenCodeModelMetadata(context, output);
+}
+
+async function refreshOpenCodeModelMetadata(
+  context: vscode.ExtensionContext,
+  output?: vscode.OutputChannel,
+): Promise<CachedModelMetadataSnapshot> {
+  if (modelMetadataRefreshPromise) {
+    return modelMetadataRefreshPromise;
+  }
+
+  modelMetadataRefreshPromise = (async () => {
     const response = await fetch(MODELS_DEV_API_URL);
 
     if (!response.ok) {
@@ -748,19 +936,42 @@ async function fetchDeprecatedOpenCodeModelIds(): Promise<Set<string>> {
     }
 
     const data = await response.json() as ModelsDevResponse;
-    const models = data.opencode?.models ?? {};
-    const deprecatedModelIds = new Set<string>();
-
-    for (const [modelId, model] of Object.entries(models)) {
-      if (model.status === "deprecated") {
-        deprecatedModelIds.add(modelId);
+    const snapshot = normalizeModelsDevSnapshot(data);
+    modelMetadataSnapshot = snapshot;
+    await context.globalState.update(MODEL_METADATA_CACHE_KEY, snapshot);
+    output?.appendLine(
+      `[metadata] refreshed models.dev cache go=${Object.keys(snapshot.providers[GO_VENDOR]).length} zen=${Object.keys(snapshot.providers[ZEN_VENDOR]).length}`,
+    );
+    return snapshot;
+  })()
+    .catch((error) => {
+      const cached =
+        modelMetadataSnapshot ??
+        context.globalState.get<CachedModelMetadataSnapshot>(
+          MODEL_METADATA_CACHE_KEY,
+        );
+      if (cached) {
+        const message = error instanceof Error ? error.message : String(error);
+        output?.appendLine(
+          `[metadata] refresh failed, using cached snapshot: ${message}`,
+        );
+        modelMetadataSnapshot = cached;
+        return cached;
       }
-    }
 
-    return deprecatedModelIds;
-  })();
+      const message = error instanceof Error ? error.message : String(error);
+      const fallback = bundledModelMetadataSnapshot();
+      output?.appendLine(
+        `[metadata] refresh failed, using bundled snapshot: ${message}`,
+      );
+      modelMetadataSnapshot = fallback;
+      return fallback;
+    })
+    .finally(() => {
+      modelMetadataRefreshPromise = undefined;
+    });
 
-  return deprecatedOpenCodeModelIdsPromise;
+  return modelMetadataRefreshPromise;
 }
 
 async function streamChatCompletions(
@@ -2327,13 +2538,11 @@ function isQwenModel(modelId: string): boolean {
 }
 
 function modelLimits(
-  modelId: string,
+  metadata: ResolvedModelMetadata,
   settings = getSettings(),
-  vendor: ProviderDefinition["vendor"] = ZEN_VENDOR
 ): ModelLimits {
-  const limits = MODEL_LIMITS_BY_PROVIDER[vendor][modelId] ?? DEFAULT_MODEL_LIMITS;
-  const contextWindow = positiveOverride(settings.maxInputTokensOverride) ?? limits.contextWindow;
-  const maxOutputTokens = positiveOverride(settings.maxOutputTokensOverride) ?? limits.maxOutputTokens;
+  const contextWindow = positiveOverride(settings.maxInputTokensOverride) ?? metadata.contextWindow;
+  const maxOutputTokens = positiveOverride(settings.maxOutputTokensOverride) ?? metadata.maxOutputTokens;
   const apiMaxOutputTokens = Math.min(maxOutputTokens, contextWindow);
   // advertisedContextWindow = actual model context window (not inflated).
   // Adding apiMaxOutputTokens here inflates the value above the real limit,
@@ -2373,8 +2582,14 @@ function positiveOverride(value: number): number | undefined {
   return Number.isFinite(value) && value > 0 ? Math.floor(value) : undefined;
 }
 
-function modelCapabilities(modelId: string): CopilotCompatibleCapabilities {
-  const supportsVision = VISION_CAPABLE_MODELS.has(modelId);
+function positiveNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : undefined;
+}
+
+function modelCapabilities(metadata: ResolvedModelMetadata): CopilotCompatibleCapabilities {
+  const supportsVision = metadata.supportsVision;
   return {
     imageInput: supportsVision,
     toolCalling: 128,
@@ -2395,6 +2610,153 @@ function toEffectiveModelId(modelId: string, vendor: ProviderDefinition["vendor"
   return `${vendor}:${modelId}::${MODEL_METADATA_REVISION}`;
 }
 
+function bundledModelMetadataSnapshot(): CachedModelMetadataSnapshot {
+  return {
+    fetchedAt: 0,
+    providers: {
+      [GO_VENDOR]: bundledModelMetadataForProvider(GO_VENDOR),
+      [ZEN_VENDOR]: bundledModelMetadataForProvider(ZEN_VENDOR),
+    },
+  };
+}
+
+function bundledModelMetadataForProvider(
+  vendor: ProviderDefinition["vendor"],
+): Record<string, ModelMetadataFields> {
+  return Object.fromEntries(
+    Object.keys(MODEL_LIMITS_BY_PROVIDER[vendor]).flatMap((modelId) => {
+      const metadata = fallbackModelMetadata(modelId, vendor);
+      return metadata ? [[modelId, metadata] as const] : [];
+    }),
+  );
+}
+
+function fallbackModelMetadata(
+  modelId: string,
+  vendor: ProviderDefinition["vendor"],
+): ModelMetadataFields | undefined {
+  const limits = MODEL_LIMITS_BY_PROVIDER[vendor][modelId];
+  const supportsVision = VISION_CAPABLE_MODELS.has(modelId);
+  const status =
+    vendor === ZEN_VENDOR && modelId === "minimax-m2.5-free"
+      ? "deprecated"
+      : undefined;
+
+  if (!limits && !supportsVision && !status && !thinkingFamily(modelId)) {
+    return undefined;
+  }
+
+  return {
+    contextWindow: limits?.contextWindow,
+    maxOutputTokens: limits?.maxOutputTokens,
+    supportsVision: supportsVision || undefined,
+    reasoning: Boolean(thinkingFamily(modelId)) || undefined,
+    status,
+  };
+}
+
+function normalizeModelsDevSnapshot(
+  data: ModelsDevResponse,
+): CachedModelMetadataSnapshot {
+  return {
+    fetchedAt: Date.now(),
+    providers: {
+      [GO_VENDOR]: normalizeModelsDevProvider(
+        data[MODELS_DEV_PROVIDER_BY_VENDOR[GO_VENDOR]]?.models ?? {},
+      ),
+      [ZEN_VENDOR]: normalizeModelsDevProvider(
+        data[MODELS_DEV_PROVIDER_BY_VENDOR[ZEN_VENDOR]]?.models ?? {},
+      ),
+    },
+  };
+}
+
+function normalizeModelsDevProvider(
+  models: Record<string, ModelsDevModelRecord>,
+): Record<string, ModelMetadataFields> {
+  const normalized: Record<string, ModelMetadataFields> = {};
+
+  for (const [modelId, model] of Object.entries(models)) {
+    const metadata = normalizeModelMetadataFields({
+      contextWindow: positiveNumber(model.limit?.context),
+      maxOutputTokens: positiveNumber(model.limit?.output),
+      supportsVision: detectVisionSupport(model.modalities, model.attachment),
+      reasoning:
+        typeof model.reasoning === "boolean" ? model.reasoning : undefined,
+      status: typeof model.status === "string" ? model.status : undefined,
+    });
+
+    if (metadata) {
+      normalized[modelId] = metadata;
+    }
+  }
+
+  return normalized;
+}
+
+function normalizeLiveModelMetadata(
+  model: ModelListEntry,
+): ModelMetadataFields | undefined {
+  return normalizeModelMetadataFields({
+    contextWindow: positiveNumber(
+      model.contextWindow ?? model.context_window ?? model.limit?.context,
+    ),
+    maxOutputTokens: positiveNumber(
+      model.maxOutputTokens ?? model.max_output_tokens ?? model.limit?.output,
+    ),
+    supportsVision: detectVisionSupport(
+      model.modalities,
+      model.imageInput ?? model.image_input ?? model.attachment,
+    ),
+    reasoning:
+      typeof model.reasoning === "boolean" ? model.reasoning : undefined,
+    status: model.deprecated
+      ? "deprecated"
+      : typeof model.status === "string"
+        ? model.status
+        : undefined,
+  });
+}
+
+function normalizeModelMetadataFields(
+  metadata: ModelMetadataFields,
+): ModelMetadataFields | undefined {
+  if (
+    metadata.contextWindow === undefined &&
+    metadata.maxOutputTokens === undefined &&
+    metadata.supportsVision === undefined &&
+    metadata.reasoning === undefined &&
+    metadata.status === undefined
+  ) {
+    return undefined;
+  }
+  return metadata;
+}
+
+function detectVisionSupport(
+  modalities: { input?: string[]; output?: string[] } | undefined,
+  attachmentHint: boolean | undefined,
+): boolean | undefined {
+  const inputModalities = Array.isArray(modalities?.input)
+    ? modalities.input
+    : undefined;
+  if (inputModalities?.length) {
+    return inputModalities.some((modality) => modality !== "text");
+  }
+  return typeof attachmentHint === "boolean" ? attachmentHint : undefined;
+}
+
+function shouldHideDeprecatedModel(
+  modelId: string,
+  vendor: ProviderDefinition["vendor"],
+  snapshot: CachedModelMetadataSnapshot,
+): boolean {
+  if (vendor !== ZEN_VENDOR) {
+    return false;
+  }
+  return snapshot.providers[vendor][modelId]?.status === "deprecated";
+}
+
 function resolveRawModelId(modelId: string): string {
   const [base] = modelId.split("::");
   const prefix = `${GO_VENDOR}:`;
@@ -2409,7 +2771,7 @@ function resolveRawModelId(modelId: string): string {
 }
 
 function hasExplicitModelLimits(modelId: string, vendor: ProviderDefinition["vendor"]): boolean {
-  return Boolean(MODEL_LIMITS_BY_PROVIDER[vendor][modelId]);
+  return Boolean(fallbackModelMetadata(modelId, vendor));
 }
 
 function isFreeZenModel(modelId: string): boolean {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,12 @@ interface ProviderDefinition {
   filterModel?: (modelId: string) => boolean;
 }
 
+type ModelEndpointKind =
+  | "chat-completions"
+  | "messages"
+  | "responses"
+  | "google";
+
 const FREE_ZEN_MODEL_IDS = new Set(["big-pickle"]);
 const MODELS_DEV_API_URL = "https://models.dev/api.json";
 const KNOWN_UNAVAILABLE_MODEL_IDS = new Set([
@@ -85,7 +91,7 @@ const PROVIDERS: Record<ProviderDefinition["vendor"], ProviderDefinition> = {
 type ApiRole = "user" | "assistant" | "tool";
 
 interface OpenCodeModel extends vscode.LanguageModelChatInformation {
-  endpointKind: "chat-completions" | "messages";
+  endpointKind: ModelEndpointKind;
   provider: ProviderDefinition;
   rawModelId?: string;
   category?: {
@@ -239,6 +245,12 @@ interface ResolvedModelMetadata extends BaseModelLimits {
   reasoning: boolean;
   status?: string;
   source: "models.dev" | "live" | "fallback" | "default";
+}
+
+interface ModelRoutingFields {
+  endpointKind: ModelEndpointKind;
+  endpointUrl: string;
+  sdkPackage?: string;
 }
 
 // Copilot surfaces combine input/output metadata differently across views.
@@ -687,6 +699,7 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
 
     return models.map((modelId) => {
       const metadata = this.resolveModelMetadata(modelId, metadataSnapshot);
+      const routing = resolveModelRouting(modelId, this.definition);
       const effectiveModelId = toEffectiveModelId(modelId, this.definition.vendor);
       const limits = modelLimits(metadata, settings);
       this.apiKeysByModelId.set(modelId, apiKey);
@@ -715,14 +728,14 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
         maxInputTokens: limits.advertisedMaxInputTokens,
         maxOutputTokens: limits.advertisedMaxOutputTokens,
         capabilities: modelCapabilities(metadata),
-        endpointKind: modelEndpointKind(modelId, this.definition),
+        endpointKind: routing.endpointKind,
         provider: this.definition,
         // Inline so Copilot Chat picks up the Thinking submenu directly
         // (parity with zelosleone/Opencode-Go-For-Copilot pattern).
         ...(configurationSchema ? { configurationSchema } : {})
       };
 
-      this.log(`Model registered: id=${info.id} family=${info.family} metadataSource=${metadata.source} configurationSchema=${configurationSchema ? JSON.stringify(configurationSchema) : "none"}`);
+      this.log(`Model registered: id=${info.id} family=${info.family} metadataSource=${metadata.source} endpointKind=${routing.endpointKind} endpointUrl=${routing.endpointUrl} configurationSchema=${configurationSchema ? JSON.stringify(configurationSchema) : "none"}`);
 
       return info;
     });
@@ -756,6 +769,7 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
     };
     const metadataSnapshot = await this.getMetadataSnapshot();
     const metadata = this.resolveModelMetadata(rawModelId, metadataSnapshot);
+    const routing = resolveModelRouting(rawModelId, this.definition);
     const limits = modelLimits(metadata, settings);
     const thinkingPayload = buildThinkingPayload(rawModelId, settings.thinking);
     const requestHeaders = buildOpenCodeRequestHeaders(
@@ -764,20 +778,39 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
       rawModelId,
     );
 
-    this.log(`Request: model=${model.id} rawModel=${rawModelId} endpoint=${model.endpointKind} metadataSource=${metadata.source} messages=${apiMessages.length} session=${requestHeaders["x-opencode-session"]} request=${requestHeaders["x-opencode-request"]} modelConfiguration=${JSON.stringify(pickThinkingModelConfiguration(requestOverride))} thinking=${JSON.stringify(settings.thinking)} thinkingPayload=${JSON.stringify(thinkingPayload)}`);
+    this.log(`Request: model=${model.id} rawModel=${rawModelId} endpoint=${routing.endpointKind} metadataSource=${metadata.source} messages=${apiMessages.length} session=${requestHeaders["x-opencode-session"]} request=${requestHeaders["x-opencode-request"]} modelConfiguration=${JSON.stringify(pickThinkingModelConfiguration(requestOverride))} thinking=${JSON.stringify(settings.thinking)} thinkingPayload=${JSON.stringify(thinkingPayload)}`);
     if (settings.debugReasoning) {
       this.log("Reasoning debug is enabled. Provider reasoning_content will be written to this output channel when available.");
     }
 
     try {
-      if (model.endpointKind === "messages") {
-        await streamAnthropicMessages(this.definition.messagesUrl, this.definition.displayName, apiKey, rawModelId, apiMessages, options, settings, limits, requestHeaders, progress, token, this.getOutputChannel());
+      if (routing.endpointKind === "messages") {
+        await streamAnthropicMessages(routing.endpointUrl, this.definition.displayName, apiKey, rawModelId, apiMessages, options, settings, limits, requestHeaders, progress, token, this.getOutputChannel());
+        return;
+      }
+
+      if (routing.endpointKind === "responses") {
+        await streamResponsesApi(routing.endpointUrl, this.definition.displayName, apiKey, rawModelId, apiMessages, options, settings, limits, requestHeaders, progress, token, this.getOutputChannel(), (toolCallIds, reasoningContent) => {
+          for (const toolCallId of toolCallIds) {
+            this.reasoningContentByToolCallId.set(toolCallId, reasoningContent);
+          }
+        });
+        this.log(`Request completed: model=${model.id}`);
+        return;
+      }
+
+      if (routing.endpointKind === "google") {
+        await streamGoogleGenerateContent(routing.endpointUrl, this.definition.displayName, apiKey, rawModelId, apiMessages, options, settings, limits, requestHeaders, progress, token, this.getOutputChannel(), (toolCallIds, reasoningContent) => {
+          for (const toolCallId of toolCallIds) {
+            this.reasoningContentByToolCallId.set(toolCallId, reasoningContent);
+          }
+        });
         return;
       }
 
       if (isQwenModel(rawModelId)) {
         await streamChatCompletionsWithAnthropicStream(
-          this.definition.chatCompletionsUrl,
+          routing.endpointUrl,
           this.definition.displayName,
           apiKey,
           rawModelId,
@@ -795,7 +828,7 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
       }
 
       await streamChatCompletions(
-        this.definition.chatCompletionsUrl,
+        routing.endpointUrl,
         this.definition.displayName,
         apiKey,
         rawModelId,
@@ -1146,6 +1179,657 @@ async function streamAnthropicMessages(
   );
 }
 
+async function streamResponsesApi(
+  url: string,
+  providerDisplayName: string,
+  apiKey: string,
+  modelId: string,
+  messages: ApiMessage[],
+  options: vscode.ProvideLanguageModelChatResponseOptions,
+  settings: ApiSettings,
+  limits: ModelLimits,
+  requestHeaders: Record<string, string>,
+  progress: vscode.Progress<vscode.LanguageModelResponsePart>,
+  token: vscode.CancellationToken,
+  output: vscode.OutputChannel,
+  onReasoningContent?: (toolCallIds: string[], reasoningContent: string) => void,
+): Promise<void> {
+  const extractor = new OpenAiResponseExtractor(onReasoningContent, (reasoningContent) => {
+    if (settings.debugReasoning) {
+      output.appendLine("[reasoning_content]");
+      output.appendLine(reasoningContent);
+      output.appendLine("[/reasoning_content]");
+    }
+  });
+
+  await streamOpenCodeResponse(
+    url,
+    providerDisplayName,
+    apiKey,
+    buildResponsesRequestBody(modelId, messages, options, settings, limits),
+    requestHeaders,
+    progress,
+    token,
+    (data) => extractor.extractStreamParts(normalizeResponsesStreamEvent(data)),
+    (data) => extractChatCompletionParts(normalizeResponsesFullResponse(data)),
+    output,
+    settings.debugReasoning,
+    settings.requestTimeoutMs,
+    settings.streamIdleTimeoutMs,
+  );
+
+  extractor.flushReasoningFallback(progress);
+  output.appendLine(`[stream-summary model=${modelId}] textChars=${extractor.emittedText} toolCalls=${extractor.emittedTools} reasoningChars=${extractor.reasoningChars}`);
+}
+
+async function streamGoogleGenerateContent(
+  url: string,
+  providerDisplayName: string,
+  apiKey: string,
+  modelId: string,
+  messages: ApiMessage[],
+  options: vscode.ProvideLanguageModelChatResponseOptions,
+  settings: ApiSettings,
+  limits: ModelLimits,
+  requestHeaders: Record<string, string>,
+  progress: vscode.Progress<vscode.LanguageModelResponsePart>,
+  token: vscode.CancellationToken,
+  output: vscode.OutputChannel,
+  onReasoningContent?: (toolCallIds: string[], reasoningContent: string) => void,
+): Promise<void> {
+  const extractor = new OpenAiResponseExtractor(onReasoningContent, (reasoningContent) => {
+    if (settings.debugReasoning) {
+      output.appendLine("[reasoning_content]");
+      output.appendLine(reasoningContent);
+      output.appendLine("[/reasoning_content]");
+    }
+  });
+
+  await streamOpenCodeResponse(
+    `${url}:streamGenerateContent?alt=sse`,
+    providerDisplayName,
+    apiKey,
+    buildGoogleGenerateContentBody(messages, options, settings, limits),
+    requestHeaders,
+    progress,
+    token,
+    (data) => extractor.extractStreamParts(normalizeGoogleStreamEvent(data)),
+    (data) => extractChatCompletionParts(normalizeGoogleFullResponse(data)),
+    output,
+    settings.debugReasoning,
+    settings.requestTimeoutMs,
+    settings.streamIdleTimeoutMs,
+    { "x-goog-api-key": apiKey },
+  );
+
+  extractor.flushReasoningFallback(progress);
+  output.appendLine(`[stream-summary model=${modelId}] textChars=${extractor.emittedText} toolCalls=${extractor.emittedTools} reasoningChars=${extractor.reasoningChars}`);
+}
+
+function mapResponsesTools(tools: readonly vscode.LanguageModelChatTool[] | undefined): Array<Record<string, unknown>> {
+  return (tools ?? []).map((tool) => ({
+    type: "function",
+    name: tool.name,
+    description: tool.description,
+    parameters: sanitizeToolSchema(tool.inputSchema),
+  }));
+}
+
+function buildResponsesRequestBody(
+  modelId: string,
+  messages: ApiMessage[],
+  options: vscode.ProvideLanguageModelChatResponseOptions,
+  settings: ApiSettings,
+  limits: ModelLimits,
+): Record<string, unknown> {
+  const input = messages.flatMap((message) => responsesInputItemsFromMessage(message));
+  const tools = mapResponsesTools(options.tools);
+
+  return {
+    model: modelId,
+    input,
+    max_output_tokens: limits.maxOutputTokens,
+    temperature: settings.temperature,
+    stream: true,
+    ...(tools.length ? { tools, tool_choice: toolChoice(options.toolMode) } : {}),
+    text: { verbosity: modelId === "gpt-5-codex" ? "medium" : "low" },
+  };
+}
+
+function responsesInputItemsFromMessage(message: ApiMessage): Array<Record<string, unknown>> {
+  if (message.role === "user") {
+    const content = responsesUserContent(message.content);
+    return content.length ? [{ role: "user", content }] : [];
+  }
+
+  if (message.role === "assistant") {
+    const items: Array<Record<string, unknown>> = [];
+    const text = responsesAssistantText(message.content);
+    if (text) {
+      items.push({ role: "assistant", content: [{ type: "output_text", text }] });
+    }
+
+    for (const toolCall of message.tool_calls ?? []) {
+      items.push({
+        type: "function_call",
+        id: toolCall.id,
+        call_id: toolCall.id,
+        name: toolCall.function.name,
+        arguments: toolCall.function.arguments,
+      });
+    }
+
+    return items;
+  }
+
+  if (message.role === "tool" && message.tool_call_id) {
+    return [{
+      type: "function_call_output",
+      call_id: message.tool_call_id,
+      output: typeof message.content === "string" ? message.content : JSON.stringify(message.content ?? ""),
+    }];
+  }
+
+  return [];
+}
+
+function responsesUserContent(content: ApiMessage["content"]): Array<Record<string, unknown>> {
+  if (typeof content === "string") {
+    return content ? [{ type: "input_text", text: content }] : [];
+  }
+
+  if (!Array.isArray(content)) {
+    return [];
+  }
+
+  return content.flatMap((part): Array<Record<string, unknown>> => {
+    if (part.type === "text" && typeof part.text === "string") {
+      return [{ type: "input_text", text: part.text }];
+    }
+
+    if (part.type === "image_url" && part.image_url?.url) {
+      return [{ type: "input_image", image_url: { url: part.image_url.url } }];
+    }
+
+    return [];
+  });
+}
+
+function responsesAssistantText(content: ApiMessage["content"]): string {
+  if (typeof content === "string") {
+    return content;
+  }
+
+  if (!Array.isArray(content)) {
+    return "";
+  }
+
+  return content
+    .filter((part): part is OpenAiContentPart & { text: string } => part.type === "text" && typeof part.text === "string")
+    .map((part) => part.text)
+    .join("");
+}
+
+function normalizeResponsesStreamEvent(data: unknown): unknown {
+  if (!isRecord(data)) {
+    return data;
+  }
+
+  const eventType = typeof data.type === "string" ? data.type : undefined;
+  if (!eventType) {
+    return data;
+  }
+
+  if (eventType === "response.output_text.delta") {
+    const delta = firstString(data.delta, data.text, data.output_text_delta);
+    return delta ? { choices: [{ index: 0, delta: { content: delta }, finish_reason: null }] } : { choices: [] };
+  }
+
+  if (eventType === "response.output_item.added") {
+    const item = data.item;
+    if (isRecord(item) && item.type === "function_call" && typeof item.name === "string") {
+      return {
+        choices: [{
+          index: 0,
+          delta: {
+            tool_calls: [{
+              index: typeof data.output_index === "number" ? data.output_index : 0,
+              id: firstString(item.call_id, item.id) ?? "",
+              type: "function",
+              function: { name: item.name, arguments: "" },
+            }],
+          },
+          finish_reason: null,
+        }],
+      };
+    }
+  }
+
+  if (eventType === "response.function_call_arguments.delta") {
+    const delta = firstString(data.delta, data.arguments_delta);
+    return delta ? {
+      choices: [{
+        index: 0,
+        delta: {
+          tool_calls: [{
+            index: typeof data.output_index === "number" ? data.output_index : 0,
+            function: { arguments: delta },
+          }],
+        },
+        finish_reason: null,
+      }],
+    } : { choices: [] };
+  }
+
+  if (eventType.includes("reasoning")) {
+    const reasoning = extractResponsesReasoningText(data);
+    return reasoning ? { choices: [{ index: 0, delta: { reasoning_content: reasoning }, finish_reason: null }] } : { choices: [] };
+  }
+
+  if (eventType === "response.completed") {
+    const response = isRecord(data.response) ? data.response : data;
+    const usage = normalizeResponsesUsage(response.usage);
+    return {
+      choices: [{
+        index: 0,
+        delta: {},
+        finish_reason: normalizeResponsesFinishReason(firstString(response.stop_reason, data.stop_reason)),
+      }],
+      ...(usage ? { usage } : {}),
+    };
+  }
+
+  return { choices: [] };
+}
+
+function normalizeResponsesFullResponse(data: unknown): unknown {
+  if (!isRecord(data) || Array.isArray(data.choices)) {
+    return data;
+  }
+
+  const response = isRecord(data.response) ? data.response : data;
+  const output = Array.isArray(response.output) ? response.output : [];
+  let text = "";
+  const toolCalls: Array<Record<string, unknown>> = [];
+
+  for (const item of output) {
+    if (!isRecord(item)) {
+      continue;
+    }
+
+    if (item.type === "message" && Array.isArray(item.content)) {
+      for (const part of item.content) {
+        if (isRecord(part) && part.type === "output_text" && typeof part.text === "string") {
+          text += part.text;
+        }
+      }
+      continue;
+    }
+
+    if (item.type === "function_call" && typeof item.name === "string") {
+      toolCalls.push({
+        id: firstString(item.call_id, item.id) ?? "",
+        type: "function",
+        function: {
+          name: item.name,
+          arguments: typeof item.arguments === "string" ? item.arguments : JSON.stringify(item.arguments ?? {}),
+        },
+      });
+    }
+  }
+
+  return {
+    choices: [{
+      index: 0,
+      message: {
+        ...(text ? { content: text } : {}),
+        ...(toolCalls.length ? { tool_calls: toolCalls } : {}),
+      },
+      finish_reason: normalizeResponsesFinishReason(firstString(response.stop_reason, response.finish_reason)),
+    }],
+    ...(normalizeResponsesUsage(response.usage) ? { usage: normalizeResponsesUsage(response.usage) } : {}),
+  };
+}
+
+function normalizeResponsesFinishReason(value: string | undefined): "stop" | "tool_calls" | "length" | "content_filter" | null {
+  if (!value) {
+    return null;
+  }
+
+  if (value === "completed" || value === "stop") {
+    return "stop";
+  }
+  if (value === "tool_call" || value === "tool_calls") {
+    return "tool_calls";
+  }
+  if (value === "max_output_tokens" || value === "length") {
+    return "length";
+  }
+  if (value.includes("filter") || value.includes("safety")) {
+    return "content_filter";
+  }
+
+  return null;
+}
+
+function normalizeResponsesUsage(usage: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(usage)) {
+    return undefined;
+  }
+
+  const promptTokens = typeof usage.input_tokens === "number" ? usage.input_tokens : undefined;
+  const completionTokens = typeof usage.output_tokens === "number" ? usage.output_tokens : undefined;
+  const cachedTokens = isRecord(usage.input_tokens_details) && typeof usage.input_tokens_details.cached_tokens === "number"
+    ? usage.input_tokens_details.cached_tokens
+    : undefined;
+
+  if (promptTokens === undefined && completionTokens === undefined) {
+    return undefined;
+  }
+
+  return {
+    prompt_tokens: promptTokens,
+    completion_tokens: completionTokens,
+    total_tokens: promptTokens !== undefined && completionTokens !== undefined ? promptTokens + completionTokens : undefined,
+    ...(cachedTokens !== undefined ? { prompt_tokens_details: { cached_tokens: cachedTokens } } : {}),
+  };
+}
+
+function extractResponsesReasoningText(data: Record<string, unknown>): string {
+  const direct = firstString(data.delta, data.text, data.summary_text, data.output_text_delta);
+  if (direct) {
+    return direct;
+  }
+
+  const item = data.item;
+  if (!isRecord(item)) {
+    return "";
+  }
+
+  if (typeof item.text === "string") {
+    return item.text;
+  }
+
+  if (Array.isArray(item.summary)) {
+    return item.summary
+      .filter((part): part is Record<string, unknown> => isRecord(part) && typeof part.text === "string")
+      .map((part) => part.text as string)
+      .join("");
+  }
+
+  return "";
+}
+
+function buildGoogleGenerateContentBody(
+  messages: ApiMessage[],
+  options: vscode.ProvideLanguageModelChatResponseOptions,
+  settings: ApiSettings,
+  limits: ModelLimits,
+): Record<string, unknown> {
+  const tools = mapGoogleTools(options.tools);
+
+  return {
+    contents: googleContentsFromMessages(messages),
+    generationConfig: {
+      maxOutputTokens: limits.maxOutputTokens,
+      temperature: settings.temperature,
+    },
+    ...(tools.length ? { tools: [{ functionDeclarations: tools }], toolConfig: googleToolConfig(options.toolMode) } : {}),
+  };
+}
+
+function mapGoogleTools(tools: readonly vscode.LanguageModelChatTool[] | undefined): Array<Record<string, unknown>> {
+  return (tools ?? []).map((tool) => ({
+    name: tool.name,
+    description: tool.description,
+    parameters: sanitizeToolSchema(tool.inputSchema),
+  }));
+}
+
+function googleToolConfig(mode: vscode.LanguageModelChatToolMode): Record<string, unknown> {
+  return {
+    functionCallingConfig: {
+      mode: mode === vscode.LanguageModelChatToolMode.Required ? "ANY" : "AUTO",
+    },
+  };
+}
+
+function googleContentsFromMessages(messages: ApiMessage[]): Array<Record<string, unknown>> {
+  const toolNamesById = new Map<string, string>();
+  const contents: Array<Record<string, unknown>> = [];
+
+  for (const message of messages) {
+    if (message.role === "user") {
+      const parts = googleUserParts(message.content);
+      if (parts.length) {
+        contents.push({ role: "user", parts });
+      }
+      continue;
+    }
+
+    if (message.role === "assistant") {
+      const parts: Array<Record<string, unknown>> = [];
+      if (typeof message.reasoning_content === "string" && message.reasoning_content.trim()) {
+        parts.push({ text: message.reasoning_content, thought: true });
+      }
+      const text = responsesAssistantText(message.content);
+      if (text) {
+        parts.push({ text });
+      }
+      for (const toolCall of message.tool_calls ?? []) {
+        const args = parseToolInput(toolCall.function.arguments);
+        parts.push({ functionCall: { name: toolCall.function.name, args } });
+        toolNamesById.set(toolCall.id, toolCall.function.name);
+      }
+      if (parts.length) {
+        contents.push({ role: "model", parts });
+      }
+      continue;
+    }
+
+    if (message.role === "tool" && message.tool_call_id) {
+      const name = toolNamesById.get(message.tool_call_id) ?? "tool";
+      const content = typeof message.content === "string" ? message.content : JSON.stringify(message.content ?? "");
+      contents.push({
+        role: "user",
+        parts: [{
+          functionResponse: {
+            name,
+            response: { name, content },
+          },
+        }],
+      });
+    }
+  }
+
+  return contents;
+}
+
+function googleUserParts(content: ApiMessage["content"]): Array<Record<string, unknown>> {
+  if (typeof content === "string") {
+    return content ? [{ text: content }] : [];
+  }
+
+  if (!Array.isArray(content)) {
+    return [];
+  }
+
+  return content.flatMap((part): Array<Record<string, unknown>> => {
+    if (part.type === "text" && typeof part.text === "string") {
+      return [{ text: part.text }];
+    }
+
+    if (part.type === "image_url" && part.image_url?.url) {
+      const inlineData = dataUrlToInlineData(part.image_url.url);
+      return inlineData ? [{ inlineData }] : [];
+    }
+
+    return [];
+  });
+}
+
+function dataUrlToInlineData(url: string): { mimeType: string; data: string } | undefined {
+  const match = /^data:(.+?);base64,(.+)$/i.exec(url);
+  if (!match) {
+    return undefined;
+  }
+  return {
+    mimeType: match[1],
+    data: match[2],
+  };
+}
+
+function normalizeGoogleStreamEvent(data: unknown): unknown {
+  if (!isRecord(data)) {
+    return data;
+  }
+
+  const candidate = Array.isArray(data.candidates) && isRecord(data.candidates[0]) ? data.candidates[0] : undefined;
+  const parts = isRecord(candidate?.content) && Array.isArray(candidate.content.parts)
+    ? candidate.content.parts.filter(isRecord)
+    : [];
+  const text = parts
+    .filter((part) => typeof part.text === "string" && part.thought !== true)
+    .map((part) => part.text as string)
+    .join("");
+  const reasoning = parts
+    .filter((part) => typeof part.text === "string" && part.thought === true)
+    .map((part) => part.text as string)
+    .join("");
+  const toolCalls = parts.flatMap((part, index) => {
+    if (!isRecord(part.functionCall) || typeof part.functionCall.name !== "string") {
+      return [];
+    }
+
+    return [{
+      index,
+      id: "",
+      type: "function",
+      function: {
+        name: part.functionCall.name,
+        arguments: JSON.stringify(part.functionCall.args ?? {}),
+      },
+    }];
+  });
+  const usage = normalizeGoogleUsage(data.usageMetadata);
+
+  if (!text && !reasoning && !toolCalls.length && !candidate?.finishReason && !usage) {
+    return { choices: [] };
+  }
+
+  return {
+    choices: [{
+      index: 0,
+      delta: {
+        ...(text ? { content: text } : {}),
+        ...(reasoning ? { reasoning_content: reasoning } : {}),
+        ...(toolCalls.length ? { tool_calls: toolCalls } : {}),
+      },
+      finish_reason: normalizeGoogleFinishReason(
+        typeof candidate?.finishReason === "string" ? candidate.finishReason : undefined,
+        toolCalls.length > 0,
+      ),
+    }],
+    ...(usage ? { usage } : {}),
+  };
+}
+
+function normalizeGoogleFullResponse(data: unknown): unknown {
+  if (!isRecord(data) || Array.isArray(data.choices)) {
+    return data;
+  }
+
+  const candidate = Array.isArray(data.candidates) && isRecord(data.candidates[0]) ? data.candidates[0] : undefined;
+  const parts = isRecord(candidate?.content) && Array.isArray(candidate.content.parts)
+    ? candidate.content.parts.filter(isRecord)
+    : [];
+  const text = parts
+    .filter((part) => typeof part.text === "string" && part.thought !== true)
+    .map((part) => part.text as string)
+    .join("");
+  const reasoning = parts
+    .filter((part) => typeof part.text === "string" && part.thought === true)
+    .map((part) => part.text as string)
+    .join("");
+  const toolCalls = parts.flatMap((part) => {
+    if (!isRecord(part.functionCall) || typeof part.functionCall.name !== "string") {
+      return [];
+    }
+
+    return [{
+      id: "",
+      type: "function",
+      function: {
+        name: part.functionCall.name,
+        arguments: JSON.stringify(part.functionCall.args ?? {}),
+      },
+    }];
+  });
+  const usage = normalizeGoogleUsage(data.usageMetadata);
+
+  return {
+    choices: [{
+      index: 0,
+      message: {
+        ...(text ? { content: text } : {}),
+        ...(reasoning ? { reasoning_content: reasoning } : {}),
+        ...(toolCalls.length ? { tool_calls: toolCalls } : {}),
+      },
+      finish_reason: normalizeGoogleFinishReason(
+        typeof candidate?.finishReason === "string" ? candidate.finishReason : undefined,
+        toolCalls.length > 0,
+      ),
+    }],
+    ...(usage ? { usage } : {}),
+  };
+}
+
+function normalizeGoogleUsage(usage: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(usage)) {
+    return undefined;
+  }
+
+  const promptTokens = typeof usage.promptTokenCount === "number" ? usage.promptTokenCount : undefined;
+  const candidatesTokens = typeof usage.candidatesTokenCount === "number" ? usage.candidatesTokenCount : undefined;
+  const thoughtsTokens = typeof usage.thoughtsTokenCount === "number" ? usage.thoughtsTokenCount : undefined;
+  const cachedTokens = typeof usage.cachedContentTokenCount === "number" ? usage.cachedContentTokenCount : undefined;
+  const completionTokens = candidatesTokens !== undefined ? candidatesTokens + (thoughtsTokens ?? 0) : undefined;
+
+  if (promptTokens === undefined && completionTokens === undefined) {
+    return undefined;
+  }
+
+  return {
+    prompt_tokens: promptTokens,
+    completion_tokens: completionTokens,
+    total_tokens: typeof usage.totalTokenCount === "number"
+      ? usage.totalTokenCount
+      : promptTokens !== undefined && completionTokens !== undefined
+        ? promptTokens + completionTokens
+        : undefined,
+    ...(cachedTokens !== undefined ? { prompt_tokens_details: { cached_tokens: cachedTokens } } : {}),
+  };
+}
+
+function normalizeGoogleFinishReason(
+  finishReason: string | undefined,
+  hasToolCalls: boolean,
+): "stop" | "tool_calls" | "length" | "content_filter" | null {
+  if (!finishReason) {
+    return null;
+  }
+  if (finishReason === "STOP") {
+    return hasToolCalls ? "tool_calls" : "stop";
+  }
+  if (finishReason === "MAX_TOKENS") {
+    return "length";
+  }
+  if (["IMAGE_SAFETY", "RECITATION", "SAFETY", "BLOCKLIST", "PROHIBITED_CONTENT", "SPII"].includes(finishReason)) {
+    return "content_filter";
+  }
+  return null;
+}
+
 // The official OpenCode client sends these headers on every request. The Zen
 // gateway reads x-opencode-session first, then converts that sticky identifier
 // into provider-specific affinity headers such as x-session-affinity upstream.
@@ -1363,6 +2047,7 @@ async function streamOpenCodeResponse(
   verbose: boolean = false,
   requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
   streamIdleTimeoutMs = DEFAULT_STREAM_IDLE_TIMEOUT_MS,
+  authHeaders: Record<string, string> = { Authorization: `Bearer ${apiKey}` },
 ): Promise<void> {
   const controller = new AbortController();
   let abortReason:
@@ -1396,7 +2081,7 @@ async function streamOpenCodeResponse(
     const response = await fetch(url, {
       method: "POST",
       headers: {
-        "Authorization": `Bearer ${apiKey}`,
+        ...authHeaders,
         "Content-Type": "application/json",
         ...requestHeaders,
       },
@@ -2598,12 +3283,36 @@ function modelCapabilities(metadata: ResolvedModelMetadata): CopilotCompatibleCa
   };
 }
 
-function modelEndpointKind(modelId: string, provider: ProviderDefinition): OpenCodeModel["endpointKind"] {
-  if (provider.vendor === GO_VENDOR && modelId.startsWith("minimax-m2.")) {
-    return "messages";
+function resolveModelRouting(modelId: string, provider: ProviderDefinition): ModelRoutingFields {
+  if (provider.vendor === ZEN_VENDOR && /^gpt-/i.test(modelId)) {
+    return {
+      endpointKind: "responses",
+      endpointUrl: provider.responsesUrl ?? provider.chatCompletionsUrl,
+      sdkPackage: "@ai-sdk/openai",
+    };
   }
 
-  return "chat-completions";
+  if (/^claude-/i.test(modelId) || (provider.vendor === GO_VENDOR && /^minimax-m2\./i.test(modelId))) {
+    return {
+      endpointKind: "messages",
+      endpointUrl: provider.messagesUrl,
+      sdkPackage: "@ai-sdk/anthropic",
+    };
+  }
+
+  if (provider.vendor === ZEN_VENDOR && /^gemini-/i.test(modelId)) {
+    return {
+      endpointKind: "google",
+      endpointUrl: `${provider.modelsUrl}/${modelId}`,
+      sdkPackage: "@ai-sdk/google",
+    };
+  }
+
+  return {
+    endpointKind: "chat-completions",
+    endpointUrl: provider.chatCompletionsUrl,
+    sdkPackage: "@ai-sdk/openai-compatible",
+  };
 }
 
 function toEffectiveModelId(modelId: string, vendor: ProviderDefinition["vendor"]): string {

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -1,0 +1,345 @@
+import { GO_VENDOR, ZEN_VENDOR, type ProviderVendor } from "./providerTypes";
+
+export interface BaseModelLimits {
+  contextWindow: number;
+  maxOutputTokens: number;
+}
+
+export interface ModelMetadataFields {
+  contextWindow?: number;
+  maxOutputTokens?: number;
+  supportsVision?: boolean;
+  reasoning?: boolean;
+  status?: string;
+}
+
+export interface CachedModelMetadataSnapshot {
+  fetchedAt: number;
+  providers: Record<ProviderVendor, Record<string, ModelMetadataFields>>;
+}
+
+export interface ResolvedModelMetadata extends BaseModelLimits {
+  supportsVision: boolean;
+  reasoning: boolean;
+  status?: string;
+  source: "models.dev" | "live" | "fallback" | "default";
+}
+
+export interface ModelListEntry {
+  id?: string;
+  status?: string;
+  deprecated?: boolean;
+  limit?: {
+    context?: number;
+    output?: number;
+  };
+  context_window?: number;
+  contextWindow?: number;
+  max_output_tokens?: number;
+  maxOutputTokens?: number;
+  attachment?: boolean;
+  image_input?: boolean;
+  imageInput?: boolean;
+  reasoning?: boolean;
+  modalities?: {
+    input?: string[];
+    output?: string[];
+  };
+}
+
+export interface ModelsDevModelRecord {
+  status?: string;
+  limit?: {
+    context?: number;
+    output?: number;
+  };
+  attachment?: boolean;
+  reasoning?: boolean;
+  modalities?: {
+    input?: string[];
+    output?: string[];
+  };
+}
+
+interface ModelsDevProviderRecord {
+  models?: Record<string, ModelsDevModelRecord>;
+}
+
+export interface ModelsDevResponse {
+  opencode?: ModelsDevProviderRecord;
+  "opencode-go"?: ModelsDevProviderRecord;
+}
+
+export const MODELS_DEV_API_URL = "https://models.dev/api.json";
+export const MODEL_METADATA_REVISION = "session-2026-05-21-b";
+export const MODEL_METADATA_CACHE_KEY = "opencodego.modelMetadataCache.v3";
+export const MODEL_METADATA_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+
+const DEFAULT_MODEL_LIMITS: BaseModelLimits = {
+  contextWindow: 262144,
+  maxOutputTokens: 65536,
+};
+
+const MODELS_DEV_PROVIDER_BY_VENDOR: Record<ProviderVendor, keyof ModelsDevResponse> = {
+  [GO_VENDOR]: "opencode-go",
+  [ZEN_VENDOR]: "opencode",
+};
+
+const MODEL_LIMITS_BY_PROVIDER: Record<ProviderVendor, Record<string, BaseModelLimits>> = {
+  [GO_VENDOR]: {
+    "deepseek-v4-flash": { contextWindow: 1000000, maxOutputTokens: 384000 },
+    "deepseek-v4-pro": { contextWindow: 1000000, maxOutputTokens: 384000 },
+    "mimo-v2.5": { contextWindow: 1000000, maxOutputTokens: 128000 },
+    "mimo-v2.5-pro": { contextWindow: 1048576, maxOutputTokens: 128000 },
+    "mimo-v2-omni": { contextWindow: 262144, maxOutputTokens: 128000 },
+    "mimo-v2-pro": { contextWindow: 1048576, maxOutputTokens: 128000 },
+    "kimi-k2.6": { contextWindow: 262144, maxOutputTokens: 65536 },
+    "kimi-k2.5": { contextWindow: 262144, maxOutputTokens: 65536 },
+    "glm-5.1": { contextWindow: 202752, maxOutputTokens: 32768 },
+    "glm-5": { contextWindow: 202752, maxOutputTokens: 32768 },
+    "minimax-m2.7": { contextWindow: 204800, maxOutputTokens: 131072 },
+    "minimax-m2.5": { contextWindow: 204800, maxOutputTokens: 65536 },
+    "qwen3.6-plus": { contextWindow: 262144, maxOutputTokens: 65536 },
+    "qwen3.5-plus": { contextWindow: 262144, maxOutputTokens: 65536 },
+    "hy3-preview": { contextWindow: 256000, maxOutputTokens: 64000 },
+    "ring-2.6-1t": { contextWindow: 262000, maxOutputTokens: 66000 },
+  },
+  [ZEN_VENDOR]: {
+    "deepseek-v4-flash-free": { contextWindow: 200000, maxOutputTokens: 128000 },
+    "minimax-m2.5-free": { contextWindow: 204800, maxOutputTokens: 131072 },
+    "qwen3.6-plus": { contextWindow: 262144, maxOutputTokens: 65536 },
+    "qwen3.6-plus-free": { contextWindow: 262144, maxOutputTokens: 65536 },
+    "qwen3.5-plus": { contextWindow: 262144, maxOutputTokens: 65536 },
+    "trinity-large-preview-free": { contextWindow: 131072, maxOutputTokens: 131072 },
+    "nemotron-3-super-free": { contextWindow: 204800, maxOutputTokens: 128000 },
+    "big-pickle": { contextWindow: 200000, maxOutputTokens: 128000 },
+  },
+};
+
+const VISION_CAPABLE_MODELS = new Set([
+  "minimax-m2.7",
+  "minimax-m2.5",
+  "minimax-m2.5-free",
+  "kimi-k2.6",
+  "kimi-k2.5",
+  "glm-5.1",
+  "glm-5",
+  "mimo-v2.5",
+  "mimo-v2.5-pro",
+  "mimo-v2-omni",
+  "mimo-v2-pro",
+  "qwen3.6-plus",
+  "qwen3.6-plus-free",
+  "qwen3.5-plus",
+]);
+
+export function isFreshModelMetadata(
+  snapshot: CachedModelMetadataSnapshot,
+): boolean {
+  return Date.now() - snapshot.fetchedAt < MODEL_METADATA_CACHE_TTL_MS;
+}
+
+export function toEffectiveModelId(
+  modelId: string,
+  vendor: ProviderVendor,
+): string {
+  return `${vendor}:${modelId}::${MODEL_METADATA_REVISION}`;
+}
+
+export function bundledModelMetadataSnapshot(): CachedModelMetadataSnapshot {
+  return {
+    fetchedAt: 0,
+    providers: {
+      [GO_VENDOR]: bundledModelMetadataForProvider(GO_VENDOR),
+      [ZEN_VENDOR]: bundledModelMetadataForProvider(ZEN_VENDOR),
+    },
+  };
+}
+
+export function fallbackModelMetadata(
+  modelId: string,
+  vendor: ProviderVendor,
+): ModelMetadataFields | undefined {
+  const limits = MODEL_LIMITS_BY_PROVIDER[vendor][modelId];
+  const supportsVision = VISION_CAPABLE_MODELS.has(modelId);
+  const status =
+    vendor === ZEN_VENDOR && modelId === "minimax-m2.5-free"
+      ? "deprecated"
+      : undefined;
+
+  if (!limits && !supportsVision && !status && !supportsReasoning(modelId)) {
+    return undefined;
+  }
+
+  return {
+    contextWindow: limits?.contextWindow,
+    maxOutputTokens: limits?.maxOutputTokens,
+    supportsVision: supportsVision || undefined,
+    reasoning: supportsReasoning(modelId) || undefined,
+    status,
+  };
+}
+
+export function normalizeModelsDevSnapshot(
+  data: ModelsDevResponse,
+): CachedModelMetadataSnapshot {
+  return {
+    fetchedAt: Date.now(),
+    providers: {
+      [GO_VENDOR]: normalizeModelsDevProvider(
+        data[MODELS_DEV_PROVIDER_BY_VENDOR[GO_VENDOR]]?.models ?? {},
+      ),
+      [ZEN_VENDOR]: normalizeModelsDevProvider(
+        data[MODELS_DEV_PROVIDER_BY_VENDOR[ZEN_VENDOR]]?.models ?? {},
+      ),
+    },
+  };
+}
+
+export function normalizeLiveModelMetadata(
+  model: ModelListEntry,
+): ModelMetadataFields | undefined {
+  return normalizeModelMetadataFields({
+    contextWindow: positiveNumber(
+      model.contextWindow ?? model.context_window ?? model.limit?.context,
+    ),
+    maxOutputTokens: positiveNumber(
+      model.maxOutputTokens ?? model.max_output_tokens ?? model.limit?.output,
+    ),
+    supportsVision: detectVisionSupport(
+      model.modalities,
+      model.imageInput ?? model.image_input ?? model.attachment,
+    ),
+    reasoning:
+      typeof model.reasoning === "boolean" ? model.reasoning : undefined,
+    status: model.deprecated
+      ? "deprecated"
+      : typeof model.status === "string"
+        ? model.status
+        : undefined,
+  });
+}
+
+export function resolveModelMetadata(
+  modelId: string,
+  vendor: ProviderVendor,
+  snapshot: CachedModelMetadataSnapshot,
+  liveModelMetadataById: Map<string, ModelMetadataFields>,
+): ResolvedModelMetadata {
+  const cachedMetadata = snapshot.providers[vendor][modelId];
+  const liveMetadata = liveModelMetadataById.get(modelId);
+  const fallbackMetadata = fallbackModelMetadata(modelId, vendor);
+
+  return {
+    contextWindow:
+      liveMetadata?.contextWindow ??
+      cachedMetadata?.contextWindow ??
+      fallbackMetadata?.contextWindow ??
+      DEFAULT_MODEL_LIMITS.contextWindow,
+    maxOutputTokens:
+      liveMetadata?.maxOutputTokens ??
+      cachedMetadata?.maxOutputTokens ??
+      fallbackMetadata?.maxOutputTokens ??
+      DEFAULT_MODEL_LIMITS.maxOutputTokens,
+    supportsVision:
+      liveMetadata?.supportsVision ??
+      cachedMetadata?.supportsVision ??
+      fallbackMetadata?.supportsVision ??
+      false,
+    reasoning:
+      liveMetadata?.reasoning ??
+      cachedMetadata?.reasoning ??
+      fallbackMetadata?.reasoning ??
+      supportsReasoning(modelId),
+    status:
+      liveMetadata?.status ??
+      cachedMetadata?.status ??
+      fallbackMetadata?.status,
+    source: liveMetadata
+      ? "live"
+      : cachedMetadata
+        ? "models.dev"
+        : fallbackMetadata
+          ? "fallback"
+          : "default",
+  };
+}
+
+export function hasExplicitModelLimits(
+  modelId: string,
+  vendor: ProviderVendor,
+): boolean {
+  return Boolean(fallbackModelMetadata(modelId, vendor));
+}
+
+function bundledModelMetadataForProvider(
+  vendor: ProviderVendor,
+): Record<string, ModelMetadataFields> {
+  return Object.fromEntries(
+    Object.keys(MODEL_LIMITS_BY_PROVIDER[vendor]).flatMap((modelId) => {
+      const metadata = fallbackModelMetadata(modelId, vendor);
+      return metadata ? [[modelId, metadata] as const] : [];
+    }),
+  );
+}
+
+function normalizeModelsDevProvider(
+  models: Record<string, ModelsDevModelRecord>,
+): Record<string, ModelMetadataFields> {
+  const normalized: Record<string, ModelMetadataFields> = {};
+
+  for (const [modelId, model] of Object.entries(models)) {
+    const metadata = normalizeModelMetadataFields({
+      contextWindow: positiveNumber(model.limit?.context),
+      maxOutputTokens: positiveNumber(model.limit?.output),
+      supportsVision: detectVisionSupport(model.modalities, model.attachment),
+      reasoning:
+        typeof model.reasoning === "boolean" ? model.reasoning : undefined,
+      status: typeof model.status === "string" ? model.status : undefined,
+    });
+
+    if (metadata) {
+      normalized[modelId] = metadata;
+    }
+  }
+
+  return normalized;
+}
+
+function normalizeModelMetadataFields(
+  metadata: ModelMetadataFields,
+): ModelMetadataFields | undefined {
+  if (
+    metadata.contextWindow === undefined &&
+    metadata.maxOutputTokens === undefined &&
+    metadata.supportsVision === undefined &&
+    metadata.reasoning === undefined &&
+    metadata.status === undefined
+  ) {
+    return undefined;
+  }
+  return metadata;
+}
+
+function detectVisionSupport(
+  modalities: { input?: string[]; output?: string[] } | undefined,
+  attachmentHint: boolean | undefined,
+): boolean | undefined {
+  const inputModalities = Array.isArray(modalities?.input)
+    ? modalities.input
+    : undefined;
+  if (inputModalities?.length) {
+    return inputModalities.some((modality) => modality !== "text");
+  }
+  return typeof attachmentHint === "boolean" ? attachmentHint : undefined;
+}
+
+function positiveNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : undefined;
+}
+
+function supportsReasoning(modelId: string): boolean {
+  return /^(deepseek-|glm-|kimi-|qwen3(?:\.|-))/i.test(modelId);
+}

--- a/src/providerTypes.ts
+++ b/src/providerTypes.ts
@@ -1,0 +1,12 @@
+export const GO_VENDOR = "opencodego" as const;
+export const ZEN_VENDOR = "opencodezen" as const;
+
+export type ProviderVendor = typeof GO_VENDOR | typeof ZEN_VENDOR;
+
+export interface ProviderRoutingDefinition {
+  vendor: ProviderVendor;
+  chatCompletionsUrl: string;
+  messagesUrl: string;
+  modelsUrl: string;
+  responsesUrl?: string;
+}

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -1,0 +1,533 @@
+import {
+  GO_VENDOR,
+  ZEN_VENDOR,
+  type ProviderRoutingDefinition,
+} from "./providerTypes";
+
+export function resolveModelRouting(
+  modelId: string,
+  provider: ProviderRoutingDefinition,
+): {
+  endpointKind: "chat-completions" | "messages" | "responses" | "google";
+  endpointUrl: string;
+  sdkPackage?: string;
+} {
+  if (provider.vendor === ZEN_VENDOR && /^gpt-/i.test(modelId)) {
+    return {
+      endpointKind: "responses",
+      endpointUrl: provider.responsesUrl ?? provider.chatCompletionsUrl,
+      sdkPackage: "@ai-sdk/openai",
+    };
+  }
+
+  if (
+    /^claude-/i.test(modelId) ||
+    (provider.vendor === GO_VENDOR && /^minimax-m2\./i.test(modelId))
+  ) {
+    return {
+      endpointKind: "messages",
+      endpointUrl: provider.messagesUrl,
+      sdkPackage: "@ai-sdk/anthropic",
+    };
+  }
+
+  if (provider.vendor === ZEN_VENDOR && /^gemini-/i.test(modelId)) {
+    return {
+      endpointKind: "google",
+      endpointUrl: `${provider.modelsUrl}/${modelId}`,
+      sdkPackage: "@ai-sdk/google",
+    };
+  }
+
+  return {
+    endpointKind: "chat-completions",
+    endpointUrl: provider.chatCompletionsUrl,
+    sdkPackage: "@ai-sdk/openai-compatible",
+  };
+}
+
+export function normalizeResponsesStreamEvent(data: unknown): unknown {
+  if (!isRecord(data)) {
+    return data;
+  }
+
+  const eventType = typeof data.type === "string" ? data.type : undefined;
+  if (!eventType) {
+    return data;
+  }
+
+  if (eventType === "response.output_text.delta") {
+    const delta = firstString(data.delta, data.text, data.output_text_delta);
+    return delta
+      ? {
+          choices: [
+            {
+              index: 0,
+              delta: { content: delta },
+              finish_reason: null,
+            },
+          ],
+        }
+      : { choices: [] };
+  }
+
+  if (eventType === "response.output_item.added") {
+    const item = data.item;
+    if (
+      isRecord(item) &&
+      item.type === "function_call" &&
+      typeof item.name === "string"
+    ) {
+      return {
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                {
+                  index:
+                    typeof data.output_index === "number"
+                      ? data.output_index
+                      : 0,
+                  id: firstString(item.call_id, item.id) ?? "",
+                  type: "function",
+                  function: { name: item.name, arguments: "" },
+                },
+              ],
+            },
+            finish_reason: null,
+          },
+        ],
+      };
+    }
+  }
+
+  if (eventType === "response.function_call_arguments.delta") {
+    const delta = firstString(data.delta, data.arguments_delta);
+    return delta
+      ? {
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  {
+                    index:
+                      typeof data.output_index === "number"
+                        ? data.output_index
+                        : 0,
+                    function: { arguments: delta },
+                  },
+                ],
+              },
+              finish_reason: null,
+            },
+          ],
+        }
+      : { choices: [] };
+  }
+
+  if (eventType.includes("reasoning")) {
+    const reasoning = extractResponsesReasoningText(data);
+    return reasoning
+      ? {
+          choices: [
+            {
+              index: 0,
+              delta: { reasoning_content: reasoning },
+              finish_reason: null,
+            },
+          ],
+        }
+      : { choices: [] };
+  }
+
+  if (eventType === "response.completed") {
+    const response = isRecord(data.response) ? data.response : data;
+    const usage = normalizeResponsesUsage(response.usage);
+    return {
+      choices: [
+        {
+          index: 0,
+          delta: {},
+          finish_reason: normalizeResponsesFinishReason(
+            firstString(response.stop_reason, data.stop_reason),
+          ),
+        },
+      ],
+      ...(usage ? { usage } : {}),
+    };
+  }
+
+  return { choices: [] };
+}
+
+export function normalizeResponsesFullResponse(data: unknown): unknown {
+  if (!isRecord(data) || Array.isArray(data.choices)) {
+    return data;
+  }
+
+  const response = isRecord(data.response) ? data.response : data;
+  const output = Array.isArray(response.output) ? response.output : [];
+  let text = "";
+  const toolCalls: Array<Record<string, unknown>> = [];
+
+  for (const item of output) {
+    if (!isRecord(item)) {
+      continue;
+    }
+
+    if (item.type === "message" && Array.isArray(item.content)) {
+      for (const part of item.content) {
+        if (
+          isRecord(part) &&
+          part.type === "output_text" &&
+          typeof part.text === "string"
+        ) {
+          text += part.text;
+        }
+      }
+      continue;
+    }
+
+    if (item.type === "function_call" && typeof item.name === "string") {
+      toolCalls.push({
+        id: firstString(item.call_id, item.id) ?? "",
+        type: "function",
+        function: {
+          name: item.name,
+          arguments:
+            typeof item.arguments === "string"
+              ? item.arguments
+              : JSON.stringify(item.arguments ?? {}),
+        },
+      });
+    }
+  }
+
+  const usage = normalizeResponsesUsage(response.usage);
+  return {
+    choices: [
+      {
+        index: 0,
+        message: {
+          ...(text ? { content: text } : {}),
+          ...(toolCalls.length ? { tool_calls: toolCalls } : {}),
+        },
+        finish_reason: normalizeResponsesFinishReason(
+          firstString(response.stop_reason, response.finish_reason),
+        ),
+      },
+    ],
+    ...(usage ? { usage } : {}),
+  };
+}
+
+export function normalizeGoogleStreamEvent(data: unknown): unknown {
+  if (!isRecord(data)) {
+    return data;
+  }
+
+  const candidate =
+    Array.isArray(data.candidates) && isRecord(data.candidates[0])
+      ? data.candidates[0]
+      : undefined;
+  const parts =
+    isRecord(candidate?.content) && Array.isArray(candidate.content.parts)
+      ? candidate.content.parts.filter(isRecord)
+      : [];
+  const text = parts
+    .filter((part) => typeof part.text === "string" && part.thought !== true)
+    .map((part) => part.text as string)
+    .join("");
+  const reasoning = parts
+    .filter((part) => typeof part.text === "string" && part.thought === true)
+    .map((part) => part.text as string)
+    .join("");
+  const toolCalls = parts.flatMap((part, index) => {
+    if (
+      !isRecord(part.functionCall) ||
+      typeof part.functionCall.name !== "string"
+    ) {
+      return [];
+    }
+
+    return [
+      {
+        index,
+        id: "",
+        type: "function",
+        function: {
+          name: part.functionCall.name,
+          arguments: JSON.stringify(part.functionCall.args ?? {}),
+        },
+      },
+    ];
+  });
+  const usage = normalizeGoogleUsage(data.usageMetadata);
+
+  if (!text && !reasoning && !toolCalls.length && !candidate?.finishReason && !usage) {
+    return { choices: [] };
+  }
+
+  return {
+    choices: [
+      {
+        index: 0,
+        delta: {
+          ...(text ? { content: text } : {}),
+          ...(reasoning ? { reasoning_content: reasoning } : {}),
+          ...(toolCalls.length ? { tool_calls: toolCalls } : {}),
+        },
+        finish_reason: normalizeGoogleFinishReason(
+          typeof candidate?.finishReason === "string"
+            ? candidate.finishReason
+            : undefined,
+          toolCalls.length > 0,
+        ),
+      },
+    ],
+    ...(usage ? { usage } : {}),
+  };
+}
+
+export function normalizeGoogleFullResponse(data: unknown): unknown {
+  if (!isRecord(data) || Array.isArray(data.choices)) {
+    return data;
+  }
+
+  const candidate =
+    Array.isArray(data.candidates) && isRecord(data.candidates[0])
+      ? data.candidates[0]
+      : undefined;
+  const parts =
+    isRecord(candidate?.content) && Array.isArray(candidate.content.parts)
+      ? candidate.content.parts.filter(isRecord)
+      : [];
+  const text = parts
+    .filter((part) => typeof part.text === "string" && part.thought !== true)
+    .map((part) => part.text as string)
+    .join("");
+  const reasoning = parts
+    .filter((part) => typeof part.text === "string" && part.thought === true)
+    .map((part) => part.text as string)
+    .join("");
+  const toolCalls = parts.flatMap((part) => {
+    if (
+      !isRecord(part.functionCall) ||
+      typeof part.functionCall.name !== "string"
+    ) {
+      return [];
+    }
+
+    return [
+      {
+        id: "",
+        type: "function",
+        function: {
+          name: part.functionCall.name,
+          arguments: JSON.stringify(part.functionCall.args ?? {}),
+        },
+      },
+    ];
+  });
+  const usage = normalizeGoogleUsage(data.usageMetadata);
+
+  return {
+    choices: [
+      {
+        index: 0,
+        message: {
+          ...(text ? { content: text } : {}),
+          ...(reasoning ? { reasoning_content: reasoning } : {}),
+          ...(toolCalls.length ? { tool_calls: toolCalls } : {}),
+        },
+        finish_reason: normalizeGoogleFinishReason(
+          typeof candidate?.finishReason === "string"
+            ? candidate.finishReason
+            : undefined,
+          toolCalls.length > 0,
+        ),
+      },
+    ],
+    ...(usage ? { usage } : {}),
+  };
+}
+
+function normalizeResponsesFinishReason(
+  value: string | undefined,
+): "stop" | "tool_calls" | "length" | "content_filter" | null {
+  if (!value) {
+    return null;
+  }
+
+  if (value === "completed" || value === "stop") {
+    return "stop";
+  }
+  if (value === "tool_call" || value === "tool_calls") {
+    return "tool_calls";
+  }
+  if (value === "max_output_tokens" || value === "length") {
+    return "length";
+  }
+  if (value.includes("filter") || value.includes("safety")) {
+    return "content_filter";
+  }
+
+  return null;
+}
+
+function normalizeResponsesUsage(
+  usage: unknown,
+): Record<string, unknown> | undefined {
+  if (!isRecord(usage)) {
+    return undefined;
+  }
+
+  const promptTokens =
+    typeof usage.input_tokens === "number" ? usage.input_tokens : undefined;
+  const completionTokens =
+    typeof usage.output_tokens === "number" ? usage.output_tokens : undefined;
+  const cachedTokens =
+    isRecord(usage.input_tokens_details) &&
+    typeof usage.input_tokens_details.cached_tokens === "number"
+      ? usage.input_tokens_details.cached_tokens
+      : undefined;
+
+  if (promptTokens === undefined && completionTokens === undefined) {
+    return undefined;
+  }
+
+  return {
+    prompt_tokens: promptTokens,
+    completion_tokens: completionTokens,
+    total_tokens:
+      promptTokens !== undefined && completionTokens !== undefined
+        ? promptTokens + completionTokens
+        : undefined,
+    ...(cachedTokens !== undefined
+      ? { prompt_tokens_details: { cached_tokens: cachedTokens } }
+      : {}),
+  };
+}
+
+function extractResponsesReasoningText(data: Record<string, unknown>): string {
+  const direct = firstString(
+    data.delta,
+    data.text,
+    data.summary_text,
+    data.output_text_delta,
+  );
+  if (direct) {
+    return direct;
+  }
+
+  const item = data.item;
+  if (!isRecord(item)) {
+    return "";
+  }
+
+  if (typeof item.text === "string") {
+    return item.text;
+  }
+
+  if (Array.isArray(item.summary)) {
+    return item.summary
+      .filter(
+        (part): part is Record<string, unknown> =>
+          isRecord(part) && typeof part.text === "string",
+      )
+      .map((part) => part.text as string)
+      .join("");
+  }
+
+  return "";
+}
+
+function normalizeGoogleUsage(
+  usage: unknown,
+): Record<string, unknown> | undefined {
+  if (!isRecord(usage)) {
+    return undefined;
+  }
+
+  const promptTokens =
+    typeof usage.promptTokenCount === "number"
+      ? usage.promptTokenCount
+      : undefined;
+  const candidatesTokens =
+    typeof usage.candidatesTokenCount === "number"
+      ? usage.candidatesTokenCount
+      : undefined;
+  const thoughtsTokens =
+    typeof usage.thoughtsTokenCount === "number"
+      ? usage.thoughtsTokenCount
+      : undefined;
+  const cachedTokens =
+    typeof usage.cachedContentTokenCount === "number"
+      ? usage.cachedContentTokenCount
+      : undefined;
+  const completionTokens =
+    candidatesTokens !== undefined
+      ? candidatesTokens + (thoughtsTokens ?? 0)
+      : undefined;
+
+  if (promptTokens === undefined && completionTokens === undefined) {
+    return undefined;
+  }
+
+  return {
+    prompt_tokens: promptTokens,
+    completion_tokens: completionTokens,
+    total_tokens:
+      typeof usage.totalTokenCount === "number"
+        ? usage.totalTokenCount
+        : promptTokens !== undefined && completionTokens !== undefined
+          ? promptTokens + completionTokens
+          : undefined,
+    ...(cachedTokens !== undefined
+      ? { prompt_tokens_details: { cached_tokens: cachedTokens } }
+      : {}),
+  };
+}
+
+function normalizeGoogleFinishReason(
+  finishReason: string | undefined,
+  hasToolCalls: boolean,
+): "stop" | "tool_calls" | "length" | "content_filter" | null {
+  if (!finishReason) {
+    return null;
+  }
+  if (finishReason === "STOP") {
+    return hasToolCalls ? "tool_calls" : "stop";
+  }
+  if (finishReason === "MAX_TOKENS") {
+    return "length";
+  }
+  if (
+    [
+      "IMAGE_SAFETY",
+      "RECITATION",
+      "SAFETY",
+      "BLOCKLIST",
+      "PROHIBITED_CONTENT",
+      "SPII",
+    ].includes(finishReason)
+  ) {
+    return "content_filter";
+  }
+  return null;
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/test/routing.test.js
+++ b/test/routing.test.js
@@ -1,0 +1,263 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  normalizeGoogleFullResponse,
+  normalizeGoogleStreamEvent,
+  normalizeResponsesStreamEvent,
+  resolveModelRouting,
+} = require("../out/routing.js");
+const { GO_VENDOR, ZEN_VENDOR } = require("../out/providerTypes.js");
+
+const GO_PROVIDER = {
+  vendor: GO_VENDOR,
+  chatCompletionsUrl: "https://go.example/v1/chat/completions",
+  messagesUrl: "https://go.example/v1/messages",
+  modelsUrl: "https://go.example/v1/models",
+};
+
+const ZEN_PROVIDER = {
+  vendor: ZEN_VENDOR,
+  chatCompletionsUrl: "https://zen.example/v1/chat/completions",
+  messagesUrl: "https://zen.example/v1/messages",
+  responsesUrl: "https://zen.example/v1/responses",
+  modelsUrl: "https://zen.example/v1/models",
+};
+
+test("normalizeResponsesStreamEvent normalizes text deltas", () => {
+  assert.deepStrictEqual(
+    normalizeResponsesStreamEvent({
+      type: "response.output_text.delta",
+      delta: "hello",
+    }),
+    {
+      choices: [
+        {
+          index: 0,
+          delta: { content: "hello" },
+          finish_reason: null,
+        },
+      ],
+    },
+  );
+});
+
+test("normalizeResponsesStreamEvent normalizes function-call and completion events", () => {
+  assert.deepStrictEqual(
+    normalizeResponsesStreamEvent({
+      type: "response.output_item.added",
+      output_index: 2,
+      item: {
+        type: "function_call",
+        name: "search",
+        call_id: "call_123",
+      },
+    }),
+    {
+      choices: [
+        {
+          index: 0,
+          delta: {
+            tool_calls: [
+              {
+                index: 2,
+                id: "call_123",
+                type: "function",
+                function: { name: "search", arguments: "" },
+              },
+            ],
+          },
+          finish_reason: null,
+        },
+      ],
+    },
+  );
+
+  assert.deepStrictEqual(
+    normalizeResponsesStreamEvent({
+      type: "response.function_call_arguments.delta",
+      output_index: 2,
+      delta: '{"q":"abc"}',
+    }),
+    {
+      choices: [
+        {
+          index: 0,
+          delta: {
+            tool_calls: [
+              {
+                index: 2,
+                function: { arguments: '{"q":"abc"}' },
+              },
+            ],
+          },
+          finish_reason: null,
+        },
+      ],
+    },
+  );
+
+  assert.deepStrictEqual(
+    normalizeResponsesStreamEvent({
+      type: "response.completed",
+      response: {
+        stop_reason: "completed",
+        usage: {
+          input_tokens: 11,
+          output_tokens: 7,
+          input_tokens_details: { cached_tokens: 3 },
+        },
+      },
+    }),
+    {
+      choices: [
+        {
+          index: 0,
+          delta: {},
+          finish_reason: "stop",
+        },
+      ],
+      usage: {
+        prompt_tokens: 11,
+        completion_tokens: 7,
+        total_tokens: 18,
+        prompt_tokens_details: { cached_tokens: 3 },
+      },
+    },
+  );
+
+  assert.deepStrictEqual(
+    normalizeResponsesStreamEvent({ type: "response.unknown" }),
+    { choices: [] },
+  );
+});
+
+test("normalizeGoogleStreamEvent keeps text, thought and finish reasons", () => {
+  assert.deepStrictEqual(
+    normalizeGoogleStreamEvent({
+      candidates: [
+        {
+          content: {
+            parts: [
+              { text: "thinking", thought: true },
+              { text: "answer" },
+            ],
+          },
+          finishReason: "STOP",
+        },
+      ],
+      usageMetadata: {
+        promptTokenCount: 9,
+        candidatesTokenCount: 4,
+        thoughtsTokenCount: 2,
+        totalTokenCount: 15,
+      },
+    }),
+    {
+      choices: [
+        {
+          index: 0,
+          delta: {
+            content: "answer",
+            reasoning_content: "thinking",
+          },
+          finish_reason: "stop",
+        },
+      ],
+      usage: {
+        prompt_tokens: 9,
+        completion_tokens: 6,
+        total_tokens: 15,
+      },
+    },
+  );
+
+  assert.deepStrictEqual(
+    normalizeGoogleStreamEvent({
+      candidates: [{ content: { parts: [] }, finishReason: "MAX_TOKENS" }],
+    }),
+    {
+      choices: [
+        {
+          index: 0,
+          delta: {},
+          finish_reason: "length",
+        },
+      ],
+    },
+  );
+});
+
+test("normalizeGoogleFullResponse preserves function calls", () => {
+  assert.deepStrictEqual(
+    normalizeGoogleFullResponse({
+      candidates: [
+        {
+          content: {
+            parts: [
+              {
+                functionCall: {
+                  name: "lookupWeather",
+                  args: { city: "Recife" },
+                },
+              },
+            ],
+          },
+          finishReason: "STOP",
+        },
+      ],
+    }),
+    {
+      choices: [
+        {
+          index: 0,
+          message: {
+            tool_calls: [
+              {
+                id: "",
+                type: "function",
+                function: {
+                  name: "lookupWeather",
+                  arguments: '{"city":"Recife"}',
+                },
+              },
+            ],
+          },
+          finish_reason: "tool_calls",
+        },
+      ],
+    },
+  );
+});
+
+test("resolveModelRouting chooses the expected transport family", () => {
+  assert.deepStrictEqual(resolveModelRouting("gpt-4.1", ZEN_PROVIDER), {
+    endpointKind: "responses",
+    endpointUrl: "https://zen.example/v1/responses",
+    sdkPackage: "@ai-sdk/openai",
+  });
+
+  assert.deepStrictEqual(resolveModelRouting("gemini-2.5-pro", ZEN_PROVIDER), {
+    endpointKind: "google",
+    endpointUrl: "https://zen.example/v1/models/gemini-2.5-pro",
+    sdkPackage: "@ai-sdk/google",
+  });
+
+  assert.deepStrictEqual(resolveModelRouting("claude-sonnet-4", ZEN_PROVIDER), {
+    endpointKind: "messages",
+    endpointUrl: "https://zen.example/v1/messages",
+    sdkPackage: "@ai-sdk/anthropic",
+  });
+
+  assert.deepStrictEqual(resolveModelRouting("minimax-m2.5", GO_PROVIDER), {
+    endpointKind: "messages",
+    endpointUrl: "https://go.example/v1/messages",
+    sdkPackage: "@ai-sdk/anthropic",
+  });
+
+  assert.deepStrictEqual(resolveModelRouting("deepseek-v4-flash", GO_PROVIDER), {
+    endpointKind: "chat-completions",
+    endpointUrl: "https://go.example/v1/chat/completions",
+    sdkPackage: "@ai-sdk/openai-compatible",
+  });
+});


### PR DESCRIPTION
## Summary

This PR improves the OpenCode Copilot Chat extension in three areas:

- hardens OpenCode requests with configurable request/stream timeouts, sticky session headers, and clearer quota/rate-limit errors
- replaces static picker metadata with a TTL-cached `models.dev` snapshot merged with live `/models` metadata and bundled fallback values
- adds internal family-based routing so Zen GPT models use `/responses`, Zen Gemini models use the documented Google-style `generateContent` endpoint, Zen Claude models use `/messages`, and Go MiniMax models use `/messages`

It also updates the extension docs and prepares the `0.1.6` release.

## Why this approach

`models.dev` is a good source for limits, deprecation state, reasoning capability, and vision support, but it does not expose the transport shape a model expects.

Because of that, this PR keeps transport routing inside the extension instead of scraping docs at runtime. The internal route map is smaller, cheaper, and more predictable, while still matching the currently documented OpenCode families.

## What changed

- Added `opencodego.requestTimeoutSeconds` and `opencodego.streamIdleTimeoutSeconds`
- Added sticky OpenCode request headers:
  - `x-opencode-session`
  - `x-opencode-request`
  - `x-opencode-client`
- Improved rate-limit/quota errors surfaced in VS Code
- Added TTL-cached `models.dev` metadata in VS Code global state
- Merged live `/models` metadata, cached `models.dev` metadata, and bundled fallback metadata before registering models
- Updated fallback limits/capability hints used when live metadata is unavailable
- Added native Zen GPT support through `/responses`
- Added native Zen Gemini support through `/models/{model}:streamGenerateContent?alt=sse`
- Updated README and changelog for `0.1.6`

## Testing

- `npm run compile`
- `npx vsce package -o opencode-copilot-chat-0.1.6-local.vsix`
- Installed the local VSIX in VS Code with:
  - `code --install-extension .\opencode-copilot-chat-0.1.6-local.vsix --force`