### PR TITLE
feat: manual usage targets + live pricing for Go tracker

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,10 @@
       {
         "command": "opencodego.showUsageDetails",
         "title": "OpenCode Go: Show Usage Details"
+      },
+      {
+        "command": "opencodego.setUsageTargets",
+        "title": "OpenCode Go: Set Usage Targets…"
       }
     ],
     "configuration": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,6 +55,7 @@ import {
 import {
   GoUsageTracker,
   formatGoUsageStatusBarText,
+  type UsageBaselineTargets,
 } from "./goUsageTracker";
 
 const SECRET_KEY = "opencodego.apiKey";
@@ -465,6 +466,14 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("opencodego.modelPickerDiagnostics", () => showModelPickerDiagnostics()),
     vscode.commands.registerCommand("opencodego.setThinkingEffort", () => showThinkingEffortPicker()),
     vscode.commands.registerCommand("opencodego.showUsageDetails", () => showUsageWebview(context)),
+    vscode.commands.registerCommand("opencodego.setUsageTargets", async () => {
+      if (!goUsageTracker) return;
+      const targets = await showUsageTargetEditor(goUsageTracker);
+      if (targets) {
+        goUsageTracker.setManualSpentTargets(targets);
+        vscode.window.showInformationMessage("OpenCode Go usage targets updated.");
+      }
+    }),
   ];
 
   // Agent-host providers for the Copilot Agents window (opt-in via config).
@@ -642,7 +651,7 @@ function ensureGoUsageStatusBar(context: vscode.ExtensionContext): void {
     vscode.StatusBarAlignment.Right,
     94,
   );
-  goUsageStatusBarItem.command = "opencodego.showUsageDetails";
+  // No command on status bar click — usage details only visible on hover via tooltip.
   context.subscriptions.push(goUsageStatusBarItem);
   refreshGoUsageStatusBar();
 }
@@ -669,7 +678,7 @@ function showUsageWebview(context: vscode.ExtensionContext): void {
     "OpenCode Usage Summary",
     vscode.ViewColumn.Beside,
     {
-      enableScripts: true,
+      enableScripts: false,
       retainContextWhenHidden: true
     }
   );
