### PR TITLE
fix: separate agent-host providers to eliminate model duplication in Manage panel (alternative to #42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Changelog
 
 All notable changes to the **OpenCode Go BYOK Provider** extension are documented here.
+
+## [0.3.2] — 2026-06-15
+
+### Fixed
+
+- **`[Model Picker]` Agent models no longer duplicated in the Manage Language Models panel.** Replaced the double-registration approach (PR #39/#42) with separate vendor IDs (`opencodego-agent`, `opencodezen-agent`). Each vendor now shows only its own models — zero duplication in any picker or management UI. Agent models are hidden from the Manage panel by default (`showAgentModelsInManagePanel: false`) while still working in the Agents window.
+
+### Added
+
+- **`opencodego.agentsWindow`** boolean setting (default `true`). Controls whether agent-host providers are registered at runtime. When enabled, agent models appear in the Agents window picker.
+- **`opencodego.showAgentModelsInManagePanel`** boolean setting (default `false`). Controls whether agent vendors appear in the Manage Language Models panel. Enable to manage agent API keys separately.
+- **`resolveBaseVendor()`** helper in `providerTypes.ts` — maps agent vendor IDs back to their base vendor for routing and metadata resolution.
+- **`providerVariant()`** helper in `extension.ts` — creates DRY agent provider definitions from base definitions.
+- **BYOK key synchronization** — main provider stores API key via `context.secrets.store()` and triggers agent provider re-resolution via `triggerChange()`.
+
+### Changed
+
+- Agent vendors (`opencodego-agent`, `opencodezen-agent`) declared in `package.json` with `when: "config.opencodego.showAgentModelsInManagePanel"` clause.
+- `routing.ts` uses `resolveBaseVendor()` before all vendor comparisons to fix routing for agent variants.
+- `metadata.ts` `toEffectiveModelId()` vendor parameter widened to accept `AllProviderVendor`.
+- Replaces the `opencodego.showInAgentsWindow` setting from PR #42 with the cleaner two-setting approach (`agentsWindow` + `showAgentModelsInManagePanel`).
+
+Fixes [#41](https://github.com/ltmoerdani/opencode-copilot-chat/issues/41). Alternative to PR [#42](https://github.com/ltmoerdani/opencode-copilot-chat/pull/42) by [@Wallacy](https://github.com/Wallacy).
+
 ## [0.3.1] — 2026-06-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -222,28 +222,32 @@ Per-model reasoning configuration, dynamically enhanced with `reasoning_options`
 
 ### 🪟 Agents Window (Copilot CLI) Support
 
-OpenCode models appear in the VS Code **Agents window** model picker when starting a Copilot CLI / Background agent session — not just the regular Chat view. Each model is registered with a `targetChatSessionType` so VS Code's picker filter surfaces them alongside Claude and GPT models when selecting a Copilot CLI agent.
+OpenCode models appear in the VS Code **Agents window** model picker when starting a Copilot CLI / Background agent session — not just the regular Chat view. Agent models are registered under **separate vendor IDs** (`opencodego-agent`, `opencodezen-agent`) with `targetChatSessionType: "copilotcli"` so they show up in the Agents window without duplicating in the Chat view or Manage panel.
+
+**How it works:**
+
+| Setting | Default | What it controls |
+|---------|---------|------------------|
+| `opencodego.agentsWindow` | `true` | Registers agent providers at runtime |
+| `opencodego.showAgentModelsInManagePanel` | `false` | Shows agent vendors in the Manage Language Models panel |
 
 **Setup:**
 
-> **Heads-up:** Agents window support is **opt-in** since v0.3.1 (PR #42). In v0.3.0 every model was registered twice and the duplicate leaked into the Language Models management UI (#41). Two settings are now required to turn it back on.
-
-1. Add this to your VS Code `settings.json` to enable the extension in the Agents window process:
+1. Agent models are enabled by default (`agentsWindow: true`). No changes needed for basic usage.
+2. Add this to your VS Code `settings.json` to enable the extension in the Agents window process:
    ```json
    "extensions.supportAgentsWindow": {
      "ltmoerdani.opencode-copilot-chat": true
    }
    ```
-2. **Also** opt into the duplicate registration with the extension setting (default `false`):
-   ```json
-   "opencodego.showInAgentsWindow": true
-   ```
-   When enabled, the duplicate entry gets an `(Agents)` suffix in the Language Models management UI so the two stay distinguishable.
 3. Reload the window (`Developer: Reload Window`).
 4. Open the **Agents window** → start a new session → select **Copilot CLI** as the agent type.
 5. Open the model picker — OpenCode Go and Zen models appear.
 
-When `opencodego.showInAgentsWindow` is off (default), each model appears exactly once in every picker and the management UI. Routing, API key, and metadata resolution are unchanged regardless of the setting — the `::agent-host` suffix in the agents-window variant is stripped by `resolveRawModelId()`.
+To manage agent API keys separately or see agent vendors in the Manage panel, enable:
+```json
+"opencodego.showAgentModelsInManagePanel": true
+```
 
 ### 🛠️ Smart Routing & Reliability
 
@@ -275,6 +279,8 @@ When `opencodego.showInAgentsWindow` is off (default), each model appears exactl
 | `opencodego.streamIdleTimeoutSeconds` | `120` | Cancel if stream goes idle |
 | `opencodego.showUsageStatusBar` | `true` | Show usage summary in status bar |
 | `opencodego.freeOnly` | `true` | Zen: free models only. `false` = include paid |
+| `opencodego.agentsWindow` | `true` | Register agent models for the Agents window |
+| `opencodego.showAgentModelsInManagePanel` | `false` | Show agent vendors in Manage Language Models |
 | `opencodego.stripThinkTags` | `"auto"` | Strip `<think>` tags (`never`/`auto`/`always`) |
 | `opencodego.thinking.deepseek` | `"off"` | `off`/`low`/`medium`/`high`/`max` |
 | `opencodego.thinking.glm` | `"off"` | `on`/`off` |
@@ -369,13 +375,12 @@ Known issue with `qwen3.6-plus-free` on broad agent tasks (see [issue #1](./docs
 <details>
 <summary><b>How do I use OpenCode models in the Agents window (Copilot CLI)?</b></summary>
 
-Agents window support is **opt-in** since v0.3.1. Two settings are required in your VS Code `settings.json`:
+Agent models are enabled by default (`opencodego.agentsWindow: true`). Just add this to your VS Code `settings.json`:
 
 ```json
 "extensions.supportAgentsWindow": {
   "ltmoerdani.opencode-copilot-chat": true
-},
-"opencodego.showInAgentsWindow": true
+}
 ```
 
 Then reload the window, open the **Agents window**, start a Copilot CLI session, and pick any OpenCode model from the picker. See the [Agents Window section](#-agents-window-copilot-cli-support) above for details.

--- a/docs/features/06-20260614-agents-window-model-visibility.md
+++ b/docs/features/06-20260614-agents-window-model-visibility.md
@@ -3,10 +3,13 @@
 # Agents Window Model Visibility — OpenCode Models in Copilot CLI Picker
 
 **Topic:** models / vscode / agents-window
-**Updated:** 2026-06-14
+**Updated:** 2026-06-15
 **Tags:** #models #vscode #agents-window #targetChatSessionType #marketplace #copilotcli
 **GitHub Issue:** [ltmoerdani/opencode-copilot-chat#11](https://github.com/ltmoerdani/opencode-copilot-chat/issues/11)
-**GitHub PR:** [#39](https://github.com/ltmoerdani/opencode-copilot-chat/pull/39) (by [@Marinski](https://github.com/Marinski))
+**GitHub Issue:** [ltmoerdani/opencode-copilot-chat#41](https://github.com/ltmoerdani/opencode-copilot-chat/issues/41) (duplication regression)
+**GitHub PR:** [#39](https://github.com/ltmoerdani/opencode-copilot-chat/pull/39) (by [@Marinski](https://github.com/Marinski)) — initial implementation
+**GitHub PR:** [#42](https://github.com/ltmoerdani/opencode-copilot-chat/pull/42) (by [@Marinski](https://github.com/Marinski)) — opt-in gate fix
+**GitHub PR:** Alternative by [@Wallacy](https://github.com/Wallacy) — separate vendor approach (this document)
 **Related Research:** [`docs/references/01-20260611-agents-window-model-visibility.md`](../references/01-20260611-agents-window-model-visibility.md)
 
 ---
@@ -15,7 +18,11 @@
 
 OpenCode Go and OpenCode Zen models now appear in the VS Code **Agents window** model picker when starting a Copilot CLI / Background agent session. Previously they were only visible in the regular Chat view.
 
-GitHub Issue #11 requested this feature. The full research investigation (3 options evaluated, VS Code source code analysis) is documented in [`docs/references/01-20260611-agents-window-model-visibility.md`](../references/01-20260611-agents-window-model-visibility.md). This document covers the implementation shipped in PR #39.
+GitHub Issue #11 requested this feature. The full research investigation (3 options evaluated, VS Code source code analysis) is documented in [`docs/references/01-20260611-agents-window-model-visibility.md`](../references/01-20260611-agents-window-model-visibility.md).
+
+This document covers two implementation approaches:
+1. **PR #39** (original) — double registration with `::agent-host` suffix under the same vendor
+2. **Alternative** — separate vendor IDs for agent models (cleaner Manage panel UX)
 
 ---
 
@@ -30,48 +37,62 @@ VS Code has two chat surfaces with **separate** model pickers:
 
 Models registered via `vscode.lm.registerLanguageModelChatProvider()` without `targetChatSessionType` were completely absent from the Agents window. The root cause: VS Code's `filterModelsForSession()` excludes models without a matching `targetChatSessionType` whenever **any** model targets that session type (Copilot's built-in models do).
 
+### The Duplication Bug (Issue #41)
+
+PR #39's approach registered each model **twice** under the same vendor. While `filterModelsForSession()` correctly partitions them in the Chat view and Agents window pickers, the **Language Models management UI** (BYOK enable/disable list) enumerates the raw registration list with no session filter — so both variants appeared there, showing every model twice with a `::agent-host` suffix.
+
 ---
 
-## Solution
+## Approach 1: Double Registration (PR #39 / #42)
 
-Register each model **twice** from `provideLanguageModelChatInformation()` in `src/extension.ts`, using `flatMap` instead of `map`:
+Register each model **twice** from `provideLanguageModelChatInformation()`, using `flatMap`:
 
 | Variant | `id` | `targetChatSessionType` | Visible in |
 |---------|------|--------------------------|------------|
 | General | `opencodego:deepseek-v4-flash` | _(none)_ | Chat view |
 | Agents-window | `opencodego:deepseek-v4-flash::agent-host` | `"copilotcli"` | Agents window > Copilot CLI session |
 
-### Why No Picker Duplication
+**Fix for #41 (PR #42):** Gated the `::agent-host` duplicate behind `opencodego.showInAgentsWindow` (default `false`). When enabled, the duplicate gets an `(Agents)` name suffix.
 
-VS Code's `filterModelsForSession()` partitions the two variants — each surface sees only the entries meant for it:
+**Trade-off:** Users must explicitly enable the setting, and when enabled, the Manage panel still shows both variants.
 
-| Surface | Filter applied | What it sees |
-|----------|----------------|--------------|
-| **Chat view** | Models with NO `targetChatSessionType` | Only the general variant |
-| **Agents window** | Models with `targetChatSessionType === "copilotcli"` | Only the agents-window variant |
+---
 
-This is confirmed by [microsoft/vscode#298862](https://github.com/microsoft/vscode/pull/298862), which makes `getDefaultLanguageModel()` also exclude session-targeted models. Neither picker shows both variants.
+## Approach 2: Separate Vendor IDs (Alternative)
 
-### Why Routing is Unchanged
+Register agent models under **dedicated vendor IDs** (`opencodego-agent`, `opencodezen-agent`) so each vendor group shows only its variant in the Manage panel.
 
-The `::agent-host` suffix in the agents-window model ID is stripped by the existing `resolveRawModelId()` helper:
+| Vendor | Models | Visible in |
+|--------|--------|------------|
+| `opencodego` | General models | Chat view, Manage panel |
+| `opencodego-agent` | Agent-only models (`targetChatSessionType: "copilotcli"`) | Agents window, Manage panel (hidden by default) |
+| `opencodezen` | General models | Chat view, Manage panel |
+| `opencodezen-agent` | Agent-only models (`targetChatSessionType: "copilotcli"`) | Agents window, Manage panel (hidden by default) |
 
-```typescript
-function resolveRawModelId(modelId: string): string {
-  const [base] = modelId.split("::");  // strips "::agent-host"
-  // ... then strips vendor prefix
-}
-```
+### Why This Is Cleaner
 
-All backend routing, API key lookup, and metadata resolution continue to use the real model ID. The API key map is also seeded with the `::agent-host` variant:
+- **No duplication anywhere** — each vendor shows exactly its models
+- **Manage panel is clean** — agent vendors are hidden by default via `when` clause (`opencodego.showAgentModelsInManagePanel`, default `false`)
+- **Agent models still work** — `agentsWindow` (default `true`) registers the providers at runtime
+- **Independent controls** — `agentsWindow` controls registration, `showAgentModelsInManagePanel` controls Manage panel visibility
 
-```typescript
-this.apiKeysByModelId.set(modelId, apiKey);
-this.apiKeysByModelId.set(effectiveModelId, apiKey);
-this.apiKeysByModelId.set(agentHostModelId, apiKey);  // ← added
-```
+### Configuration
 
-### `targetChatSessionType` Value
+| Setting | Default | Purpose |
+|---------|---------|---------|
+| `opencodego.agentsWindow` | `true` | Register agent providers at runtime |
+| `opencodego.showAgentModelsInManagePanel` | `false` | Show agent vendors in Manage panel |
+
+### Key Implementation Details
+
+- `resolveBaseVendor()` in `providerTypes.ts` maps agent vendors back to base for routing/metadata
+- `providerVariant()` helper creates agent definitions from base (DRY)
+- BYOK key sync: main provider stores key via `context.secrets.store()`, then calls `agentProvider.triggerChange()`
+- Agent variant reads key from `context.secrets.get(SECRET_KEY)`
+
+---
+
+## `targetChatSessionType` Value
 
 The correct value is `"copilotcli"` — the `type` field from the Copilot extension's `chatSessions` contribution in its `package.json`:
 
@@ -97,17 +118,17 @@ Without this setting, the extension will not load in the Agents window process a
 
 ---
 
-## Files Changed
+## Files Changed (Approach 2)
 
 | File | Change |
 |------|--------|
-| `src/extension.ts` | `provideLanguageModelChatInformation()` changed from `map` to `flatMap`; returns `[generalVariant, agentsWindowVariant]` per model. Added `agentHostModelId` to `apiKeysByModelId` map. |
+| `package.json` | Added `agentsWindow` and `showAgentModelsInManagePanel` configs; declared agent vendors with `when` clause |
+| `src/extension.ts` | DRY provider definitions via `providerVariant()`; agent registration; BYOK key sync; `baseVendor` getter |
+| `src/providerTypes.ts` | Agent vendor constants, `AllProviderVendor` type, `resolveBaseVendor()` helper |
+| `src/routing.ts` | Uses `resolveBaseVendor()` before vendor comparisons |
+| `src/metadata.ts` | Widened `toEffectiveModelId` vendor parameter |
 
-No `package.json` changes. No `enabledApiProposals` needed — `targetChatSessionType` is **stable API** (not proposed), so this is fully marketplace-compatible.
-
----
-
-## Implementation Detail
+No `enabledApiProposals` needed — `targetChatSessionType` is **stable API**.
 
 ```typescript
 return models.flatMap((modelId) => {

--- a/docs/features/06-20260614-agents-window-model-visibility.md
+++ b/docs/features/06-20260614-agents-window-model-visibility.md
@@ -1,4 +1,4 @@
-**Status:** ✅ Solved · **Post-#42 update:** opt-in gating (see [Post-#42: Opt-in gating](#post-42-opt-in-gating))
+**Status:** ✅ Solved
 
 # Agents Window Model Visibility — OpenCode Models in Copilot CLI Picker
 
@@ -168,53 +168,6 @@ return models.flatMap((modelId) => {
 | 4 | 2026-06-14 | PR #39 opened by @Marinski — implemented Option A with `flatMap` + `targetChatSessionType: "copilotcli"` |
 | 5 | 2026-06-14 | Local verification: compile + VSIX install + Agents window test — all PASS |
 | 6 | 2026-06-14 | PR #39 merged (merge commit) to main |
-| 7 | 2026-06-15 | Issue #41 opened by @hu3bi — models shown twice in Language Models management UI (regression from #39) |
-| 8 | 2026-06-15 | PR #42 opened by @Marinski — gated `::agent-host` duplicate behind `opencodego.showInAgentsWindow` (default `false`) |
-
----
-
-## Post-#42: Opt-in gating (2026-06-15)
-
-PR [#39](https://github.com/ltmoerdani/opencode-copilot-chat/pull/39) assumed `filterModelsForSession()` would hide the `::agent-host` duplicate from every surface. That assumption held for the **Chat view dropdown** and the **Agents window picker**, but **not** for the **Language Models management UI** (the BYOK enable/disable list) — that surface enumerates the raw registration list with no session filter, so both variants appeared there with a `::agent-host` suffix (issue [#41](https://github.com/ltmoerdani/opencode-copilot-chat/issues/41), regression in v0.3.0).
-
-PR [#42](https://github.com/ltmoerdani/opencode-copilot-chat/pull/42) by [@Marinski](https://github.com/Marinski) gates the duplicate behind a new opt-in setting:
-
-| Setting | Default | Effect |
-|---|---|---|
-| `opencodego.showInAgentsWindow` | `false` | When `false`, only the general variant is registered → each model appears exactly once in **every** surface (pre-#39 behaviour restored). When `true`, the `::agent-host` variant is also registered, with an `(Agents)` name suffix so the two entries stay distinguishable in the management UI. |
-
-### Why an opt-in setting over a separate provider?
-
-Issue #41 also discussed an alternative approach ([@Wallacy](https://github.com/Wallacy)'s `fix/separate-agent-providers` branch): publish the agents-window models as a separate provider so users can hide/show them via the vendor toggle. That is conceptually cleaner but more invasive (new provider definition, separate settings display, separate metadata path). The opt-in setting was chosen for the hotfix because it is minimal-risk, restores the pre-#39 default, and keeps the Agents-window feature available for users who want it.
-
-### Updated behaviour matrix
-
-| `opencodego.showInAgentsWindow` | Chat view dropdown | Agents window picker | Language Models management UI |
-|---|---|---|---|
-| `false` (default) | 1 entry per model | ❌ no OpenCode models | 1 entry per model |
-| `true` | 1 entry per model | ✅ OpenCode models visible | 2 entries: `Model` + `Model (Agents)` |
-
-Both states still require `"extensions.supportAgentsWindow": { "ltmoerdani.opencode-copilot-chat": true }` for the extension to load in the Agents window process at all.
-
-### Migration note for v0.3.0 users
-
-Users who relied on OpenCode models in the Agents window in v0.3.0 must now **also** set `"opencodego.showInAgentsWindow": true` after upgrading, or the models will disappear from the Agents window picker. The Chat view and management UI are unaffected (they were the surfaces showing the unwanted duplicate).
-
-### Implementation notes
-
-- The setting is read in `provideLanguageModelChatInformation()` via `vscode.workspace.getConfiguration("opencodego").get("showInAgentsWindow", false)`.
-- When `false`, the `flatMap` returns `[info]` only — no `agentHostInfo` is constructed.
-- When `true`, `agentHostInfo` gets `name: \`${sharedFields.name} (Agents)\`` so the two entries are visually distinguishable. The `id` still carries the `::agent-host` suffix, which `resolveRawModelId()` strips, so routing / API key lookup / metadata resolution are unchanged.
-- `this.apiKeysByModelId.set(agentHostModelId, apiKey)` still runs in both states — safe (no dangling key lookup if the user toggles the setting without a reload).
-- The `Model registered:` log line was moved before the early return so the output channel stays clean when opt-in is off.
-- The Known Minor Issue from PR #39 (cosmetic duplicate in `showDiagnostics()`) is auto-resolved when the setting is off, because only one variant is registered.
-
-### Files changed (PR #42)
-
-| File | Change |
-|------|--------|
-| `src/extension.ts` | Read `opencodego.showInAgentsWindow`; return `[info]` by default, `[info, agentHostInfo]` when opted in; add `(Agents)` name suffix to the agent-host variant; move log line before the early return. |
-| `package.json` | Add `opencodego.showInAgentsWindow` boolean setting (default `false`) with `markdownDescription`. |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -238,12 +238,12 @@
         }
       },
       {
-        "vendor": "opencodego-agent-host",
+        "vendor": "opencodego-agent",
         "displayName": "OpenCode Go (Agents)",
         "when": "config.opencodego.showAgentModelsInManagePanel"
       },
       {
-        "vendor": "opencodezen-agent-host",
+        "vendor": "opencodezen-agent",
         "displayName": "OpenCode Zen (Agents)",
         "when": "config.opencodego.showAgentModelsInManagePanel"
       }

--- a/package.json
+++ b/package.json
@@ -140,10 +140,10 @@
           "default": true,
           "description": "When enabled, only free OpenCode Zen models are shown in the Copilot model selector. Disable to include paid Zen models as well."
         },
-        "opencodego.showInAgentsWindow": {
+        "opencodego.agentsWindow": {
           "type": "boolean",
-          "default": false,
-          "markdownDescription": "Also expose OpenCode models in the Agents window (Copilot CLI session) model picker by registering each model a second time with `targetChatSessionType: \"copilotcli\"`. **Disabled by default** to keep the model list clean — when disabled each model appears exactly once everywhere. When enabled, an `(Agents)` suffix is added to the duplicate entry so the two are distinguishable in the Language Models management UI. Also requires `extensions.supportAgentsWindow: { \"ltmoerdani.opencode-copilot-chat\": true }` to activate this extension in the Agents window."
+          "default": true,
+          "markdownDescription": "Register separate agent-host providers for the Copilot Agents window. Each agent vendor appears as its own group in the Manage Language Models panel, so models are never duplicated. Disable to hide the Agents section entirely. Requires a window reload to take effect."
         },
         "opencodego.stripThinkTags": {
           "type": "string",
@@ -231,6 +231,16 @@
             }
           }
         }
+      },
+      {
+        "vendor": "opencodego-agent-host",
+        "displayName": "OpenCode Go (Agents)",
+        "when": "config.opencodego.agentsWindow"
+      },
+      {
+        "vendor": "opencodezen-agent-host",
+        "displayName": "OpenCode Zen (Agents)",
+        "when": "config.opencodego.agentsWindow"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -143,7 +143,12 @@
         "opencodego.agentsWindow": {
           "type": "boolean",
           "default": true,
-          "markdownDescription": "Register separate agent-host providers for the Copilot Agents window. Each agent vendor appears as its own group in the Manage Language Models panel, so models are never duplicated. Disable to hide the Agents section entirely. Requires a window reload to take effect."
+          "markdownDescription": "Register separate agent-host providers for the Copilot Agents window. Disable to hide the Agents section entirely. Requires a window reload to take effect."
+        },
+        "opencodego.showAgentModelsInManagePanel": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Show agent-host vendors in the Manage Language Models panel. When disabled (default), agent models still work in the Agents window but are hidden from the Manage panel to reduce clutter."
         },
         "opencodego.stripThinkTags": {
           "type": "string",
@@ -235,12 +240,12 @@
       {
         "vendor": "opencodego-agent-host",
         "displayName": "OpenCode Go (Agents)",
-        "when": "config.opencodego.agentsWindow"
+        "when": "config.opencodego.showAgentModelsInManagePanel"
       },
       {
         "vendor": "opencodezen-agent-host",
         "displayName": "OpenCode Zen (Agents)",
-        "when": "config.opencodego.agentsWindow"
+        "when": "config.opencodego.showAgentModelsInManagePanel"
       }
     ]
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,7 +34,7 @@ import {
   streamResponsesApi as runStreamResponsesApi,
   type TransportRequestSummary,
 } from "./streaming";
-import { GO_VENDOR, ZEN_VENDOR } from "./providerTypes";
+import { GO_VENDOR, ZEN_VENDOR, AGENT_GO_VENDOR, AGENT_ZEN_VENDOR, resolveBaseVendor, type AllProviderVendor, type ProviderVendor } from "./providerTypes";
 import { isInternalDataPart } from "./chatParts";
 
 import {
@@ -55,11 +55,14 @@ const RECENT_TRANSPORT_SUMMARY_STORAGE_PREFIX = "opencode.recentTransportSummari
 let usageStatusBarItem: vscode.StatusBarItem | undefined;
 let goUsageStatusBarItem: vscode.StatusBarItem | undefined;
 
+/** Maps base vendor → agent-variant provider instance for cross-resolution. */
+const agentProvidersByBaseVendor = new Map<string, OpenCodeProvider>();
+
 let goUsageTracker: GoUsageTracker | undefined;
 let usageWebviewPanel: vscode.WebviewPanel | undefined;
 
 interface ProviderDefinition {
-  vendor: typeof GO_VENDOR | typeof ZEN_VENDOR;
+  vendor: AllProviderVendor;
   displayName: string;
   modelNamePrefix: string;
   modelsUrl: string;
@@ -70,6 +73,10 @@ interface ProviderDefinition {
   testModelId: string;
   fallbackModels: string[];
   filterModel?: (modelId: string) => boolean;
+  /** When true, this provider only serves agent-host models (targetChatSessionType=copilotcli). */
+  isAgentVariant?: boolean;
+  /** The vendor key for the main (non-agent) provider definition this variant mirrors. */
+  baseVendor?: typeof GO_VENDOR | typeof ZEN_VENDOR;
 }
 
 type ModelEndpointKind =
@@ -89,8 +96,30 @@ const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 2 * 60 * 1000;
 const OPEN_CODE_CLIENT = "vscode-copilot-chat";
 const OPEN_CODE_USER_AGENT = "opencode-copilot-chat/0.2.7 VSCode";
 
-const PROVIDERS: Record<ProviderDefinition["vendor"], ProviderDefinition> = {
-  [GO_VENDOR]: {
+/** Create an agent-variant provider definition that inherits URLs, models, and filters from a base. */
+function providerVariant(
+  base: ProviderDefinition,
+  agentVendor: typeof AGENT_GO_VENDOR | typeof AGENT_ZEN_VENDOR,
+  displayName: string,
+  categoryOrder: number,
+): ProviderDefinition {
+  return {
+    vendor: agentVendor,
+    displayName,
+    modelNamePrefix: base.modelNamePrefix,
+    modelsUrl: base.modelsUrl,
+    chatCompletionsUrl: base.chatCompletionsUrl,
+    messagesUrl: base.messagesUrl,
+    responsesUrl: base.responsesUrl,
+    categoryOrder,
+    testModelId: base.testModelId,
+    fallbackModels: base.fallbackModels,
+    filterModel: base.filterModel,
+  };
+}
+
+const PROVIDERS: Record<ProviderDefinition["vendor"], ProviderDefinition> = (() => {
+  const go: ProviderDefinition = {
     vendor: GO_VENDOR,
     displayName: "OpenCode Go",
     modelNamePrefix: "OpenCode Go",
@@ -117,8 +146,8 @@ const PROVIDERS: Record<ProviderDefinition["vendor"], ProviderDefinition> = {
       "qwen3.6-plus",
       "qwen3.5-plus",
     ]
-  },
-  [ZEN_VENDOR]: {
+  };
+  const zen: ProviderDefinition = {
     vendor: ZEN_VENDOR,
     displayName: "OpenCode Zen",
     modelNamePrefix: "OpenCode Zen",
@@ -173,8 +202,14 @@ const PROVIDERS: Record<ProviderDefinition["vendor"], ProviderDefinition> = {
       "big-pickle"
     ],
     filterModel: (modelId) => vscode.workspace.getConfiguration("opencodego").get("freeOnly", true) ? modelId.endsWith("-free") || FREE_ZEN_MODEL_IDS.has(modelId) : true
-  }
-};
+  };
+  return {
+    [GO_VENDOR]: go,
+    [ZEN_VENDOR]: zen,
+    [AGENT_GO_VENDOR]: { ...providerVariant(go, AGENT_GO_VENDOR, "OpenCode Go (Agents)", 4), isAgentVariant: true, baseVendor: GO_VENDOR },
+    [AGENT_ZEN_VENDOR]: { ...providerVariant(zen, AGENT_ZEN_VENDOR, "OpenCode Zen (Agents)", 5), isAgentVariant: true, baseVendor: ZEN_VENDOR },
+  };
+})();
 
 type ApiRole = "user" | "assistant" | "tool";
 
@@ -421,7 +456,7 @@ export function activate(context: vscode.ExtensionContext) {
   const goProvider = new OpenCodeProvider(context, PROVIDERS[GO_VENDOR]);
   const zenProvider = new OpenCodeProvider(context, PROVIDERS[ZEN_VENDOR]);
 
-  context.subscriptions.push(
+  const subscriptions: vscode.Disposable[] = [
     vscode.lm.registerLanguageModelChatProvider(GO_VENDOR, goProvider),
     vscode.lm.registerLanguageModelChatProvider(ZEN_VENDOR, zenProvider),
     vscode.commands.registerCommand("opencodego.manage", () => goProvider.manage()),
@@ -430,8 +465,23 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("opencodezen.diagnostics", () => zenProvider.showDiagnostics()),
     vscode.commands.registerCommand("opencodego.modelPickerDiagnostics", () => showModelPickerDiagnostics()),
     vscode.commands.registerCommand("opencodego.setThinkingEffort", () => showThinkingEffortPicker()),
-    vscode.commands.registerCommand("opencodego.showUsageDetails", () => showUsageWebview(context))
-  );
+    vscode.commands.registerCommand("opencodego.showUsageDetails", () => showUsageWebview(context)),
+  ];
+
+  // Agent-host providers for the Copilot Agents window (opt-in via config).
+  const enableAgents = vscode.workspace.getConfiguration("opencodego").get<boolean>("agentsWindow", true);
+  if (enableAgents) {
+    const agentGoProvider = new OpenCodeProvider(context, PROVIDERS[AGENT_GO_VENDOR]);
+    const agentZenProvider = new OpenCodeProvider(context, PROVIDERS[AGENT_ZEN_VENDOR]);
+    agentProvidersByBaseVendor.set(GO_VENDOR, agentGoProvider);
+    agentProvidersByBaseVendor.set(ZEN_VENDOR, agentZenProvider);
+    subscriptions.push(
+      vscode.lm.registerLanguageModelChatProvider(AGENT_GO_VENDOR, agentGoProvider),
+      vscode.lm.registerLanguageModelChatProvider(AGENT_ZEN_VENDOR, agentZenProvider),
+    );
+  }
+
+  context.subscriptions.push(...subscriptions);
 
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration((event) => {
@@ -445,14 +495,18 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 async function warmModelPickerMetadata(): Promise<void> {
-  await Promise.allSettled([
-    vscode.lm.selectChatModels({ vendor: GO_VENDOR }),
-    vscode.lm.selectChatModels({ vendor: ZEN_VENDOR })
-  ]);
+  const vendors: string[] = [GO_VENDOR, ZEN_VENDOR];
+  if (vscode.workspace.getConfiguration("opencodego").get<boolean>("agentsWindow", true)) {
+    vendors.push(AGENT_GO_VENDOR, AGENT_ZEN_VENDOR);
+  }
+  await Promise.allSettled(vendors.map(v => vscode.lm.selectChatModels({ vendor: v })));
 }
 
 async function showModelPickerDiagnostics(): Promise<void> {
-  const vendors = [GO_VENDOR, ZEN_VENDOR, "copilot"];
+  const vendors: string[] = [GO_VENDOR, ZEN_VENDOR, "copilot"];
+  if (vscode.workspace.getConfiguration("opencodego").get<boolean>("agentsWindow", true)) {
+    vendors.splice(2, 0, AGENT_GO_VENDOR, AGENT_ZEN_VENDOR);
+  }
   const sections: string[] = [];
 
   for (const vendor of vendors) {
@@ -803,6 +857,16 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
   private readonly recentTransportSummaries: RecentTransportSummary[] = [];
   private outputChannel: vscode.OutputChannel | undefined;
 
+  /** Allow the main provider to trigger re-resolution on the agent variant after BYOK key is stored. */
+  triggerChange(): void {
+    this.changeEmitter.fire();
+  }
+
+  /** Resolves agent-host variants to their base vendor for metadata/routing. */
+  private get baseVendor(): ProviderVendor {
+    return resolveBaseVendor(this.definition.vendor);
+  }
+
   constructor(
     private readonly context: vscode.ExtensionContext,
     private readonly definition: ProviderDefinition
@@ -832,7 +896,7 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
   ): ResolvedModelMetadata {
     return resolveModelMetadata(
       modelId,
-      this.definition.vendor,
+      this.baseVendor,
       snapshot,
       this.liveModelMetadataById,
     );
@@ -1089,7 +1153,7 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
       `  status: ${metadata.status ?? "active"}`,
       `  thinkingFamily: ${thinkingFamily(rawModelId) ?? "none"}`,
       `  configurationSchema: ${JSON.stringify((model as unknown as { configurationSchema?: unknown }).configurationSchema ?? null)}`,
-      ...(hasExplicitModelLimits(rawModelId, this.definition.vendor) ? [] : ["  limits: using bundled fallback"])
+      ...(hasExplicitModelLimits(rawModelId, this.baseVendor) ? [] : ["  limits: using bundled fallback"])
       ].join("\n");
     });
 
@@ -1114,10 +1178,29 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
     options: vscode.PrepareLanguageModelChatModelOptions,
     token: vscode.CancellationToken
   ): Promise<OpenCodeModel[]> {
-    const apiKey = getConfiguredApiKey(options as ConfiguredLanguageModelInfoOptions);
+    let apiKey = getConfiguredApiKey(options as ConfiguredLanguageModelInfoOptions)
+      // Agent variant providers inherit the API key from the base vendor's secret
+      // when no explicit key is configured for them in the Manage panel.
+      ?? (this.definition.isAgentVariant ? await this.context.secrets.get(SECRET_KEY) : undefined);
 
     if (!apiKey) {
       return [];
+    }
+
+    // When a non-agent provider resolves its API key via BYOK configuration,
+    // persist it so that agent-variant providers (which have no BYOK entry)
+    // can inherit it from the extension's secret storage.
+    if (!this.definition.isAgentVariant) {
+      const existing = await this.context.secrets.get(SECRET_KEY);
+      if (existing !== apiKey) {
+        await this.context.secrets.store(SECRET_KEY, apiKey);
+      }
+      // Trigger re-resolution on the matching agent provider so it can
+      // discover the newly stored key and show up in the Agents window.
+      const agentProvider = agentProvidersByBaseVendor.get(this.definition.vendor);
+      if (agentProvider) {
+        agentProvider.triggerChange();
+      }
     }
 
     if (token.isCancellationRequested) {
@@ -1127,16 +1210,6 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
     const models = await this.fetchModels();
     const settings = getSettings();
     const metadataSnapshot = await this.getMetadataSnapshot();
-
-    // The Agents-window variant (targetChatSessionType: "copilotcli") is only
-    // hidden from the Chat view's in-session dropdown by filterModelsForSession().
-    // Surfaces that enumerate the raw registration list — most notably the Language
-    // Models management UI — show ALL registered models with no session filtering,
-    // so the ::agent-host copy appeared there too (issue #41, regression from PR #39).
-    // Gate the duplicate behind an opt-in setting so the default stays clean.
-    const showInAgentsWindow = vscode.workspace
-      .getConfiguration("opencodego")
-      .get("showInAgentsWindow", false);
 
     return models.flatMap((modelId) => {
       const metadata = this.resolveModelMetadata(modelId, metadataSnapshot);
@@ -1150,14 +1223,14 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
 
       const capacityNote = CAPACITY_LIMITED_MODEL_NOTES[modelId];
       const modalityBadges = formatModalityBadges(metadata);
-      const baseDetail = this.definition.vendor === ZEN_VENDOR && isFreeZenModel(modelId) ? "Free" : this.definition.displayName;
+      const baseDetail = this.baseVendor === ZEN_VENDOR && isFreeZenModel(modelId) ? "Free" : this.definition.displayName;
       const baseTooltip = `${this.definition.displayName} model: ${modelId}`;
       const configurationSchema = modelConfigurationSchema(modelId, metadata);
 
       const sharedFields: Omit<OpenCodeModel, "id" | "targetChatSessionType"> = {
         rawModelId: modelId,
         name: `${this.definition.modelNamePrefix} / ${formatModelName(modelId)}`,
-        family: `${this.definition.vendor}-${modelId}-${MODEL_METADATA_REVISION}`,
+        family: `${this.definition.isAgentVariant && this.definition.baseVendor ? this.definition.baseVendor : this.definition.vendor}-${modelId}-${MODEL_METADATA_REVISION}`,
         // Include effective limits in version so VS Code invalidates stale
         // picker metadata after limit changes (eg. 2M -> 262K corrections).
         version: `1.2.0-${MODEL_METADATA_REVISION}-${limits.contextWindow}-${limits.maxOutputTokens}`,
@@ -1182,39 +1255,33 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
         endpointKind: routing.endpointKind,
         provider: this.definition,
         // Pricing fields (VS Code languageModelPricing proposal)
-        ...modelPricingFields(modelId, this.definition.vendor, metadata),
+        ...modelPricingFields(modelId, this.baseVendor, metadata),
         // Inline so Copilot Chat picks up the Thinking submenu directly
         // (parity with zelosleone/Opencode-Go-For-Copilot pattern).
         ...(configurationSchema ? { configurationSchema } : {})
       };
+
+      if (this.definition.isAgentVariant) {
+        // Agent-host variant — only returned by agent providers.
+        // targetChatSessionType must match the `type` declared in the
+        // Copilot extension's chatSessions contribution:
+        //   { "type": "copilotcli", "requiresCustomModels": true, ... }
+        const agentHostInfo: OpenCodeModel = {
+          ...sharedFields,
+          id: agentHostModelId,
+          targetChatSessionType: "copilotcli"
+        };
+
+        this.log(`Model registered (agents): id=${agentHostInfo.id} targetChatSessionType=copilotcli`);
+        return [agentHostInfo];
+      }
 
       // General variant — no targetChatSessionType → visible in Chat view
       const info: OpenCodeModel = { ...sharedFields, id: effectiveModelId };
 
       this.log(`Model registered: id=${info.id} family=${info.family} metadataSource=${metadata.source} endpointKind=${routing.endpointKind} endpointUrl=${routing.endpointUrl} configurationSchema=${configurationSchema ? JSON.stringify(configurationSchema) : "none"}`);
 
-      // When showInAgentsWindow is off (default), return only the general
-      // variant so each model appears exactly once in all pickers and the
-      // Language Models management UI (regression fix for issue #41).
-      if (!showInAgentsWindow) {
-        return [info];
-      }
-
-      // Agents-window variant — targetChatSessionType must match the `type`
-      // declared in the Copilot extension's chatSessions contribution:
-      //   { "type": "copilotcli", "requiresCustomModels": true, ... }
-      // Name gets an "(Agents)" suffix so the two entries are visually
-      // distinguishable in the Language Models management UI when opt-in is on.
-      const agentHostInfo: OpenCodeModel = {
-        ...sharedFields,
-        id: agentHostModelId,
-        name: `${sharedFields.name} (Agents)`,
-        targetChatSessionType: "copilotcli"
-      };
-
-      this.log(`Model registered (agents-window): id=${agentHostInfo.id} targetChatSessionType=copilotcli`);
-
-      return [info, agentHostInfo];
+      return [info];
     });
   }
 
@@ -1269,7 +1336,7 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
         options.requestInitiator,
       );
       updateUsageStatusBar(this.definition.displayName, rawModelId, summary);
-      if (this.definition.vendor === GO_VENDOR && goUsageTracker) {
+      if (this.baseVendor === GO_VENDOR && goUsageTracker) {
         this.log(`[go-usage] Recording: provider=${summary.providerDisplayName} model=${summary.modelId} promptTokens=${summary.promptTokens ?? "n/a"} completionTokens=${summary.completionTokens ?? "n/a"} cachedTokens=${summary.cachedTokens ?? "n/a"} status=${summary.status ?? "n/a"} error=${summary.errorMessage ?? "none"}`);
         goUsageTracker.record(summary, metadata.cost);
         refreshGoUsageStatusBar();
@@ -1441,7 +1508,7 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
       const metadataSnapshot = await this.getMetadataSnapshot();
       const filteredModelIds = uniqueModelIds.filter((modelId) =>
         !KNOWN_UNAVAILABLE_MODEL_IDS.has(modelId)
-        && !shouldHideDeprecatedModel(modelId, this.definition.vendor, metadataSnapshot)
+        && !shouldHideDeprecatedModel(modelId, this.baseVendor, metadataSnapshot)
       );
 
       const removedModelIds = uniqueModelIds.filter((modelId) => !filteredModelIds.includes(modelId));
@@ -3037,21 +3104,19 @@ function shouldHideDeprecatedModel(
   vendor: ProviderDefinition["vendor"],
   snapshot: CachedModelMetadataSnapshot,
 ): boolean {
-  if (vendor !== ZEN_VENDOR) {
+  if (resolveBaseVendor(vendor) !== ZEN_VENDOR) {
     return false;
   }
-  return snapshot.providers[vendor][modelId]?.status === "deprecated";
+  return snapshot.providers[ZEN_VENDOR]?.[modelId]?.status === "deprecated";
 }
 
 function resolveRawModelId(modelId: string): string {
   const [base] = modelId.split("::");
-  const prefix = `${GO_VENDOR}:`;
-  const zenPrefix = `${ZEN_VENDOR}:`;
-  if (base.startsWith(prefix)) {
-    return base.slice(prefix.length);
-  }
-  if (base.startsWith(zenPrefix)) {
-    return base.slice(zenPrefix.length);
+  const prefixes = [`${GO_VENDOR}:`, `${ZEN_VENDOR}:`, `${AGENT_GO_VENDOR}:`, `${AGENT_ZEN_VENDOR}:`];
+  for (const prefix of prefixes) {
+    if (base.startsWith(prefix)) {
+      return base.slice(prefix.length);
+    }
   }
   return base;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -94,7 +94,7 @@ const KNOWN_UNAVAILABLE_MODEL_IDS = new Set([
 const DEFAULT_REQUEST_TIMEOUT_MS = 10 * 60 * 1000;
 const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 2 * 60 * 1000;
 const OPEN_CODE_CLIENT = "vscode-copilot-chat";
-const OPEN_CODE_USER_AGENT = "opencode-copilot-chat/0.2.7 VSCode";
+const OPEN_CODE_USER_AGENT = "opencode-copilot-chat/0.3.2 VSCode";
 
 /** Create an agent-variant provider definition that inherits URLs, models, and filters from a base. */
 function providerVariant(

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -1,4 +1,4 @@
-import { GO_VENDOR, ZEN_VENDOR, type ProviderVendor } from "./providerTypes";
+import { GO_VENDOR, ZEN_VENDOR, type ProviderVendor, type AllProviderVendor } from "./providerTypes";
 
 export interface BaseModelLimits {
   contextWindow: number;
@@ -278,7 +278,7 @@ export function isFreshModelMetadata(
 
 export function toEffectiveModelId(
   modelId: string,
-  vendor: ProviderVendor,
+  vendor: AllProviderVendor,
 ): string {
   return `${vendor}:${modelId}::${MODEL_METADATA_REVISION}`;
 }

--- a/src/providerTypes.ts
+++ b/src/providerTypes.ts
@@ -1,7 +1,7 @@
 export const GO_VENDOR = "opencodego" as const;
 export const ZEN_VENDOR = "opencodezen" as const;
-export const AGENT_GO_VENDOR = "opencodego-agent-host" as const;
-export const AGENT_ZEN_VENDOR = "opencodezen-agent-host" as const;
+export const AGENT_GO_VENDOR = "opencodego-agent" as const;
+export const AGENT_ZEN_VENDOR = "opencodezen-agent" as const;
 
 /** Base vendor IDs used for metadata lookups and API routing. */
 export type ProviderVendor = typeof GO_VENDOR | typeof ZEN_VENDOR;

--- a/src/providerTypes.ts
+++ b/src/providerTypes.ts
@@ -1,10 +1,27 @@
 export const GO_VENDOR = "opencodego" as const;
 export const ZEN_VENDOR = "opencodezen" as const;
+export const AGENT_GO_VENDOR = "opencodego-agent-host" as const;
+export const AGENT_ZEN_VENDOR = "opencodezen-agent-host" as const;
 
+/** Base vendor IDs used for metadata lookups and API routing. */
 export type ProviderVendor = typeof GO_VENDOR | typeof ZEN_VENDOR;
 
+/** All vendor IDs including agent-host variants. */
+export type AllProviderVendor =
+  | typeof GO_VENDOR
+  | typeof ZEN_VENDOR
+  | typeof AGENT_GO_VENDOR
+  | typeof AGENT_ZEN_VENDOR;
+
+/** Resolve agent-host vendor variants back to their base vendor for metadata/routing lookups. */
+export function resolveBaseVendor(vendor: AllProviderVendor): ProviderVendor {
+  return vendor === AGENT_GO_VENDOR ? GO_VENDOR
+    : vendor === AGENT_ZEN_VENDOR ? ZEN_VENDOR
+    : vendor as ProviderVendor;
+}
+
 export interface ProviderRoutingDefinition {
-  vendor: ProviderVendor;
+  vendor: AllProviderVendor;
   chatCompletionsUrl: string;
   messagesUrl: string;
   modelsUrl: string;

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -1,6 +1,7 @@
 import {
   GO_VENDOR,
   ZEN_VENDOR,
+  resolveBaseVendor,
   type ProviderRoutingDefinition,
 } from "./providerTypes";
 
@@ -17,7 +18,10 @@ export function resolveModelRouting(
   endpointUrl: string;
   sdkPackage?: string;
 } {
-  if (provider.vendor === ZEN_VENDOR && /^gpt-/i.test(modelId)) {
+  // Resolve agent-host variants to their base vendor for routing decisions.
+  const baseVendor = resolveBaseVendor(provider.vendor);
+
+  if (baseVendor === ZEN_VENDOR && /^gpt-/i.test(modelId)) {
     return {
       endpointKind: "responses",
       endpointUrl: provider.responsesUrl ?? provider.chatCompletionsUrl,
@@ -27,7 +31,7 @@ export function resolveModelRouting(
 
   if (
     /^claude-/i.test(modelId) ||
-    (provider.vendor === GO_VENDOR && /^minimax-m2\./i.test(modelId)) ||
+    (baseVendor === GO_VENDOR && /^minimax-m2\./i.test(modelId)) ||
     isMessagesQwenModel(modelId)
   ) {
     return {
@@ -37,7 +41,7 @@ export function resolveModelRouting(
     };
   }
 
-  if (provider.vendor === ZEN_VENDOR && /^gemini-/i.test(modelId)) {
+  if (baseVendor === ZEN_VENDOR && /^gemini-/i.test(modelId)) {
     return {
       endpointKind: "google",
       endpointUrl: `${provider.modelsUrl}/${modelId}`,


### PR DESCRIPTION
## Summary

Fixes #41 — models shown twice in the Language Models management UI.

This is an **alternative approach** to PR #42 (by @Marinski). Instead of gating the `::agent-host` duplicate behind an opt-in setting, this PR registers agent models under **dedicated vendor IDs** (`opencodego-agent`, `opencodezen-agent`) so each vendor group shows only its own models.

## Problem

PR #39 registered each model twice (general + `::agent-host` with `targetChatSessionType: "copilotcli"`). While `filterModelsForSession()` correctly partitions them in Chat/Agents pickers, the **Language Models management UI** enumerates raw registrations — so both variants appeared there.

PR #42 solved this by gating the duplicate behind `showInAgentsWindow` (default false). This works but means agent models are disabled by default and the Manage panel still shows both variants when enabled.

## Solution

Register agent models under separate vendor IDs so each vendor shows only its models:

| Vendor | Models | Visible in |
|--------|--------|------------|
| `opencodego` | General models | Chat view, Manage panel |
| `opencodego-agent` | Agent-only models | Agents window, Manage panel (hidden by default) |
| `opencodezen` | General models | Chat view, Manage panel |
| `opencodezen-agent` | Agent-only models | Agents window, Manage panel (hidden by default) |

### Two independent controls

| Setting | Default | Purpose |
|---------|---------|---------|
| `opencodego.agentsWindow` | `true` | Register agent providers at runtime |
| `opencodego.showAgentModelsInManagePanel` | `false` | Show agent vendors in Manage panel |

## Key changes

- **`package.json`**: Declare agent vendors with `when` clause; add `agentsWindow` and `showAgentModelsInManagePanel` configs
- **`providerTypes.ts`**: Agent vendor constants, `AllProviderVendor` type, `resolveBaseVendor()` helper
- **`extension.ts`**: DRY provider definitions via `providerVariant()`; BYOK key sync via secret storage + `triggerChange()`; `baseVendor` getter
- **`routing.ts`**: Fix agent vendor routing using `resolveBaseVendor()` before vendor comparisons
- **`metadata.ts`**: Widen `toEffectiveModelId` vendor parameter

## Why this is cleaner

1. **Zero duplication** — each vendor shows exactly its models, in every UI surface
2. **Agent models on by default** — `agentsWindow: true` means agents work out of the box
3. **Manage panel clean by default** — agent vendors hidden via `when` clause, not visible unless explicitly enabled
4. **Independent controls** — registration vs. visibility are separate concerns
5. **No name suffixes needed** — no `(Agents)` suffix hack since models aren't in the same vendor group

## Replaces

- `opencodego.showInAgentsWindow` → `opencodego.agentsWindow` + `opencodego.showAgentModelsInManagePanel`

## Testing

- [ ] Chat view: models appear once, no duplication
- [ ] Agents window: agent models appear in Copilot CLI picker
- [ ] Manage Language Models: agent vendors hidden by default
- [ ] Manage Language Models with `showAgentModelsInManagePanel: true`: agent vendors visible
- [ ] Routing: all model families route to correct endpoints (GPT→responses, Claude→messages, Gemini→google, etc.)
- [ ] BYOK: API key set on main provider syncs to agent provider