### PR TITLE
Respect model temperature support from models.dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the **OpenCode Go BYOK Provider** extension are documente
 ### Fixed
 
 - **Kimi thinking format correction.** The `[0.2.4]` changelog entry incorrectly stated that Kimi models use `enable_thinking: true | false`. Tests confirm the OpenCode Go gateway **rejects** `enable_thinking` (HTTP 400: "Extra inputs are not permitted"). The correct format is `thinking: { type: "enabled" | "disabled" }` — matching GLM's format and what the gateway expects for MoonshotAI models on the OpenAI-compatible endpoint. The extension code has been using `thinking: { type }` all along; this entry corrects the record.
+- **Respect model `temperature` support from models.dev.** The extension now reads the `temperature: boolean` field from `models.dev` metadata and omits the `temperature` parameter from request payloads when the model declares it unsupported (`temperature: false`). This fixes HTTP 400 errors ("temperature is deprecated for this model.") on models like `claude-opus-4-8` and the GPT-5 family, which have deprecated the temperature parameter.
 
 ## [0.2.6] — 2026-06-10
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1178,7 +1178,7 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
           providerDisplayName: this.definition.displayName,
           apiKey,
           modelId: rawModelId,
-          body: buildAnthropicMessagesRequestBody(rawModelId, apiMessages, options, settings, limits),
+          body: buildAnthropicMessagesRequestBody(rawModelId, apiMessages, options, settings, metadata, limits),
           requestHeaders,
           progress,
           token,
@@ -1200,7 +1200,7 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
           providerDisplayName: this.definition.displayName,
           apiKey,
           modelId: rawModelId,
-          body: buildResponsesRequestBody(rawModelId, apiMessages, options, settings, limits),
+          body: buildResponsesRequestBody(rawModelId, apiMessages, options, settings, metadata, limits),
           authHeaders: buildOpenCodeGatewayAuthHeaders("responses", apiKey),
           requestHeaders,
           progress,
@@ -1254,7 +1254,7 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
         providerDisplayName: this.definition.displayName,
         apiKey,
         modelId: rawModelId,
-        body: buildChatCompletionsRequestBody(rawModelId, apiMessages, options, settings, limits),
+        body: buildChatCompletionsRequestBody(rawModelId, apiMessages, options, settings, metadata, limits),
         authHeaders: buildOpenCodeGatewayAuthHeaders("chat-completions", apiKey),
         requestHeaders,
         progress,
