### PR TITLE
fix: baseline negative support, status bar QuickPick, input validation, tooltip refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to the **OpenCode Go BYOK Provider** extension are documente
 
 ## [Unreleased]
 
-_No changes yet._
+### Fixed
+
+- **`[Usage]` Session/weekly targets now apply correctly.** Previously, editing session or weekly spent values could silently fail when the baseline had already been zeroed by a prior edit (the delta calculation resulted in a negative value clamped to 0). Session and weekly baselines are now set to the absolute target value, so editing always reflects the user's input. Monthly continues to use delta-based calculation to preserve the anchor expiry logic.
+- **`[Usage]` Removed dead `setCostResolver()` method.** The `CostResolver` is injected via constructor closure and never updated after initialization — the setter was unreachable code.
+- **`[Usage]` Validation limits now derive from `GO_LIMITS`.** Input box validation for session ($12), weekly ($30), and monthly ($60) limits now reads from the exported `GO_LIMITS` constant instead of hardcoded numbers, preventing drift if limits change.
+- **`[Usage]` Tooltip command link now uses `supportedCommands`.** Added `md.supportedCommands = ["opencodego.setUsageTargets"]` to the usage tooltip so the `[$(pencil) Set spent targets]` link renders as a clickable command in all VS Code versions.
 
 ## [0.3.3] — 2026-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@ All notable changes to the **OpenCode Go BYOK Provider** extension are documente
 
 ## [Unreleased]
 
+### Added
+
+- **`[Usage]` Status bar click opens usage QuickPick.** Clicking the OpenCode Go usage status bar item now opens a QuickPick with session/weekly/monthly progress bars, usage percentages, and reset countdowns. Includes quick actions to "Set spent targets…" and "Open full usage panel". Previously, status bar was hover-only with no click behavior.
+
 ### Fixed
 
-- **`[Usage]` Session/weekly targets now apply correctly.** Previously, editing session or weekly spent values could silently fail when the baseline had already been zeroed by a prior edit (the delta calculation resulted in a negative value clamped to 0). Session and weekly baselines are now set to the absolute target value, so editing always reflects the user's input. Monthly continues to use delta-based calculation to preserve the anchor expiry logic.
+- **`[Usage]` Baseline editing now correctly recalculates on re-edit.** The `setManualSpentTargets()` function now computes `baseline = target - tracked` (without clamping to 0) for all three periods. This allows **negative baselines** that offset tracked entries downward, so `display = tracked + baseline = target` exactly. Previously, `Math.max(0, ...)` prevented negative baselines — when a user lowered a target below the tracked amount, the display never updated because the delta clamped to 0. Also, session and weekly now use delta-based calculation (same as monthly) instead of absolute target injection, ensuring consistency and proper expiry behavior.
+- **`[Usage]` Input validation rejects non-numeric characters.** The usage target editor now validates input with a strict regex (`/^-?\d+[.,]?\d*$/`) that rejects strings like `60f` or `18asd` (which `parseFloat` would partially accept). Accepts both `.` and `,` as decimal separators for international users.
+- **`[Usage]` Status bar tooltip refreshes immediately after editing targets.** `refreshGoUsageStatusBar()` is now called right after `setManualSpentTargets()` so the hover tooltip updates without requiring a VS Code window reload.
 - **`[Usage]` Removed dead `setCostResolver()` method.** The `CostResolver` is injected via constructor closure and never updated after initialization — the setter was unreachable code.
 - **`[Usage]` Validation limits now derive from `GO_LIMITS`.** Input box validation for session ($12), weekly ($30), and monthly ($60) limits now reads from the exported `GO_LIMITS` constant instead of hardcoded numbers, preventing drift if limits change.
 - **`[Usage]` Tooltip command link now uses `supportedCommands`.** Added `md.supportedCommands = ["opencodego.setUsageTargets"]` to the usage tooltip so the `[$(pencil) Set spent targets]` link renders as a clickable command in all VS Code versions.

