### PR TITLE
feat: show OpenCode models in Agents window (Copilot CLI) model picker

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1128,13 +1128,15 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
     const settings = getSettings();
     const metadataSnapshot = await this.getMetadataSnapshot();
 
-    return models.map((modelId) => {
+    return models.flatMap((modelId) => {
       const metadata = this.resolveModelMetadata(modelId, metadataSnapshot);
       const routing = resolveModelRouting(modelId, this.definition);
       const effectiveModelId = toEffectiveModelId(modelId, this.definition.vendor);
+      const agentHostModelId = `${effectiveModelId}::agent-host`;
       const limits = modelLimits(metadata, settings);
       this.apiKeysByModelId.set(modelId, apiKey);
       this.apiKeysByModelId.set(effectiveModelId, apiKey);
+      this.apiKeysByModelId.set(agentHostModelId, apiKey);
 
       const capacityNote = CAPACITY_LIMITED_MODEL_NOTES[modelId];
       const modalityBadges = formatModalityBadges(metadata);
@@ -1142,8 +1144,7 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
       const baseTooltip = `${this.definition.displayName} model: ${modelId}`;
       const configurationSchema = modelConfigurationSchema(modelId, metadata);
 
-      const info: OpenCodeModel = {
-        id: effectiveModelId,
+      const sharedFields: Omit<OpenCodeModel, "id" | "targetChatSessionType"> = {
         rawModelId: modelId,
         name: `${this.definition.modelNamePrefix} / ${formatModelName(modelId)}`,
         family: `${this.definition.vendor}-${modelId}-${MODEL_METADATA_REVISION}`,
@@ -1177,9 +1178,23 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
         ...(configurationSchema ? { configurationSchema } : {})
       };
 
-      this.log(`Model registered: id=${info.id} family=${info.family} metadataSource=${metadata.source} endpointKind=${routing.endpointKind} endpointUrl=${routing.endpointUrl} configurationSchema=${configurationSchema ? JSON.stringify(configurationSchema) : "none"}`);
+      // General variant — no targetChatSessionType → visible in Chat view
+      const info: OpenCodeModel = { ...sharedFields, id: effectiveModelId };
 
-      return info;
+      // Agents-window variant — targetChatSessionType must match the `type`
+      // declared in the Copilot extension's chatSessions contribution:
+      //   { "type": "copilotcli", "requiresCustomModels": true, ... }
+      // Each surface only sees its own variant so there is no duplication.
+      const agentHostInfo: OpenCodeModel = {
+        ...sharedFields,
+        id: agentHostModelId,
+        targetChatSessionType: "copilotcli"
+      };
+
+      this.log(`Model registered: id=${info.id} family=${info.family} metadataSource=${metadata.source} endpointKind=${routing.endpointKind} endpointUrl=${routing.endpointUrl} configurationSchema=${configurationSchema ? JSON.stringify(configurationSchema) : "none"}`);
+      this.log(`Model registered (agents-window): id=${agentHostInfo.id} targetChatSessionType=copilotcli`);
+
+      return [info, agentHostInfo];
     });
   }
 


### PR DESCRIPTION
## Summary

Fixes #11 - OpenCode models now appear in the VS Code Agents window model picker when using the Copilot CLI agent session.

## Problem

Models registered via `vscode.lm.registerLanguageModelChatProvider()` were visible in the Chat view's model picker but completely absent from the Agents window (Copilot CLI session). The root cause: VS Code's model picker for the Copilot CLI session only shows models that explicitly declare a matching `targetChatSessionType`, and our models had none.

## Solution

Register each model **twice** from `provideLanguageModelChatInformation()`, using `flatMap` instead of `map`:

| Variant | `id` | `targetChatSessionType` | Visible in |
|---|---|---|---|
| General | `opencodego:deepseek-v4-flash` | _(none)_ | Chat view |
| Agents-window | `opencodego:deepseek-v4-flash::agent-host` | `"copilotcli"` | Agents window ? Copilot CLI session |

### No picker duplication

VS Code's `filterModelsForSession()` logic partitions the two variants - each surface sees only the entries meant for it. This is confirmed by [microsoft/vscode#298862](https://github.com/microsoft/vscode/pull/298862), which makes `getDefaultLanguageModel()` also exclude session-targeted models. Neither picker shows both variants.

### Routing is unchanged

The `::agent-host` suffix in the agent-window model ID is stripped by the existing `resolveRawModelId()` helper (splits on `::`, takes the first segment), so all backend routing, API key lookup, and metadata resolution continue to use the real model ID.

### `targetChatSessionType` value

The correct value is `"copilotcli"` - the `type` field from the Copilot extension's `chatSessions` contribution in its `package.json`:
`json
{ "type": "copilotcli", "requiresCustomModels": true, ... }
`
Earlier research pointed to `"agent-host-copilotcli"` (the VS Code internal resource URI scheme), which is different and does not work.

## Required user setting

The Agents window does not activate third-party extensions by default. Users need to add this to their VS Code `settings.json`:

`json
"extensions.supportAgentsWindow": {
    "ltmoerdani.opencode-copilot-chat": true
}
`

## Testing

1. Add the `extensions.supportAgentsWindow` setting above to VS Code user settings.
2. Reload the Agents window.
3. Start a new session ? select **Copilot CLI** as the agent type.
4. Open the model picker - OpenCode Go and OpenCode Zen models appear alongside Claude / GPT models.
5. Verify the Chat view model picker shows each model exactly once (no `::agent-host` entries visible there).

## Files changed

- `src/extension.ts` - `provideLanguageModelChatInformation()` changed from `map` to `flatMap`, returning `[generalVariant, agentsWindowVariant]` per model.