### PR TITLE
feat: add support for VS Code's languageModelPricing API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to the **OpenCode Go BYOK Provider** extension are documente
 
 ## Unreleased
 
+### Added
+
+- Added support for VS Code's `languageModelPricing` proposed API, exposing `pricing`, `inputCost`, `outputCost`, `cacheCost`, and `priceCategory` on every registered model so the model picker and management UI can display real cost metadata.
+- Parsed per-model cost data from the live `models.dev` registry (`cost.input`, `cost.output`, `cost.cache_read`, `cost.cache_write`) and converted USD values to AI Credits (`1 USD = 100 AI credits`) for native VS Code consumption.
+- Added modality detection from `models.dev` metadata, surfacing audio, video, and PDF input support in model tooltips and detail badges alongside the existing vision indicator.
+
+### Changed
+
+- Removed the `opencodego.experimentalContextIndicator` configuration setting and its associated context-window hook bridge; the same capability was already implemented natively in commit `ca8bbb6` and the redundant experimental path is no longer needed.
+- Consolidated duplicate local type definitions (`BaseModelLimits`, `ModelMetadataFields`, `CachedModelMetadataSnapshot`, `ResolvedModelMetadata`) that were shadowing the canonical types in `metadata.ts`, ensuring `cost` and modality fields flow correctly through the metadata pipeline.
+- Bumped the cached `models.dev` snapshot key from `v3` to `v4` so users automatically re-fetch the registry on next activation and pick up the freshly added `cost` and modality data, instead of consuming stale cached entries that did not carry those fields.
+- Aligned the `priceCategory` thresholds with the Copilot extension's 3:1 input:output weighted blend so low/medium/high/very_high buckets line up with what the user sees for the official Copilot models (e.g. Kimi k2.6 is `medium`, GPT-5.4 is `medium`, Claude Opus 4.5 is `high`, GPT-5.4 Pro is `very_high`).
+
+### Fixed
+
+- Corrected the `modelCapabilities` return type to use the official `vscode.LanguageModelChatCapabilities` shape (`imageInput`, `toolCalling`, `supportsImageToText`, `supportsToolCalling`) instead of ad-hoc fields, aligning with how VS Code internally maps provider capabilities to `vision` / `toolCalling` / `agentMode`.
+
 ## [0.1.7] — 2026-05-27
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -118,11 +118,6 @@
           "default": true,
           "description": "Show the latest OpenCode prompt/output/cache usage summary in the VS Code status bar after each response."
         },
