### PR TITLE
fix: gate agent-host model duplicate behind opt-in setting (fixes #41)

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,6 +140,11 @@
           "default": true,
           "description": "When enabled, only free OpenCode Zen models are shown in the Copilot model selector. Disable to include paid Zen models as well."
         },
+        "opencodego.showInAgentsWindow": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Also expose OpenCode models in the Agents window (Copilot CLI session) model picker by registering each model a second time with `targetChatSessionType: \"copilotcli\"`. **Disabled by default** to keep the model list clean — when disabled each model appears exactly once everywhere. When enabled, an `(Agents)` suffix is added to the duplicate entry so the two are distinguishable in the Language Models management UI. Also requires `extensions.supportAgentsWindow: { \"ltmoerdani.opencode-copilot-chat\": true }` to activate this extension in the Agents window."
+        },
         "opencodego.stripThinkTags": {
           "type": "string",
           "enum": ["never", "auto", "always"],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1128,6 +1128,16 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
     const settings = getSettings();
     const metadataSnapshot = await this.getMetadataSnapshot();
 
+    // The Agents-window variant (targetChatSessionType: "copilotcli") is only
+    // hidden from the Chat view's in-session dropdown by filterModelsForSession().
+    // Surfaces that enumerate the raw registration list — most notably the Language
+    // Models management UI — show ALL registered models with no session filtering,
+    // so the ::agent-host copy appeared there too (issue #41, regression from PR #39).
+    // Gate the duplicate behind an opt-in setting so the default stays clean.
+    const showInAgentsWindow = vscode.workspace
+      .getConfiguration("opencodego")
+      .get("showInAgentsWindow", false);
+
     return models.flatMap((modelId) => {
       const metadata = this.resolveModelMetadata(modelId, metadataSnapshot);
       const routing = resolveModelRouting(modelId, this.definition);
@@ -1181,17 +1191,27 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
       // General variant — no targetChatSessionType → visible in Chat view
       const info: OpenCodeModel = { ...sharedFields, id: effectiveModelId };
 
+      this.log(`Model registered: id=${info.id} family=${info.family} metadataSource=${metadata.source} endpointKind=${routing.endpointKind} endpointUrl=${routing.endpointUrl} configurationSchema=${configurationSchema ? JSON.stringify(configurationSchema) : "none"}`);
+
+      // When showInAgentsWindow is off (default), return only the general
+      // variant so each model appears exactly once in all pickers and the
+      // Language Models management UI (regression fix for issue #41).
+      if (!showInAgentsWindow) {
+        return [info];
+      }
+
       // Agents-window variant — targetChatSessionType must match the `type`
       // declared in the Copilot extension's chatSessions contribution:
       //   { "type": "copilotcli", "requiresCustomModels": true, ... }
-      // Each surface only sees its own variant so there is no duplication.
+      // Name gets an "(Agents)" suffix so the two entries are visually
+      // distinguishable in the Language Models management UI when opt-in is on.
       const agentHostInfo: OpenCodeModel = {
         ...sharedFields,
         id: agentHostModelId,
+        name: `${sharedFields.name} (Agents)`,
         targetChatSessionType: "copilotcli"
       };
 
-      this.log(`Model registered: id=${info.id} family=${info.family} metadataSource=${metadata.source} endpointKind=${routing.endpointKind} endpointUrl=${routing.endpointUrl} configurationSchema=${configurationSchema ? JSON.stringify(configurationSchema) : "none"}`);
       this.log(`Model registered (agents-window): id=${agentHostInfo.id} targetChatSessionType=copilotcli`);
 
       return [info, agentHostInfo];


### PR DESCRIPTION
## Problem

PR #39 introduced a regression: every model was registered twice - a general variant and a `::agent-host` variant with `targetChatSessionType: "copilotcli"`. While `filterModelsForSession()` correctly hides the `::agent-host` copy from the Chat view dropdown and the Agents window, the **Language Models management UI** (the BYOK enable/disable list) enumerates the raw registration list with no session filtering - so both variants appeared there, showing every model twice with a `::agent-host` suffix (reported in #41).

## Fix

Gate the `::agent-host` duplicate behind a new **opt-in** setting `opencodego.showInAgentsWindow` (default `false`).

### Behaviour

| Setting | Chat view | Agents window | Management UI |
|---|---|---|---|
| `false` (default) | ? one entry per model | ? no OpenCode models | ? one entry per model |
| `true` | ? one entry per model | ? OpenCode models visible | Two entries: `Model Name` + `Model Name (Agents)` |

When `showInAgentsWindow: true`, the `::agent-host` variant gets an `(Agents)` name suffix so the two entries are visually distinguishable in the management UI.

### Required additional setting (unchanged from PR #39)

`json
"extensions.supportAgentsWindow": {
    "ltmoerdani.opencode-copilot-chat": true
}
`

## Files changed

- `src/extension.ts` - reads `opencodego.showInAgentsWindow`; returns `[info]` by default, `[info, agentHostInfo]` when opted in; adds `(Agents)` name suffix to the agent-host variant.
- `package.json` - adds `opencodego.showInAgentsWindow` boolean setting (default `false`) with full description.

Fixes #41