@@ -684,7 +693,6 @@ function showUsageWebview(context: vscode.ExtensionContext): void {
 function updateWebviewContent(): void {
   if (!usageWebviewPanel || !goUsageTracker) return;
   const s = goUsageTracker.getSummary();
-  const svg = buildUsageTooltipSvg(s);
 
   usageWebviewPanel.webview.html = `
     <!DOCTYPE html>
@@ -725,7 +733,7 @@ function updateWebviewContent(): void {
     </head>
     <body>
       <div class="container">
-        ${svg}
+        ${buildUsageTooltipSvg(s)}
       </div>
     </body>
     </html>
@@ -735,11 +743,110 @@ function updateWebviewContent(): void {
 function buildUsageTooltip(s: ReturnType<GoUsageTracker["getSummary"]>): vscode.MarkdownString {
   const md = new vscode.MarkdownString("", true);
   md.supportHtml = true;
+  md.isTrusted = true;
   md.appendMarkdown(
     `<img alt="OpenCode Go usage summary" src="${usageTooltipSvgDataUri(s)}" width="330">`,
   );
-
+  md.appendMarkdown(
+    "\n\n[$(pencil) Set spent targets](command:opencodego.setUsageTargets)"
+  );
   return md;
+}
+
+/**
+ * Show input boxes for the user to manually set Go usage targets.
+ * Returns UsageBaselineTargets if the user completed the flow, or undefined if cancelled.
+ */
+async function showUsageTargetEditor(
+  tracker: GoUsageTracker,
+): Promise<UsageBaselineTargets | undefined> {
+  const summary = tracker.getSummary();
+
+  // Ask for session spent (pre-filled with current tracked value)
+  const sessionStr = await vscode.window.showInputBox({
+    title: "OpenCode Go — Session Spent",
+    prompt: `Total spent in the 5-hour rolling window (limit: $12).`,
+    placeHolder: "e.g. 3.50",
+    value: summary.session.spent.toFixed(2),
+    validateInput: (value: string) => {
+      const n = parseFloat(value);
+      if (isNaN(n) || n < 0) return "Enter a valid positive number (e.g. 3.50).";
+      if (n > 12) return "Session limit is $12. Enter a value between 0 and 12.";
+      return undefined;
+    },
+  });
+  if (sessionStr === undefined) return undefined;
+
+  // Ask for weekly spent (pre-filled)
+  const weeklyStr = await vscode.window.showInputBox({
+    title: "OpenCode Go — Weekly Spent",
+    prompt: `Total spent this week Mon–Mon UTC (limit: $30).`,
+    placeHolder: "e.g. 12.00",
+    value: summary.weekly.spent.toFixed(2),
+    validateInput: (value: string) => {
+      const n = parseFloat(value);
+      if (isNaN(n) || n < 0) return "Enter a valid positive number (e.g. 12.00).";
+      if (n > 30) return "Weekly limit is $30. Enter a value between 0 and 30.";
+      return undefined;
+    },
+  });
+  if (weeklyStr === undefined) return undefined;
+
+  // Ask for monthly spent (pre-filled)
+  const monthlyStr = await vscode.window.showInputBox({
+    title: "OpenCode Go — Monthly Spent",
+    prompt: `Total spent this month (limit: $60).`,
+    placeHolder: "e.g. 25.00",
+    value: summary.monthly.spent.toFixed(2),
+    validateInput: (value: string) => {
+      const n = parseFloat(value);
+      if (isNaN(n) || n < 0) return "Enter a valid positive number (e.g. 25.00).";
+      if (n > 60) return "Monthly limit is $60. Enter a value between 0 and 60.";
+      return undefined;
+    },
+  });
+  if (monthlyStr === undefined) return undefined;
+
+  // Ask for monthly reset day (1-31) — pre-filled
+  const monthlyDayStr = await vscode.window.showInputBox({
+    title: "OpenCode Go — Monthly Reset Day",
+    prompt: "Day of month when monthly usage resets (1-31). Press Enter to keep current.",
+    placeHolder: "e.g. 10",
+    value: summary.monthly.resetsAt.getUTCDate().toString(),
+    validateInput: (value: string) => {
+      if (!value) return undefined;
+      const n = parseInt(value, 10);
+      if (isNaN(n) || n < 1 || n > 31) return "Enter a day between 1 and 31.";
+      return undefined;
+    },
+  });
+  if (monthlyDayStr === undefined) return undefined;
+
+  // Ask for monthly reset hour (0-23 UTC) — pre-filled
+  const monthlyHourStr = await vscode.window.showInputBox({
+    title: "OpenCode Go — Monthly Reset Hour",
+    prompt: "Hour (UTC, 0-23) when monthly usage resets. Press Enter to keep current.",
+    placeHolder: "e.g. 0",
+    value: summary.monthly.resetsAt.getUTCHours().toString(),
+    validateInput: (value: string) => {
+      if (!value) return undefined;
+      const n = parseInt(value, 10);
+      if (isNaN(n) || n < 0 || n > 23) return "Enter an hour between 0 and 23 (UTC).";
+      return undefined;
+    },
+  });
+  if (monthlyHourStr === undefined) return undefined;
+
+  const monthlyAnchorDay = monthlyDayStr ? parseInt(monthlyDayStr, 10) : undefined;
+  const monthlyAnchorHour = monthlyHourStr ? parseInt(monthlyHourStr, 10) : undefined;
+
+  return {
+    session: parseFloat(sessionStr),
+    weekly: parseFloat(weeklyStr),
+    monthly: parseFloat(monthlyStr),
+    monthlyAnchorDay,
+    monthlyAnchorHour,
+  };
 }
 
 type _UsageSummary = ReturnType<GoUsageTracker["getSummary"]>;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -450,6 +450,8 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(goUsageLogChannel);
   goUsageTracker = new GoUsageTracker(context, (msg) => {
     goUsageLogChannel.appendLine(`[${new Date().toISOString()}] ${msg}`);
+  }, (modelId) => {
+    return modelMetadataSnapshot?.providers[GO_VENDOR]?.[modelId]?.cost;
   });
   ensureUsageStatusBar(context);
   ensureGoUsageStatusBar(context);

--- a/src/goUsageTracker.ts
+++ b/src/goUsageTracker.ts
@@ -7,6 +7,9 @@ import { GO_VENDOR } from "./providerTypes";
 import type { ModelCost } from "./metadata";
 import type { TransportRequestSummary } from "./streaming";
 
+/** Callback to resolve live model cost from the models.dev metadata cache. */
+export type CostResolver = (modelId: string) => ModelCost | undefined;
+
 // ─── Constants ──────────────────────────────────────────────────────────────
 
 const STORAGE_KEY = "opencodego.usageLog.v1";
@@ -23,7 +26,9 @@ const GO_LIMITS = {
 const FIVE_HOURS_MS = 5 * 60 * 60 * 1000;
 const WEEK_MS       = 7 * 24 * 60 * 60 * 1000;
 
-// ─── Go model pricing ($/1M tokens) from https://opencode.ai/docs/go ────────
+// ─── Go model pricing ($/1M tokens) — bundled snapshot fallback ────────────
+// This table is a static snapshot kept as a last resort. The primary source
+// is the live models.dev metadata cache injected via CostResolver.
 
 const GO_MODEL_PRICING: Record<string, ModelCost> = {
   "glm-5.1":         { input: 1.40, output: 4.40,  cache_read: 0.26  },
@@ -168,8 +173,10 @@ function estimateCost(
   completionTokens: number,
   cachedTokens: number,
   externalCost?: ModelCost,
+  liveCostResolver?: CostResolver,
 ): number {
-  const pricing = externalCost ?? GO_MODEL_PRICING[modelId];
+  // Priority: caller-provided cost > live models.dev snapshot > bundled table
+  const pricing = externalCost ?? liveCostResolver?.(modelId) ?? GO_MODEL_PRICING[modelId];
   if (!pricing) return 0;
 
   const billablePrompt = Math.max(0, promptTokens - cachedTokens);
@@ -230,13 +237,21 @@ export class GoUsageTracker {
   private entries: UsageLogEntry[] = [];
   private baseline: UsageBaseline = {};
   private readonly log?: (msg: string) => void;
+  private costResolver?: CostResolver;
 
   constructor(
     private readonly context: vscode.ExtensionContext,
     log?: (msg: string) => void,
+    costResolver?: CostResolver,
   ) {
     this.log = log;
+    this.costResolver = costResolver;
     this.restore();
+  }
+
+  /** Update the live cost resolver (e.g. after models.dev refresh). */
+  setCostResolver(resolver: CostResolver): void {
+    this.costResolver = resolver;
   }
 
   /** Record a completed Go request. externalCost is from resolved metadata if available. */
@@ -256,7 +271,7 @@ export class GoUsageTracker {
       return;
     }
 
-    const cost = estimateCost(summary.modelId, prompt, completion, cached, externalCost);
+    const cost = estimateCost(summary.modelId, prompt, completion, cached, externalCost, this.costResolver);
 
     this.log?.(`[go-tracker] RECORD: model=${summary.modelId} prompt=${prompt} completion=${completion} cached=${cached} cost=$${cost.toFixed(6)}`);
 

--- a/src/goUsageTracker.ts
+++ b/src/goUsageTracker.ts
@@ -94,10 +94,14 @@ interface UsageBaseline {
   monthly?: UsageBaselinePeriod;
 }
 
-interface UsageBaselineTargets {
+export interface UsageBaselineTargets {
   session: number;
   weekly: number;
   monthly: number;
+  /** Day of month (1-31) when monthly counter resets. Combined with monthlyAnchorHour. */
+  monthlyAnchorDay?: number;
+  /** Hour of day (0-23 UTC) when monthly counter resets. Combined with monthlyAnchorDay. */
+  monthlyAnchorHour?: number;
 }
 
 // ─── Time window helpers ─────────────────────────────────────────────────────
@@ -290,6 +294,7 @@ export class GoUsageTracker {
     const weekMs      = startOfUtcWeek(nowMs);
     const sessionStart = nowMs - FIVE_HOURS_MS;
 
+    // Use stored activation date as anchor; fall back to earliest row.
     const earliest = Math.min(...rows.map(r => r.createdMs));
     const monthStartMs = anchoredMonthStart(nowMs, earliest);
     const monthEndMs   = anchoredMonthEnd(monthStartMs, earliest);
@@ -320,6 +325,11 @@ export class GoUsageTracker {
       }
     }
 
+    // If a monthly baseline exists and is active, use its expiresAt for resetsAt.
+    const monthlyResetsAt = this.baseline.monthly
+      ? new Date(this.baseline.monthly.expiresAt)
+      : new Date(monthEndMs);
+
     return {
       session: {
         spent:    Math.round(sessionCost * 10000) / 10000,
@@ -337,7 +347,7 @@ export class GoUsageTracker {
         spent:    Math.round(monthlyCost * 10000) / 10000,
         limit:    GO_LIMITS.monthly,
         percent:  clamp(monthlyCost, GO_LIMITS.monthly),
-        resetsAt: new Date(monthEndMs),
+        resetsAt: monthlyResetsAt,
       },
       today: {
         cost:     Math.round(todayCost * 10000) / 10000,
@@ -403,6 +413,12 @@ export class GoUsageTracker {
 
     const weekEnd = weekMs + WEEK_MS;
 
+    // If a monthly baseline exists and is active, use its expiresAt for resetsAt
+    // instead of the anchor-based calculation (which ignores manual targets).
+    const monthlyResetsAt = this.baseline.monthly
+      ? new Date(this.baseline.monthly.expiresAt)
+      : new Date(monthEndMs);
+
     return {
       session: {
         spent:    Math.round(sessionCost * 10000) / 10000,
@@ -420,7 +436,7 @@ export class GoUsageTracker {
         spent:    Math.round(monthlyCost * 10000) / 10000,
         limit:    GO_LIMITS.monthly,
         percent:  clamp(monthlyCost, GO_LIMITS.monthly),
-        resetsAt: new Date(monthEndMs),
+        resetsAt: monthlyResetsAt,
       },
       today: {
         cost:     Math.round(todayCost * 10000) / 10000,
@@ -444,7 +460,6 @@ export class GoUsageTracker {
     const currentBaselineWeekly = this.getActiveBaselineAmount("weekly", nowMs);
     const currentBaselineMonthly = this.getActiveBaselineAmount("monthly", nowMs);
 
-    // Calculate tracked-only amounts from current displayed totals.
     const trackedSession = Math.max(0, summary.session.spent - currentBaselineSession);
     const trackedWeekly = Math.max(0, summary.weekly.spent - currentBaselineWeekly);
     const trackedMonthly = Math.max(0, summary.monthly.spent - currentBaselineMonthly);
@@ -461,6 +476,22 @@ export class GoUsageTracker {
       amount: Math.max(0, targets.monthly - trackedMonthly),
       expiresAt: summary.monthly.resetsAt.getTime(),
     };
+
+    // Override monthly expiry if caller provided anchor day + hour.
+    if (targets.monthlyAnchorDay && targets.monthlyAnchorDay >= 1 && targets.monthlyAnchorDay <= 31) {
+      const hour = targets.monthlyAnchorHour ?? 0;
+      const now = new Date(nowMs);
+      let year = now.getUTCFullYear();
+      let month = now.getUTCMonth();
+      let candidate = Date.UTC(year, month, targets.monthlyAnchorDay, hour, 0, 0, 0);
+      if (candidate <= nowMs) {
+        // If the anchor day+hour has passed this month, next reset is next month.
+        month++;
+        if (month > 11) { year++; month = 0; }
+        candidate = Date.UTC(year, month, targets.monthlyAnchorDay, hour, 0, 0, 0);
+      }
+      this.baseline.monthly.expiresAt = candidate;
+    }
 
     this.persistBaseline();
   }


### PR DESCRIPTION
## Summary

Adds manual Go usage target configuration and fixes cost estimation to use live models.dev pricing instead of a stale hardcoded table.

## Closes

Closes #23

## Changes

### Manual Usage Targets (`showUsageTargetEditor`)
- New command **"OpenCode Go: Set Usage Targets..."** opens 5 sequential input boxes pre-filled with current values:
  - Session spent (rolling 5h, limit $12)
  - Weekly spent (Mon–Mon UTC, limit $30)
  - Monthly spent (limit $60)
  - Monthly reset **day** (1–31)
  - Monthly reset **hour** (0–23 UTC)
- Press Enter on any input to keep the current value; Escape cancels the entire flow.
- Targets are persisted in `globalState` as baseline amounts with a custom `expiresAt` for the monthly anchor.

### Monthly Reset Display Fix
- `buildSummaryFromTracked` and `buildSummaryFromRows` now use `baseline.monthly.expiresAt` as `resetsAt` when available, so the "resets in Xd Yh" text reflects the user-configured anchor date instead of the auto-calculated month end.

### Webview / Status Bar Cleanup
- Removed button and scripts from the usage webview (now display-only SVG).
- Status bar click disabled (hover-only via tooltip).
- Tooltip links to the `setUsageTargets` command.

### Live Pricing Fallback
- Injected a `CostResolver` callback into `GoUsageTracker` that reads from the live `models.dev` metadata snapshot.
- Cost resolution priority: per-request `externalCost` → live snapshot → bundled static table.
- The hardcoded `GO_MODEL_PRICING` is kept only as a last-resort fallback.

## Commits

- `d031457` — feat: add manual usage targets editor for Go usage tracker
- `094978e` — fix: use live models.dev pricing instead of hardcoded fallback in Go tracker