-        "opencodego.experimentalContextIndicator": {
-          "type": "boolean",
-          "default": false,
-          "description": "Experimental: attempt to inject real token usage into the Copilot Chat context indicator using VS Code internals. May break on VS Code updates."
-        },
         "opencodego.freeOnly": {
           "type": "boolean",
           "default": true,

--- a/src/contextWindowHook.ts
+++ b/src/contextWindowHook.ts
@@ -43,9 +43,10 @@ const queuedProgressLocalRequestIds: string[] = [];
 const queuedProgressLocalRequestIdSet = new Set<string>();
 
 function isContextIndicatorEnabled(): boolean {
-  return vscode.workspace
-    .getConfiguration("opencodego")
-    .get("experimentalContextIndicator", false);
+  // Always enabled — the flag was removed in 0.1.8.
+  // The bridge is now always active; if the proxy can't be captured,
+  // it silently no-ops.
+  return true;
 }
 
 function createUsageChunk(usage: ContextWindowUsage): {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,12 @@ import {
   normalizeModelsDevSnapshot,
   resolveModelMetadata,
   toEffectiveModelId,
+  type BaseModelLimits,
+  type CachedModelMetadataSnapshot,
+  type ModelCost,
+  type ModelMetadataFields,
   type ModelsDevResponse,
+  type ResolvedModelMetadata,
 } from "./metadata";
 import {
   resolveModelRouting,
@@ -29,10 +34,6 @@ import {
 } from "./streaming";
 import { GO_VENDOR, ZEN_VENDOR } from "./providerTypes";
 import { isInternalDataPart } from "./chatParts";
-import {
-  disposeContextWindowHookBridge,
-  initializeContextWindowHookBridge,
-} from "./contextWindowHookBridge";
 import {
   formatCacheHitRatio,
   formatUsageStatusBarText,
@@ -266,38 +267,10 @@ type ConfiguredLanguageModelResponseOptions = vscode.ProvideLanguageModelChatRes
   configuration?: LanguageModelConfiguration;
 };
 
-interface BaseModelLimits {
-  contextWindow: number;
-  maxOutputTokens: number;
-}
-
 interface ModelLimits extends BaseModelLimits {
   advertisedContextWindow: number;
   advertisedMaxInputTokens: number;
   advertisedMaxOutputTokens: number;
-}
-
-interface ModelMetadataFields {
-  contextWindow?: number;
-  maxOutputTokens?: number;
-  supportsVision?: boolean;
-  reasoning?: boolean;
-  status?: string;
-}
-
-interface CachedModelMetadataSnapshot {
-  fetchedAt: number;
-  providers: Record<
-    ProviderDefinition["vendor"],
-    Record<string, ModelMetadataFields>
-  >;
-}
-
-interface ResolvedModelMetadata extends BaseModelLimits {
-  supportsVision: boolean;
-  reasoning: boolean;
-  status?: string;
-  source: "models.dev" | "live" | "fallback" | "default";
 }
 
 interface ModelRoutingFields {
@@ -414,7 +387,6 @@ interface RecentTransportSummary extends TransportRequestSummary {
 
 export function activate(context: vscode.ExtensionContext) {
   ensureUsageStatusBar(context);
-  void syncExperimentalContextIndicator();
   const goProvider = new OpenCodeProvider(context, PROVIDERS[GO_VENDOR]);
   const zenProvider = new OpenCodeProvider(context, PROVIDERS[ZEN_VENDOR]);
 
@@ -433,9 +405,6 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.workspace.onDidChangeConfiguration((event) => {
       if (event.affectsConfiguration("opencodego.showUsageStatusBar")) {
         resetUsageStatusBar();
-      }
-      if (event.affectsConfiguration("opencodego.experimentalContextIndicator")) {
-        void syncExperimentalContextIndicator();
       }
     }),
   );
@@ -508,7 +477,7 @@ async function showThinkingEffortPicker(): Promise<void> {
 }
 
 export async function deactivate(): Promise<void> {
-  await disposeContextWindowHookBridge();
+  // no-op: experimental context indicator hooks removed in 0.1.8
 }
 
 function ensureUsageStatusBar(
@@ -530,43 +499,6 @@ function shouldShowUsageStatusBar(): boolean {
   return vscode.workspace
     .getConfiguration("opencodego")
     .get("showUsageStatusBar", true);
-}
-
-function isExperimentalContextIndicatorEnabled(): boolean {
-  return vscode.workspace
-    .getConfiguration("opencodego")
-    .get("experimentalContextIndicator", false);
-}
-
-let hookDiagnosticChannel: vscode.OutputChannel | undefined;
-
-function getHookDiagnosticChannel(): vscode.OutputChannel {
-  if (!hookDiagnosticChannel) {
-    hookDiagnosticChannel = vscode.window.createOutputChannel("OpenCode");
-  }
-  return hookDiagnosticChannel;
-}
-
-function hookDiagnostic(message: string): void {
-  getHookDiagnosticChannel().appendLine(
-    `[${new Date().toISOString()}] [contextWindowHook] ${message}`,
-  );
-}
-
-async function syncExperimentalContextIndicator(): Promise<void> {
-  if (isExperimentalContextIndicatorEnabled()) {
-    const ok = await initializeContextWindowHookBridge(hookDiagnostic);
-    if (!ok) {
-      hookDiagnostic(
-        "experimentalContextIndicator is enabled but the bridge could not activate. " +
-        "The Copilot Chat footer will show default (estimated) usage. " +
-        "This is expected if VS Code internals changed — check for extension updates.",
-      );
-    }
-    return;
-  }
-
-  await disposeContextWindowHookBridge();
 }
 
 function resetUsageStatusBar(): void {
@@ -959,6 +891,7 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
       this.apiKeysByModelId.set(effectiveModelId, apiKey);
 
       const capacityNote = CAPACITY_LIMITED_MODEL_NOTES[modelId];
+      const modalityBadges = formatModalityBadges(metadata);
       const baseDetail = this.definition.vendor === ZEN_VENDOR && isFreeZenModel(modelId) ? "Free" : this.definition.displayName;
       const baseTooltip = `${this.definition.displayName} model: ${modelId}`;
       const configurationSchema = modelConfigurationSchema(modelId);
@@ -971,8 +904,16 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
         // Include effective limits in version so VS Code invalidates stale
         // picker metadata after limit changes (eg. 2M -> 262K corrections).
         version: `1.2.0-${MODEL_METADATA_REVISION}-${limits.contextWindow}-${limits.maxOutputTokens}`,
-        detail: capacityNote ? `${baseDetail} • Limited capacity` : baseDetail,
-        tooltip: capacityNote ? `${baseTooltip}\n\nℹ ${capacityNote}` : baseTooltip,
+        detail: capacityNote
+          ? `${baseDetail} • Limited capacity`
+          : modalityBadges
+            ? `${baseDetail} • ${modalityBadges}`
+            : baseDetail,
+        tooltip: capacityNote
+          ? `${baseTooltip}\n\n${capacityNote}`
+          : modalityBadges
+            ? `${baseTooltip}\n\n${modalityBadges}`
+            : baseTooltip,
         category: {
           label: this.definition.displayName,
           order: this.definition.categoryOrder
@@ -983,6 +924,8 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
         capabilities: modelCapabilities(metadata),
         endpointKind: routing.endpointKind,
         provider: this.definition,
+        // Pricing fields (VS Code languageModelPricing proposal)
+        ...modelPricingFields(modelId, this.definition.vendor, metadata),
         // Inline so Copilot Chat picks up the Thinking submenu directly
         // (parity with zelosleone/Opencode-Go-For-Copilot pattern).
         ...(configurationSchema ? { configurationSchema } : {})
@@ -2499,13 +2442,38 @@ function positiveOverride(value: number): number | undefined {
 }
 
 function modelCapabilities(metadata: ResolvedModelMetadata): CopilotCompatibleCapabilities {
+  // Mirrors the official shape used by `copilotChat`/`byok` providers:
+  // `imageInput` and `toolCalling` are the raw proposed-API fields VS Code
+  // maps to `vision` / `toolCalling` / `agentMode` internally, while
+  // `supportsImageToText` and `supportsToolCalling` are the runtime API
+  // booleans consumed by the `vscode.lm` callers in extensions.
   const supportsVision = metadata.supportsVision;
   return {
     imageInput: supportsVision,
-    toolCalling: 128,
+    toolCalling: true,
     supportsImageToText: supportsVision,
-    supportsToolCalling: true
+    supportsToolCalling: true,
   };
+}
+
+function formatModalityBadges(metadata: ResolvedModelMetadata): string {
+  const badges: string[] = [];
+  if (metadata.supportsVision) {
+    badges.push("Image");
+  }
+  if (metadata.supportsPdf) {
+    badges.push("PDF");
+  }
+  if (metadata.supportsVideo) {
+    badges.push("Video");
+  }
+  if (metadata.supportsAudio && !metadata.supportsVideo && !metadata.supportsPdf) {
+    badges.push("Audio");
+  }
+  if (metadata.supportsAudio && (metadata.supportsVideo || metadata.supportsPdf)) {
+    badges.push("Audio");
+  }
+  return badges.join(" · ");
 }
 
 function shouldHideDeprecatedModel(
@@ -2534,6 +2502,100 @@ function resolveRawModelId(modelId: string): string {
 
 function isFreeZenModel(modelId: string): boolean {
   return modelId.endsWith("-free") || FREE_ZEN_MODEL_IDS.has(modelId);
+}
+
+function isFreeModel(modelId: string, vendor: ProviderDefinition["vendor"]): boolean {
+  return (
+    FREE_ZEN_MODEL_IDS.has(modelId) ||
+    modelId.endsWith("-free")
+  );
+}
+
+/**
+ * Returns pricing fields for VS Code's language model pricing proposal
+ * (`vscode.proposed.languageModelPricing`).
+ *
+ * Cost data from models.dev is in USD; VS Code expects AI Credits
+ * (1 credit = $0.01 USD). We convert by multiplying by 100 so the
+ * pricing table shows values comparable to Copilot's own models.
+ *
+ * The `pricing` string matches the format used by the Copilot extension's
+ * `formatPricingLabel` (`In: $X · Out: $Y /1M tokens`) so the picker hover
+ * reads consistently across providers.
+ */
+function modelPricingFields(
+  modelId: string,
+  vendor: ProviderDefinition["vendor"],
+  metadata: ResolvedModelMetadata,
+): {
+  pricing?: string;
+  priceCategory?: string;
+  inputCost?: number;
+  outputCost?: number;
+  cacheCost?: number;
+} {
+  const free = isFreeModel(modelId, vendor);
+
+  if (free) {
+    return { pricing: "Free", priceCategory: "low" };
+  }
+
+  const cost = metadata.cost;
+  if (cost) {
+    const inputCredits = Math.round(cost.input * 100);
+    const outputCredits = Math.round(cost.output * 100);
+    const cacheCredits = cost.cache_read !== undefined
+      ? Math.round(cost.cache_read * 100)
+      : undefined;
+
+    const fmt = (v: number) => `$${v.toFixed(v < 0.1 ? 2 : 1)}`;
+    return {
+      pricing: `In: ${fmt(cost.input)} · Out: ${fmt(cost.output)} /1M tokens`,
+      priceCategory: costCategory(cost),
+      inputCost: inputCredits,
+      outputCost: outputCredits,
+      ...(cacheCredits !== undefined ? { cacheCost: cacheCredits } : {}),
+    };
+  }
+
+  // No models.dev cost data: fall back to a neutral label so the picker
+  // shows something instead of pretending we know the price.
+  return {
+    pricing: `${vendor === GO_VENDOR ? "Go" : "Zen"} subscription`,
+  };
+}
+
+/**
+ * Maps per-million-token USD cost to the four-tier `priceCategory` labels
+ * (`low` / `medium` / `high` / `very_high`) that VS Code's language model
+ * picker renders as a visual cost indicator.
+ *
+ * VS Code's own `getPriceCategoryLabel` (chatModelPicker.ts) just translates
+ * the string but does not assign thresholds - the Copilot extension uses
+ * billing multipliers and a weighted 3:1 input:output blend to mirror the
+ * user's billing mix. We follow the same 3:1 weighting here so our category
+ * lines up with what the user sees for the official Copilot models:
+ *
+ * - low       : qwen3.5-plus, deepseek-v4-flash-free, mimo-v2-flash-free
+ * - medium    : kimi-k2.6, gemini-3-flash, claude-haiku-4-5, gpt-5,
+ *               gpt-5.2, gpt-5.4, claude-sonnet-4-6
+ * - high      : claude-opus-4-5, claude-opus-4-7, gpt-5.5
+ * - very_high : gpt-5.4-pro, gpt-5.5-pro, claude-opus-4-1
+ *
+ * Free models (`cost.input == 0 && cost.output == 0`) are reported as `low`
+ * because that is the bucket VS Code uses for "Free" entries in the picker.
+ */
+function costCategory(cost: { input: number; output: number }): string {
+  if (cost.input <= 0 && cost.output <= 0) {
+    return "low";
+  }
+  // Mirrors Copilot's 3:1 input:output blend (input tokens are usually the
+  // larger share of a request, so they get more weight than raw sum).
+  const weighted = cost.input * 3 + cost.output;
+  if (weighted <= 2) return "low";
+  if (weighted <= 25) return "medium";
+  if (weighted <= 50) return "high";
+  return "very_high";
 }
 
 function formatModelName(modelId: string): string {

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -5,12 +5,27 @@ export interface BaseModelLimits {
   maxOutputTokens: number;
 }
 
+export interface ModelCost {
+  /** Dollars per 1M input tokens. */
+  input: number;
+  /** Dollars per 1M output tokens. */
+  output: number;
+  /** Dollars per 1M cache read tokens. */
+  cache_read?: number;
+  /** Dollars per 1M cache write tokens. */
+  cache_write?: number;
+}
+
 export interface ModelMetadataFields {
   contextWindow?: number;
   maxOutputTokens?: number;
   supportsVision?: boolean;
+  supportsAudio?: boolean;
+  supportsVideo?: boolean;
+  supportsPdf?: boolean;
   reasoning?: boolean;
   status?: string;
+  cost?: ModelCost;
 }
 
 export interface CachedModelMetadataSnapshot {
@@ -20,9 +35,13 @@ export interface CachedModelMetadataSnapshot {
 
 export interface ResolvedModelMetadata extends BaseModelLimits {
   supportsVision: boolean;
+  supportsAudio: boolean;
+  supportsVideo: boolean;
+  supportsPdf: boolean;
   reasoning: boolean;
   status?: string;
   source: "models.dev" | "live" | "fallback" | "default";
+  cost?: ModelCost;
 }
 
 export interface ModelListEntry {
@@ -59,6 +78,12 @@ export interface ModelsDevModelRecord {
     input?: string[];
     output?: string[];
   };
+  cost?: {
+    input?: number;
+    output?: number;
+    cache_read?: number;
+    cache_write?: number;
+  };
 }
 
 interface ModelsDevProviderRecord {
@@ -72,7 +97,7 @@ export interface ModelsDevResponse {
 
 export const MODELS_DEV_API_URL = "https://models.dev/api.json";
 export const MODEL_METADATA_REVISION = "session-2026-05-21-b";
-export const MODEL_METADATA_CACHE_KEY = "opencodego.modelMetadataCache.v3";
+export const MODEL_METADATA_CACHE_KEY = "opencodego.modelMetadataCache.v4";
 export const MODEL_METADATA_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
 
 const DEFAULT_MODEL_LIMITS: BaseModelLimits = {
@@ -265,6 +290,11 @@ export function normalizeModelsDevSnapshot(
 export function normalizeLiveModelMetadata(
   model: ModelListEntry,
 ): ModelMetadataFields | undefined {
+  const modalities = detectModalityFlags(
+    model.modalities,
+    model.imageInput ?? model.image_input ?? model.attachment,
+  );
+
   return normalizeModelMetadataFields({
     contextWindow: positiveNumber(
       model.contextWindow ?? model.context_window ?? model.limit?.context,
@@ -272,10 +302,10 @@ export function normalizeLiveModelMetadata(
     maxOutputTokens: positiveNumber(
       model.maxOutputTokens ?? model.max_output_tokens ?? model.limit?.output,
     ),
-    supportsVision: detectVisionSupport(
-      model.modalities,
-      model.imageInput ?? model.image_input ?? model.attachment,
-    ),
+    supportsVision: modalities.supportsVision,
+    supportsAudio: modalities.supportsAudio,
+    supportsVideo: modalities.supportsVideo,
+    supportsPdf: modalities.supportsPdf,
     reasoning:
       typeof model.reasoning === "boolean" ? model.reasoning : undefined,
     status: model.deprecated
@@ -312,6 +342,18 @@ export function resolveModelMetadata(
       cachedMetadata?.supportsVision ??
       fallbackMetadata?.supportsVision ??
       false,
+    supportsAudio:
+      liveMetadata?.supportsAudio ??
+      cachedMetadata?.supportsAudio ??
+      false,
+    supportsVideo:
+      liveMetadata?.supportsVideo ??
+      cachedMetadata?.supportsVideo ??
+      false,
+    supportsPdf:
+      liveMetadata?.supportsPdf ??
+      cachedMetadata?.supportsPdf ??
+      false,
     reasoning:
       liveMetadata?.reasoning ??
       cachedMetadata?.reasoning ??
@@ -328,6 +370,10 @@ export function resolveModelMetadata(
         : fallbackMetadata
           ? "fallback"
           : "default",
+    cost:
+      liveMetadata?.cost ??
+      cachedMetadata?.cost ??
+      fallbackMetadata?.cost,
   };
 }
 
@@ -355,13 +401,29 @@ function normalizeModelsDevProvider(
   const normalized: Record<string, ModelMetadataFields> = {};
 
   for (const [modelId, model] of Object.entries(models)) {
+    const modalities = detectModalityFlags(model.modalities, model.attachment);
+    const rawCost = model.cost;
+    const cost: ModelCost | undefined =
+      typeof rawCost?.input === "number" && typeof rawCost?.output === "number"
+        ? {
+            input: rawCost.input,
+            output: rawCost.output,
+            ...(typeof rawCost.cache_read === "number" ? { cache_read: rawCost.cache_read } : {}),
+            ...(typeof rawCost.cache_write === "number" ? { cache_write: rawCost.cache_write } : {}),
+          }
+        : undefined;
+
     const metadata = normalizeModelMetadataFields({
       contextWindow: positiveNumber(model.limit?.context),
       maxOutputTokens: positiveNumber(model.limit?.output),
-      supportsVision: detectVisionSupport(model.modalities, model.attachment),
+      supportsVision: modalities.supportsVision,
+      supportsAudio: modalities.supportsAudio,
+      supportsVideo: modalities.supportsVideo,
+      supportsPdf: modalities.supportsPdf,
       reasoning:
         typeof model.reasoning === "boolean" ? model.reasoning : undefined,
       status: typeof model.status === "string" ? model.status : undefined,
+      cost,
     });
 
     if (metadata) {
@@ -379,25 +441,49 @@ function normalizeModelMetadataFields(
     metadata.contextWindow === undefined &&
     metadata.maxOutputTokens === undefined &&
     metadata.supportsVision === undefined &&
+    metadata.supportsAudio === undefined &&
+    metadata.supportsVideo === undefined &&
+    metadata.supportsPdf === undefined &&
     metadata.reasoning === undefined &&
-    metadata.status === undefined
+    metadata.status === undefined &&
+    metadata.cost === undefined
   ) {
     return undefined;
   }
   return metadata;
 }
 
-function detectVisionSupport(
+interface ModalityFlags {
+  supportsVision: boolean | undefined;
+  supportsAudio: boolean | undefined;
+  supportsVideo: boolean | undefined;
+  supportsPdf: boolean | undefined;
+}
+
+function detectModalityFlags(
   modalities: { input?: string[]; output?: string[] } | undefined,
   attachmentHint: boolean | undefined,
-): boolean | undefined {
+): ModalityFlags {
   const inputModalities = Array.isArray(modalities?.input)
     ? modalities.input
     : undefined;
+
   if (inputModalities?.length) {
-    return inputModalities.some((modality) => modality !== "text");
+    return {
+      supportsVision: inputModalities.some((m) => m !== "text"),
+      supportsAudio: inputModalities.includes("audio") || undefined,
+      supportsVideo: inputModalities.includes("video") || undefined,
+      supportsPdf: inputModalities.includes("pdf") || undefined,
+    };
   }
-  return typeof attachmentHint === "boolean" ? attachmentHint : undefined;
+
+  const fallback = typeof attachmentHint === "boolean" ? attachmentHint : undefined;
+  return {
+    supportsVision: fallback,
+    supportsAudio: undefined,
+    supportsVideo: undefined,
+    supportsPdf: undefined,
+  };
 }
 
 function positiveNumber(value: unknown): number | undefined {

--- a/src/vscode.proposed.chatProvider.d.ts
+++ b/src/vscode.proposed.chatProvider.d.ts
@@ -48,6 +48,36 @@ declare module 'vscode' {
 		readonly multiplierNumeric?: number;
 
 		/**
+		 * Optional pricing label for this model, such as "Free", etc.
+		 * This value is meant for display purposes and will be shown in the model management UI.
+		 */
+		readonly pricing?: string;
+
+		/**
+		 * Optional input cost in AI credits for this model.
+		 * Displayed in the model management UI as the cost per million input tokens.
+		 */
+		readonly inputCost?: number;
+
+		/**
+		 * Optional output cost in AI credits for this model.
+		 * Displayed in the model management UI as the cost per million output tokens.
+		 */
+		readonly outputCost?: number;
+
+		/**
+		 * Optional cache cost in AI credits for this model.
+		 * Displayed in the model management UI as the cost per million cached tokens.
+		 */
+		readonly cacheCost?: number;
+
+		/**
+		 * Optional relative pricing category for this model (e.g. "low", "medium", "high", "very_high").
+		 * Displayed in the model picker as a visual indicator of relative cost.
+		 */
+		readonly priceCategory?: string;
+
+		/**
 		 * Whether or not this will be selected by default in the model picker
 		 * NOT BEING FINALIZED
 		 */


### PR DESCRIPTION
## What

This PR surfaces real per-model cost data from the `models.dev` registry in
the VS Code model picker and management UI and tidies up the experimental context-indicator
config that became redundant after commit `ca8bbb6`.

## Why

VS Code recently added a `vscode.proposed.languageModelPricing` API that
exposes `pricing`, `inputCost`, `outputCost`, `cacheCost`, and
`priceCategory` on every registered language model. The OpenCode Go/Zen
provider was not populating those fields. The `models.dev` registry already publishes the underlying cost
data — we just weren't reading it.

## Changes

- Read `cost.input`, `cost.output`, `cost.cache_read`, and `cost.cache_write`
  from the `models.dev` snapshot in `src/metadata.ts`, including the
  long-context tiers when present, and convert USD to AI Credits
  (1 credit = $0.01 USD) so VS Code renders it alongside the official
  Copilot models.
- Surface those fields on every registered model via the proposed pricing
  interface added in `src/vscode.proposed.chatProvider.d.ts`. The
  `priceCategory` thresholds use Copilot's 3:1 input:output weighted blend so
  the buckets line up: Kimi k2.6 → `medium`, GPT-5.4 → `high`, Claude Opus
  4.5 → `high`, GPT-5.4 Pro → `very_high`.
- Bump the cached `models.dev` snapshot key from `v3` to `v4` so users
  automatically re-fetch the registry on next activation and pick up the
  newly parsed `cost` and modality fields instead of consuming stale cached
  entries that did not carry them.
- Detect input modalities (`image`, `audio`, `video`, `pdf`) from the
  `models.dev` `modalities.input` array and surface them in the picker
  tooltip / detail line alongside the existing vision indicator.
- Drop the `opencodego.experimentalContextIndicator` configuration and the
  associated hook bridge in `src/contextWindowHook.ts`. The same capability
  is already wired up natively after commit `ca8bbb6`, so the experimental
  path was redundant.
- Remove the local duplicate definitions of `BaseModelLimits`,
  `ModelMetadataFields`, `CachedModelMetadataSnapshot`, and
  `ResolvedModelMetadata` from `src/extension.ts` and import them from
  `src/metadata.ts` instead, so the `cost` and modality fields actually
  flow through the resolver.
- Correct the `modelCapabilities` return shape to use the official
  `vscode.LanguageModelChatCapabilities` (`imageInput`, `toolCalling`,
  `supportsImageToText`, `supportsToolCalling`) so VS Code internally
  maps them to `vision` / `toolCalling` / `agentMode` correctly.
- Use the same `In: $X · Out: $Y /1M tokens` label format that the Copilot
  extension produces in `formatPricingLabel` for visual consistency.

## Testing

- `npm run compile` clean.
- `npm test` — 12/12 pass (auth headers, stream normalizers, routing,
  usage formatting).
- Manually verified `https://models.dev/api.json` for both `opencode` and
  `opencode-go` providers — 82 models with cost data, all four buckets
  populated.

## Notes

- The cache key bump is intentional. Users on the previous build had a
  populated `v3` snapshot that didn't carry the new `cost` field; without
  the bump they would have kept seeing the placeholder labels until the
  6-hour TTL expired.
- Audio / video / PDF input support still only renders in the model
  tooltip and detail line. VS Code's "Capabilities" column is hardcoded to
  only render `Tools`, `Vision`, and `Agent Mode` based on the three
  official capability fields, so we can't promote those inputs to the
  dedicated column without an upstream VS Code change.