--- a/package.json
+++ b/package.json
@@ -93,6 +93,10 @@
       {
         "command": "opencodego.setUsageTargets",
         "title": "OpenCode Go: Set Usage Targets…"
+      },
+      {
+        "command": "opencodego.showUsageQuickPick",
+        "title": "OpenCode Go: Show Usage Quick Pick"
       }
     ],
     "configuration": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,6 +56,7 @@ import {
   GoUsageTracker,
   GO_LIMITS,
   formatGoUsageStatusBarText,
+  buildUsageQuickPickItems,
   type UsageBaselineTargets,
 } from "./goUsageTracker";
 
@@ -474,7 +475,28 @@ export function activate(context: vscode.ExtensionContext) {
       const targets = await showUsageTargetEditor(goUsageTracker);
       if (targets) {
         goUsageTracker.setManualSpentTargets(targets);
+        refreshGoUsageStatusBar(); // Update tooltip immediately
         vscode.window.showInformationMessage("OpenCode Go usage targets updated.");
+      }
+    }),
+    vscode.commands.registerCommand("opencodego.showUsageQuickPick", async () => {
+      if (!goUsageTracker) return;
+      const summary = goUsageTracker.getSummary();
+      const items = buildUsageQuickPickItems(summary);
+      const separator: vscode.QuickPickItem = { label: "", kind: vscode.QuickPickItemKind.Separator };
+      const setTargetItem: vscode.QuickPickItem & { _action?: string } = { label: "$(edit) Set spent targets…", _action: "setUsageTargets" };
+      const panelItem: vscode.QuickPickItem & { _action?: string } = { label: "$(graph) Open full usage panel", _action: "showUsageDetails" };
+      items.push(separator, setTargetItem, panelItem);
+      const picked = await vscode.window.showQuickPick(items, {
+        placeHolder: "OpenCode Go — Current Usage",
+        title: "Usage Summary",
+      });
+      if (!picked || !("_action" in picked)) return;
+      const action = (picked as typeof setTargetItem)._action;
+      if (action === "setUsageTargets") {
+        vscode.commands.executeCommand("opencodego.setUsageTargets");
+      } else if (action === "showUsageDetails") {
+        vscode.commands.executeCommand("opencodego.showUsageDetails");
       }
     }),
   ];
@@ -654,7 +676,7 @@ function ensureGoUsageStatusBar(context: vscode.ExtensionContext): void {
     vscode.StatusBarAlignment.Right,
     94,
   );
-  // No command on status bar click — usage details only visible on hover via tooltip.
+  goUsageStatusBarItem.command = "opencodego.showUsageQuickPick";
   context.subscriptions.push(goUsageStatusBarItem);
   refreshGoUsageStatusBar();
 }
@@ -762,6 +784,14 @@ function buildUsageTooltip(s: ReturnType<GoUsageTracker["getSummary"]>): vscode.
  * Show input boxes for the user to manually set Go usage targets.
  * Returns UsageBaselineTargets if the user completed the flow, or undefined if cancelled.
  */