@@ -1437,6 +1437,7 @@ function buildChatCompletionsRequestBody(
   messages: ApiMessage[],
   options: vscode.ProvideLanguageModelChatResponseOptions,
   settings: ApiSettings,
+  metadata: ResolvedModelMetadata,
   limits: ModelLimits,
 ): Record<string, unknown> {
   const tools = mapOpenAiTools(options.tools);
@@ -1445,7 +1446,8 @@ function buildChatCompletionsRequestBody(
   return {
     model: modelId,
     messages,
-    temperature: settings.temperature,
+    // Only send temperature if the model supports it (not deprecated)
+    ...(metadata.temperature !== false ? { temperature: settings.temperature } : {}),
     max_tokens: limits.maxOutputTokens,
     stream: true,
     stream_options: { include_usage: true },
@@ -1459,6 +1461,7 @@ function buildAnthropicMessagesRequestBody(
   messages: ApiMessage[],
   options: vscode.ProvideLanguageModelChatResponseOptions,
   settings: ApiSettings,
+  metadata: ResolvedModelMetadata,
   limits: ModelLimits,
 ): Record<string, unknown> {
   const tools = mapAnthropicTools(options.tools);
@@ -1474,7 +1477,8 @@ function buildAnthropicMessagesRequestBody(
 
   return {
     model: modelId,
-    temperature: settings.temperature,
+    // Only send temperature if the model supports it (not deprecated)
+    ...(metadata.temperature !== false ? { temperature: settings.temperature } : {}),
     max_tokens: limits.maxOutputTokens,
     stream: true,
     messages: anthropicMessages,
@@ -1642,6 +1646,7 @@ function buildResponsesRequestBody(
   messages: ApiMessage[],
   options: vscode.ProvideLanguageModelChatResponseOptions,
   settings: ApiSettings,
+  metadata: ResolvedModelMetadata,
   limits: ModelLimits,
 ): Record<string, unknown> {
   const input = messages.flatMap((message) => responsesInputItemsFromMessage(message));
@@ -1651,7 +1656,8 @@ function buildResponsesRequestBody(
     model: modelId,
     input,
     max_output_tokens: limits.maxOutputTokens,
-    temperature: settings.temperature,
+    // Only send temperature if the model supports it (not deprecated)
+    ...(metadata.temperature !== false ? { temperature: settings.temperature } : {}),
     stream: true,
     ...(tools.length ? { tools, tool_choice: toolChoice(options.toolMode) } : {}),
     text: { verbosity: modelId === "gpt-5-codex" ? "medium" : "low" },
@@ -2748,8 +2754,7 @@ function buildThinkingPayload(modelId: string, thinking: ThinkingSettings, hasIm
   }
 
   if (/^kimi-/i.test(modelId)) {
-    // Testes confirmam que o gateway aceita thinking: { type } para Kimi
-    // (HTTP 200). enable_thinking causa 400 ("Extra inputs not permitted").
+    // Tests confirm the gateway accepts thinking: { type } for Kimi
     return { thinking: { type: thinking.kimi === "on" ? "enabled" : "disabled" } };
   }
 

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -46,6 +46,8 @@ export interface ModelMetadataFields {
   reasoning?: boolean;
   /** Raw reasoning_options from models.dev, e.g. [{ type: "toggle" }, { type: "effort", values: ["low","medium","high"] }]. */
   reasoningOptions?: Array<{ type?: string; values?: string[] }>;
+  /** Whether the model supports the temperature parameter. False means temperature is deprecated/unsupported. */
+  temperature?: boolean;
   status?: string;
   cost?: ModelCost;
 }
@@ -63,6 +65,8 @@ export interface ResolvedModelMetadata extends BaseModelLimits {
   reasoning: boolean;
   /** Parsed reasoning_options from models.dev, if available. */
   reasoningOptions?: Array<{ type?: string; values?: string[] }>;
+  /** Whether the model supports the temperature parameter. Undefined means unknown (assume supported). */
+  temperature?: boolean;
   status?: string;
   source: "models.dev" | "live" | "fallback" | "default";
   cost?: ModelCost;
@@ -99,6 +103,7 @@ export interface ModelsDevModelRecord {
   attachment?: boolean;
   reasoning?: boolean;
   reasoning_options?: Array<{ type?: string; values?: string[] }>;
+  temperature?: boolean;
   modalities?: {
     input?: string[];
     output?: string[];
@@ -418,6 +423,9 @@ export function resolveModelMetadata(
     reasoningOptions:
       liveMetadata?.reasoningOptions ??
       cachedMetadata?.reasoningOptions,
+    temperature:
+      liveMetadata?.temperature ??
+      cachedMetadata?.temperature,
   };
 }
 
@@ -482,6 +490,8 @@ function normalizeModelsDevProvider(
         Array.isArray(model.reasoning_options) && model.reasoning_options.length > 0
           ? model.reasoning_options
           : undefined,
+      temperature:
+        typeof model.temperature === "boolean" ? model.temperature : undefined,
       status: typeof model.status === "string" ? model.status : undefined,
       cost,
     });
@@ -506,6 +516,7 @@ function normalizeModelMetadataFields(
     metadata.supportsPdf === undefined &&
     metadata.reasoning === undefined &&
     metadata.reasoningOptions === undefined &&
+    metadata.temperature === undefined &&
     metadata.status === undefined &&
     metadata.cost === undefined
   ) {


### PR DESCRIPTION
## Problem

Several models have deprecated the `temperature` parameter, causing HTTP 400 errors when the extension sends it. For example, `claude-opus-4-8` returns:
```
Sorry, your request failed. Please try again.
Reason: OpenCode Zen API request failed (400) model=claude-opus-4-8{"message":"temperature is deprecated for this model."}
```

Related issue: [ltmoerdani/opencode-copilot-chat#20](https://github.com/ltmoerdani/opencode-copilot-chat/issues/20)

## Root cause

The extension was unconditionally sending `temperature` in all request payloads, regardless of whether the model supports it. The `models.dev` registry already declares which models support temperature via the `temperature: boolean` field, but the extension was not reading or respecting this field.

## Solution

### `src/metadata.ts` — Read and propagate temperature support
- Added `temperature?: boolean` field to `ModelMetadataFields`, `ResolvedModelMetadata`, and `ModelsDevModelRecord` interfaces
- Parse the `temperature` field from `models.dev` API responses
- Propagate the field through the metadata resolution pipeline (live → cached → fallback)

### `src/extension.ts` — Conditionally send temperature
- Modified `buildChatCompletionsRequestBody()`, `buildAnthropicMessagesRequestBody()`, and `buildResponsesRequestBody()` to accept `ResolvedModelMetadata` parameter
- Only include `temperature` in the request payload when `metadata.temperature !== false`
- When `temperature` is `false`, the parameter is omitted entirely from the request

## Affected models (OpenCode Zen)

Models with `temperature: false` in models.dev:
- **Claude**: `claude-fable-5`, `claude-opus-4-7`, `claude-opus-4-8`
- **GPT-5 family**: `gpt-5`, `gpt-5-codex`, `gpt-5-nano`, `gpt-5.1`, `gpt-5.1-codex`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`, `gpt-5.2`, `gpt-5.2-codex`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.4-pro`, `gpt-5.5`, `gpt-5.5-pro`

**OpenCode Go**: No models currently have `temperature: false`.

## Testing

- TypeScript compilation: ✅ No errors
- Metadata parsing: ✅ Correctly reads `temperature` field from models.dev
- Request building: ✅ Omits `temperature` when `metadata.temperature === false`
- Backward compatibility: ✅ Models with `temperature: true` or `undefined` continue to send temperature as before

## How to test

1. Open VS Code with the extension loaded
2. Select a model with `temperature: false` (e.g., `claude-opus-4-8`)
3. Send a message — it should no longer return HTTP 400 "temperature is deprecated"
4. Select a model with `temperature: true` (e.g., `claude-sonnet-4-6`)
5. Verify temperature is still sent and works as expected

---

Fixes [ltmoerdani/opencode-copilot-chat#20](https://github.com/ltmoerdani/opencode-copilot-chat/issues/20)