+/** Parse a user-entered currency value. Accepts comma or dot as decimal separator.
+ *  Returns NaN if the string contains non-numeric characters beyond the decimal separator. */
+function parseCurrencyInput(value: string): number {
+  // Allow only digits, one comma or dot, and optional leading minus
+  if (!/^-?\d+[.,]?\d*$/.test(value)) return NaN;
+  return parseFloat(value.replace(",", "."));
+}
+
 async function showUsageTargetEditor(
   tracker: GoUsageTracker,
 ): Promise<UsageBaselineTargets | undefined> {
@@ -774,8 +804,8 @@ async function showUsageTargetEditor(
     placeHolder: "e.g. 3.50",
     value: summary.session.spent.toFixed(2),
     validateInput: (value: string) => {
-      const n = parseFloat(value);
-      if (isNaN(n) || n < 0) return "Enter a valid positive number (e.g. 3.50).";
+      const n = parseCurrencyInput(value);
+      if (isNaN(n) || n < 0) return "Enter a valid number using digits and . or , as decimal separator (e.g. 3.50).";
       if (n > GO_LIMITS.session) return `Session limit is $${GO_LIMITS.session}. Enter a value between 0 and ${GO_LIMITS.session}.`;
       return undefined;
     },
@@ -789,8 +819,8 @@ async function showUsageTargetEditor(
     placeHolder: "e.g. 12.00",
     value: summary.weekly.spent.toFixed(2),
     validateInput: (value: string) => {
-      const n = parseFloat(value);
-      if (isNaN(n) || n < 0) return "Enter a valid positive number (e.g. 12.00).";
+      const n = parseCurrencyInput(value);
+      if (isNaN(n) || n < 0) return "Enter a valid number using digits and . or , as decimal separator (e.g. 12.00).";
       if (n > GO_LIMITS.weekly) return `Weekly limit is $${GO_LIMITS.weekly}. Enter a value between 0 and ${GO_LIMITS.weekly}.`;
       return undefined;
     },
@@ -804,8 +834,8 @@ async function showUsageTargetEditor(
     placeHolder: "e.g. 25.00",
     value: summary.monthly.spent.toFixed(2),
     validateInput: (value: string) => {
-      const n = parseFloat(value);
-      if (isNaN(n) || n < 0) return "Enter a valid positive number (e.g. 25.00).";
+      const n = parseCurrencyInput(value);
+      if (isNaN(n) || n < 0) return "Enter a valid number using digits and . or , as decimal separator (e.g. 25.00).";
       if (n > GO_LIMITS.monthly) return `Monthly limit is $${GO_LIMITS.monthly}. Enter a value between 0 and ${GO_LIMITS.monthly}.`;
       return undefined;
     },
@@ -846,9 +876,9 @@ async function showUsageTargetEditor(
   const monthlyAnchorHour = monthlyHourStr ? parseInt(monthlyHourStr, 10) : undefined;
 
   return {
-    session: parseFloat(sessionStr),
-    weekly: parseFloat(weeklyStr),
-    monthly: parseFloat(monthlyStr),
+    session: parseCurrencyInput(sessionStr),
+    weekly: parseCurrencyInput(weeklyStr),
+    monthly: parseCurrencyInput(monthlyStr),
     monthlyAnchorDay,
     monthlyAnchorHour,
   };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -54,6 +54,7 @@ import {
 } from "./usage";
 import {
   GoUsageTracker,
+  GO_LIMITS,
   formatGoUsageStatusBarText,
   type UsageBaselineTargets,
 } from "./goUsageTracker";
@@ -746,6 +747,8 @@ function buildUsageTooltip(s: ReturnType<GoUsageTracker["getSummary"]>): vscode.
   const md = new vscode.MarkdownString("", true);
   md.supportHtml = true;
   md.isTrusted = true;
+  // supportedCommands is a proposed API — cast to bypass type check.
+  (md as any).supportedCommands = ["opencodego.setUsageTargets"];
   md.appendMarkdown(
     `<img alt="OpenCode Go usage summary" src="${usageTooltipSvgDataUri(s)}" width="330">`,
   );
@@ -767,13 +770,13 @@ async function showUsageTargetEditor(
   // Ask for session spent (pre-filled with current tracked value)
   const sessionStr = await vscode.window.showInputBox({
     title: "OpenCode Go — Session Spent",
-    prompt: `Total spent in the 5-hour rolling window (limit: $12).`,
+    prompt: `Total spent in the 5-hour rolling window (limit: $${GO_LIMITS.session}).`,
     placeHolder: "e.g. 3.50",
     value: summary.session.spent.toFixed(2),
     validateInput: (value: string) => {
       const n = parseFloat(value);
       if (isNaN(n) || n < 0) return "Enter a valid positive number (e.g. 3.50).";
-      if (n > 12) return "Session limit is $12. Enter a value between 0 and 12.";
+      if (n > GO_LIMITS.session) return `Session limit is $${GO_LIMITS.session}. Enter a value between 0 and ${GO_LIMITS.session}.`;
       return undefined;
     },
   });
@@ -782,13 +785,13 @@ async function showUsageTargetEditor(
   // Ask for weekly spent (pre-filled)
   const weeklyStr = await vscode.window.showInputBox({
     title: "OpenCode Go — Weekly Spent",
-    prompt: `Total spent this week Mon–Mon UTC (limit: $30).`,
+    prompt: `Total spent this week Mon–Mon UTC (limit: $${GO_LIMITS.weekly}).`,
     placeHolder: "e.g. 12.00",
     value: summary.weekly.spent.toFixed(2),
     validateInput: (value: string) => {
       const n = parseFloat(value);
       if (isNaN(n) || n < 0) return "Enter a valid positive number (e.g. 12.00).";
-      if (n > 30) return "Weekly limit is $30. Enter a value between 0 and 30.";
+      if (n > GO_LIMITS.weekly) return `Weekly limit is $${GO_LIMITS.weekly}. Enter a value between 0 and ${GO_LIMITS.weekly}.`;
       return undefined;
     },
   });
@@ -797,13 +800,13 @@ async function showUsageTargetEditor(
   // Ask for monthly spent (pre-filled)
   const monthlyStr = await vscode.window.showInputBox({
     title: "OpenCode Go — Monthly Spent",
-    prompt: `Total spent this month (limit: $60).`,
+    prompt: `Total spent this month (limit: $${GO_LIMITS.monthly}).`,
     placeHolder: "e.g. 25.00",
     value: summary.monthly.spent.toFixed(2),
     validateInput: (value: string) => {
       const n = parseFloat(value);
       if (isNaN(n) || n < 0) return "Enter a valid positive number (e.g. 25.00).";
-      if (n > 60) return "Monthly limit is $60. Enter a value between 0 and 60.";
+      if (n > GO_LIMITS.monthly) return `Monthly limit is $${GO_LIMITS.monthly}. Enter a value between 0 and ${GO_LIMITS.monthly}.`;
       return undefined;
     },
   });

--- a/src/goUsageTracker.ts
+++ b/src/goUsageTracker.ts
@@ -17,7 +17,7 @@ const BASELINE_STORAGE_KEY = "opencodego.usageBaseline.v1";
 const MAX_LOG_ENTRIES = 2000;
 
 /** OpenCode Go subscription limits in USD, from https://opencode.ai/docs/go */
-const GO_LIMITS = {
+export const GO_LIMITS = {
   session: 12,   // $12 per rolling 5-hour window
   weekly:  30,   // $30 per week (Mon–Mon UTC)
   monthly: 60,   // $60 per month (anchor-based)
@@ -249,11 +249,6 @@ export class GoUsageTracker {
     this.restore();
   }
 
-  /** Update the live cost resolver (e.g. after models.dev refresh). */
-  setCostResolver(resolver: CostResolver): void {
-    this.costResolver = resolver;
-  }
-
   /** Record a completed Go request. externalCost is from resolved metadata if available. */
   record(summary: TransportRequestSummary, externalCost?: ModelCost): void {
     const displayNameLower = summary.providerDisplayName.toLowerCase();
@@ -471,22 +466,20 @@ export class GoUsageTracker {
     const nowMs = Date.now();
     const summary = this.getSummary();
 
-    const currentBaselineSession = this.getActiveBaselineAmount("session", nowMs);
-    const currentBaselineWeekly = this.getActiveBaselineAmount("weekly", nowMs);
     const currentBaselineMonthly = this.getActiveBaselineAmount("monthly", nowMs);
-
-    const trackedSession = Math.max(0, summary.session.spent - currentBaselineSession);
-    const trackedWeekly = Math.max(0, summary.weekly.spent - currentBaselineWeekly);
     const trackedMonthly = Math.max(0, summary.monthly.spent - currentBaselineMonthly);
 
+    // Session & weekly: absolute targets — the display should show exactly
+    // what the user entered, regardless of tracked entries or prior baselines.
     this.baseline.session = {
-      amount: Math.max(0, targets.session - trackedSession),
+      amount: Math.max(0, targets.session),
       expiresAt: summary.session.resetsAt.getTime(),
     };
     this.baseline.weekly = {
-      amount: Math.max(0, targets.weekly - trackedWeekly),
+      amount: Math.max(0, targets.weekly),
       expiresAt: summary.weekly.resetsAt.getTime(),
     };
+    // Monthly: baseline fills the gap between tracked entries and the target.
     this.baseline.monthly = {
       amount: Math.max(0, targets.monthly - trackedMonthly),
       expiresAt: summary.monthly.resetsAt.getTime(),

--- a/src/goUsageTracker.ts
+++ b/src/goUsageTracker.ts
@@ -466,22 +466,29 @@ export class GoUsageTracker {
     const nowMs = Date.now();
     const summary = this.getSummary();
 
+    // For all periods: baseline = target - tracked. This can be negative
+    // (offsetting tracked entries downward) or positive (adding to tracked).
+    // Display = tracked + baseline = tracked + (target - tracked) = target.
+    // When the window rolls (5h session, Mon weekly, anchor monthly),
+    // expiresAt triggers, baseline is cleared, and display resets to 0.
+    const currentBaselineSession = this.getActiveBaselineAmount("session", nowMs);
+    const currentBaselineWeekly = this.getActiveBaselineAmount("weekly", nowMs);
     const currentBaselineMonthly = this.getActiveBaselineAmount("monthly", nowMs);
+
+    const trackedSession = Math.max(0, summary.session.spent - currentBaselineSession);
+    const trackedWeekly = Math.max(0, summary.weekly.spent - currentBaselineWeekly);
     const trackedMonthly = Math.max(0, summary.monthly.spent - currentBaselineMonthly);
 
-    // Session & weekly: absolute targets — the display should show exactly
-    // what the user entered, regardless of tracked entries or prior baselines.
     this.baseline.session = {
-      amount: Math.max(0, targets.session),
+      amount: targets.session - trackedSession,
       expiresAt: summary.session.resetsAt.getTime(),
     };
     this.baseline.weekly = {
-      amount: Math.max(0, targets.weekly),
+      amount: targets.weekly - trackedWeekly,
       expiresAt: summary.weekly.resetsAt.getTime(),
     };
-    // Monthly: baseline fills the gap between tracked entries and the target.
     this.baseline.monthly = {
-      amount: Math.max(0, targets.monthly - trackedMonthly),
+      amount: targets.monthly - trackedMonthly,
       expiresAt: summary.monthly.resetsAt.getTime(),
     };
 


### PR DESCRIPTION
## Summary

Fixes baseline editing bug where session/weekly targets silently failed on re-edit, adds status bar click → QuickPick for usage details, and improves input validation.

## Changes

### Fixed
- **Baseline editing now correctly recalculates on re-edit.** `setManualSpentTargets()` now computes `baseline = target - tracked` (without clamping to 0) for all three periods. This allows **negative baselines** that offset tracked entries downward, so `display = tracked + baseline = target` exactly. Previously, `Math.max(0, ...)` prevented negative baselines — when a user lowered a target below the tracked amount, the display never updated.
- **Input validation rejects non-numeric characters.** The usage target editor now validates input with a strict regex (`/^-?\\d+[.,]?\\d*$/`) that rejects strings like `60f` or `18asd`. Accepts both `.` and `,` as decimal separators for international users.
- **Status bar tooltip refreshes immediately after editing targets.** `refreshGoUsageStatusBar()` is now called right after `setManualSpentTargets()` so the hover tooltip updates without requiring a VS Code window reload.

### Added
- **Status bar click opens usage QuickPick.** Clicking the OpenCode Go usage status bar item now opens a QuickPick with session/weekly/monthly progress bars, usage percentages, and reset countdowns. Includes quick actions to \"Set spent targets…\" and \"Open full usage panel\".

## Testing

1. Set session/weekly/monthly targets → verify display shows exact values
2. Re-edit targets → verify values change (not sum)
3. Click status bar → QuickPick opens with usage summary
4. Verify tooltip updates immediately after editing targets
5. Try entering invalid input (e.g. `60f`, `18asd`) → should be rejected
6. Try entering `3,50` → should be accepted as `3.50`