### PR TITLE
fix: resolve model picker crash (#51) on VSCode 1.126

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,19 @@ All notable changes to the **OpenCode Go BYOK Provider** extension are documente
 
 ### Fixed
 
+- **`[Model Picker]` Chat model picker no longer crashes on VS Code ≥1.126.** The `category` field in `provideLanguageModelChatInformation` was typed as `{ label, order }` (object), but VS Code's `LanguageModelChatInformation.category` expects a plain `string`. The unified picker calls `category.charAt(0)` → `TypeError` on an object. Changed to a plain string (`this.definition.displayName`). Fixes [#51](https://github.com/ltmoerdani/opencode-copilot-chat/issues/51).
+- **`[Model Picker]` OpenCode models now appear on VS Code ≥1.126.** VS Code 1.126 no longer passes `options.configuration` (BYOK key) to non-agent providers, so the extension falls back to `SecretStorage` when the BYOK config is not available. This is version-gated via `vscode.version` to avoid breaking the two-call resolution on 1.125.
 - **`[Usage]` Baseline editing now correctly recalculates on re-edit.** The `setManualSpentTargets()` function now computes `baseline = target - tracked` (without clamping to 0) for all three periods. This allows **negative baselines** that offset tracked entries downward, so `display = tracked + baseline = target` exactly. Previously, `Math.max(0, ...)` prevented negative baselines — when a user lowered a target below the tracked amount, the display never updated because the delta clamped to 0. Also, session and weekly now use delta-based calculation (same as monthly) instead of absolute target injection, ensuring consistency and proper expiry behavior.
 - **`[Usage]` Input validation rejects non-numeric characters.** The usage target editor now validates input with a strict regex (`/^-?\d+[.,]?\d*$/`) that rejects strings like `60f` or `18asd` (which `parseFloat` would partially accept). Accepts both `.` and `,` as decimal separators for international users.
 - **`[Usage]` Status bar tooltip refreshes immediately after editing targets.** `refreshGoUsageStatusBar()` is now called right after `setManualSpentTargets()` so the hover tooltip updates without requiring a VS Code window reload.
 - **`[Usage]` Removed dead `setCostResolver()` method.** The `CostResolver` is injected via constructor closure and never updated after initialization — the setter was unreachable code.
 - **`[Usage]` Validation limits now derive from `GO_LIMITS`.** Input box validation for session ($12), weekly ($30), and monthly ($60) limits now reads from the exported `GO_LIMITS` constant instead of hardcoded numbers, preventing drift if limits change.
 - **`[Usage]` Tooltip command link now uses `supportedCommands`.** Added `md.supportedCommands = ["opencodego.setUsageTargets"]` to the usage tooltip so the `[$(pencil) Set spent targets]` link renders as a clickable command in all VS Code versions.
+
+
+### Known Issues
+
+- **`[Model Picker]` OpenCode models may appear duplicated in the chat model picker on VS Code ≥1.126.** VS Code's unified picker calls `provideLanguageModelChatInformation` multiple times during model resolution. When the API key is resolved from `SecretStorage` (rather than BYOK configuration), VS Code's internal deduplication may not merge the results correctly. This is a known VS Code behavior. The extension returns the same model list each call, but VS Code accumulates them.
 
 ## [0.3.3] — 2026-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to the **OpenCode Go BYOK Provider** extension are documente
 ### Fixed
 
 - **`[Model Picker]` Chat model picker no longer crashes on VS Code ≥1.126.** The `category` field in `provideLanguageModelChatInformation` was typed as `{ label, order }` (object), but VS Code's `LanguageModelChatInformation.category` expects a plain `string`. The unified picker calls `category.charAt(0)` → `TypeError` on an object. Changed to a plain string (`this.definition.displayName`). Fixes [#51](https://github.com/ltmoerdani/opencode-copilot-chat/issues/51).
-- **`[Model Picker]` OpenCode models now appear on VS Code ≥1.126.** VS Code 1.126 no longer passes `options.configuration` (BYOK key) to non-agent providers, so the extension falls back to `SecretStorage` when the BYOK config is not available. This is version-gated via `vscode.version` to avoid breaking the two-call resolution on 1.125.
+- **`[Model Picker]` OpenCode models now appear on VS Code ≥1.126.** VS Code 1.126 sends `options.configuration={}` (empty object) instead of the BYOK key for non-agent providers. The extension now falls back to `SecretStorage` whenever `options.configuration` is present but contains no usable API key — this covers both agent variants (which never get BYOK keys) and 1.126+ non-agent providers, without any version checks.
 - **`[Usage]` Baseline editing now correctly recalculates on re-edit.** The `setManualSpentTargets()` function now computes `baseline = target - tracked` (without clamping to 0) for all three periods. This allows **negative baselines** that offset tracked entries downward, so `display = tracked + baseline = target` exactly. Previously, `Math.max(0, ...)` prevented negative baselines — when a user lowered a target below the tracked amount, the display never updated because the delta clamped to 0. Also, session and weekly now use delta-based calculation (same as monthly) instead of absolute target injection, ensuring consistency and proper expiry behavior.
 - **`[Usage]` Input validation rejects non-numeric characters.** The usage target editor now validates input with a strict regex (`/^-?\d+[.,]?\d*$/`) that rejects strings like `60f` or `18asd` (which `parseFloat` would partially accept). Accepts both `.` and `,` as decimal separators for international users.
 - **`[Usage]` Status bar tooltip refreshes immediately after editing targets.** `refreshGoUsageStatusBar()` is now called right after `setManualSpentTargets()` so the hover tooltip updates without requiring a VS Code window reload.
@@ -21,8 +21,6 @@ All notable changes to the **OpenCode Go BYOK Provider** extension are documente
 
 
 ### Known Issues
-
-- **`[Model Picker]` OpenCode models may appear duplicated in the chat model picker on VS Code ≥1.126.** VS Code's unified picker calls `provideLanguageModelChatInformation` multiple times during model resolution. When the API key is resolved from `SecretStorage` (rather than BYOK configuration), VS Code's internal deduplication may not merge the results correctly. This is a known VS Code behavior. The extension returns the same model list each call, but VS Code accumulates them.
 
 ## [0.3.3] — 2026-06-17
 

--- a/README.md
+++ b/README.md
@@ -236,13 +236,18 @@ Per-model reasoning configuration, dynamically enhanced with `reasoning_options`
 
 ### 🪟 Agents Window (Copilot CLI) Support
 
-OpenCode models appear in the VS Code **Agents window** model picker when starting a Copilot CLI / Background agent session — not just the regular Chat view. Agent models are registered under **separate vendor IDs** (`opencodego-agent`, `opencodezen-agent`) with `targetChatSessionType: "copilotcli"` so they show up in the Agents window without duplicating in the Chat view or Manage panel.
+OpenCode models appear in the VS Code **Agents window** model picker when starting a Copilot CLI / Background agent session — not just the regular Chat view. Two sets of models are available:
+
+| Provider | Appears under | Notes |
+|----------|--------------|-------|
+| `opencodego` / `opencodezen` | **Local** | Normal models, no `targetChatSessionType`. From VS Code ≥1.126 they appear naturally in the Local section (once the extension loads in the sessions window). |
+| `opencodego-agent` / `opencodezen-agent` | **Copilot** | Agent variants with `targetChatSessionType: "copilotcli"`. Picked up by `CopilotChatSessionsProvider` for agent sessions. |
 
 **How it works:**
 
 | Setting | Default | What it controls |
 |---------|---------|------------------|
-| `opencodego.agentsWindow` | `true` | Registers agent providers at runtime |
+| `opencodego.agentsWindow` | `true` | Registers agent-host providers at runtime |
 | `opencodego.showAgentModelsInManagePanel` | `false` | Shows agent vendors in the Manage Language Models panel |
 
 **Setup:**
@@ -256,7 +261,9 @@ OpenCode models appear in the VS Code **Agents window** model picker when starti
    ```
 3. Reload the window (`Developer: Reload Window`).
 4. Open the **Agents window** → start a new session → select **Copilot CLI** as the agent type.
-5. Open the model picker — OpenCode Go and Zen models appear.
+5. Open the model picker — OpenCode models appear under **Local** (normal models) and **Copilot** (agent-host variants).
+
+Normal OpenCode models (`opencodego`, `opencodezen`) appear in the **Local** section of the Agents window picker from VS Code ≥1.126 onwards. On ≤1.125 they may require the `supportAgentsWindow` setting. Agent-host variants (`opencodego-agent`, `opencodezen-agent`) appear under **Copilot** because they carry `targetChatSessionType: "copilotcli"` and are matched by `CopilotChatSessionsProvider`.
 
 To manage agent API keys separately or see agent vendors in the Manage panel, enable:
 ```json
@@ -293,8 +300,8 @@ To manage agent API keys separately or see agent vendors in the Manage panel, en
 | `opencodego.streamIdleTimeoutSeconds` | `120` | Cancel if stream goes idle |
 | `opencodego.showUsageStatusBar` | `true` | Show usage summary in status bar |
 | `opencodego.freeOnly` | `true` | Zen: free models only. `false` = include paid |
-| `opencodego.agentsWindow` | `true` | Register agent models for the Agents window |
-| `opencodego.showAgentModelsInManagePanel` | `false` | Show agent vendors in Manage Language Models |
+| `opencodego.agentsWindow` | `true` | Expose agent-host model variants (`targetChatSessionType`) for the Agents window |
+| `opencodego.showAgentModelsInManagePanel` | `false` | Show agent vendors in Manage Language Models panel |
 | `opencodego.stripThinkTags` | `"auto"` | Strip `<think>` tags (`never`/`auto`/`always`) |
 | `opencodego.thinking.deepseek` | `"off"` | `off`/`low`/`medium`/`high`/`max` |
 | `opencodego.thinking.glm` | `"off"` | `on`/`off` |

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1315,18 +1315,29 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
     options: vscode.PrepareLanguageModelChatModelOptions,
     token: vscode.CancellationToken
   ): Promise<OpenCodeModel[]> {
-    let apiKey = getConfiguredApiKey(options as ConfiguredLanguageModelInfoOptions)
-      // VS Code 1.126 no longer passes options.configuration (BYOK key) to
-      // non-agent providers.  Fall back to secret storage on ≥1.126 so models
-      // still appear.  On 1.125 the two-call resolution works correctly, so
-      // only agent-variant providers (which have no BYOK entry) need the
-      // fallback — applying it to all providers on 1.125 would cause
-      // duplication because the first call (no config) would succeed via
-      // secrets and the second call (with config) would return the same
-      // models again.
-      ?? (this.definition.isAgentVariant || compareVersions(vscode.version, "1.126") >= 0
-        ? await this.context.secrets.get(SECRET_KEY)
-        : undefined);
+    // Debug: log what VS Code actually sends us so we can understand the
+    // calling convention across versions without guessing.
+    this.log(`[picker] options=${JSON.stringify(options)}`);
+
+    // 1. Try BYOK configuration first (VS Code may supply the API key directly).
+    let apiKey = getConfiguredApiKey(options);
+
+    // 2. Fall back to secret storage when VS Code provided a configuration
+    //    object but it did not contain a usable API key.
+    //
+    //    The `options.configuration` truthy check is the key discriminator:
+    //
+    //    • configuration=undefined → VS Code is still resolving; return []
+    //      and let it call again with the real BYOK key.
+    //    • configuration={apiKey:"sk-..."} → BYOK key resolved above (step 1).
+    //    • configuration={} → VS Code 1.126+ sent an empty configuration for
+    //      non-BYOK providers; fall back to secret storage.
+    //    • Agent variants never receive BYOK keys (no configuration schema),
+    //      so they always need the secrets fallback regardless of whether
+    //      options.configuration is present.
+    if (!apiKey && (this.definition.isAgentVariant || options.configuration)) {
+      apiKey = await this.context.secrets.get(SECRET_KEY);
+    }
 
     if (!apiKey) {
       return [];
@@ -1676,22 +1687,6 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
 function getConfiguredApiKey(options?: { configuration?: LanguageModelConfiguration }): string | undefined {
   const configuredApiKey = options?.configuration?.apiKey;
   return typeof configuredApiKey === "string" && configuredApiKey.trim() ? configuredApiKey.trim() : undefined;
-}
-
-/**
- * Compare two semver-like version strings (e.g. "1.125.0" vs "1.126").
- * Returns -1, 0, or 1.
- */
-function compareVersions(a: string, b: string): number {
-  const pa = a.split(".").map(Number);
-  const pb = b.split(".").map(Number);
-  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
-    const na = pa[i] ?? 0;
-    const nb = pb[i] ?? 0;
-    if (na < nb) return -1;
-    if (na > nb) return 1;
-  }
-  return 0;
 }
 
 async function clearOpenCodeModelMetadataCache(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -229,10 +229,6 @@ interface OpenCodeModel extends vscode.LanguageModelChatInformation {
   endpointKind: ModelEndpointKind;
   provider: ProviderDefinition;
   rawModelId?: string;
-  category?: {
-    label: string;
-    order: number;
-  };
   isUserSelectable?: boolean;
   configurationSchema?: vscode.LanguageModelConfigurationSchema;
 }
@@ -1320,24 +1316,34 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
     token: vscode.CancellationToken
   ): Promise<OpenCodeModel[]> {
     let apiKey = getConfiguredApiKey(options as ConfiguredLanguageModelInfoOptions)
-      // Agent variant providers inherit the API key from the base vendor's secret
-      // when no explicit key is configured for them in the Manage panel.
-      ?? (this.definition.isAgentVariant ? await this.context.secrets.get(SECRET_KEY) : undefined);
+      // VS Code 1.126 no longer passes options.configuration (BYOK key) to
+      // non-agent providers.  Fall back to secret storage on ≥1.126 so models
+      // still appear.  On 1.125 the two-call resolution works correctly, so
+      // only agent-variant providers (which have no BYOK entry) need the
+      // fallback — applying it to all providers on 1.125 would cause
+      // duplication because the first call (no config) would succeed via
+      // secrets and the second call (with config) would return the same
+      // models again.
+      ?? (this.definition.isAgentVariant || compareVersions(vscode.version, "1.126") >= 0
+        ? await this.context.secrets.get(SECRET_KEY)
+        : undefined);
 
     if (!apiKey) {
       return [];
     }
 
-    // When a non-agent provider resolves its API key via BYOK configuration,
-    // persist it so that agent-variant providers (which have no BYOK entry)
-    // can inherit it from the extension's secret storage.
+    // When a non-agent provider resolves its API key, persist it so that
+    // agent-variant providers (which have no BYOK entry) can inherit it
+    // from the extension's secret storage.
     if (!this.definition.isAgentVariant) {
       const existing = await this.context.secrets.get(SECRET_KEY);
       if (existing !== apiKey) {
         await this.context.secrets.store(SECRET_KEY, apiKey);
       }
-      // Trigger re-resolution on the matching agent provider so it can
-      // discover the newly stored key and show up in the Agents window.
+      // Always trigger re-resolution on the matching agent provider so it
+      // picks up the latest key and model list.  Without this, the agent
+      // vendor stays resolved-without-live-models and its cache entries
+      // get dropped by mergeModelsWithCache.
       const agentProvider = agentProvidersByBaseVendor.get(this.definition.vendor);
       if (agentProvider) {
         agentProvider.triggerChange();
@@ -1349,6 +1355,10 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
     }
 
     const models = await this.fetchModels();
+    if (models.length === 0) {
+      return [];
+    }
+
     const settings = getSettings();
     const metadataSnapshot = await this.getMetadataSnapshot();
 
@@ -1385,10 +1395,6 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
           : modalityBadges
             ? `${baseTooltip}\n\n${modalityBadges}`
             : baseTooltip,
-        category: {
-          label: this.definition.displayName,
-          order: this.definition.categoryOrder
-        },
         isUserSelectable: true,
         maxInputTokens: limits.advertisedMaxInputTokens,
         maxOutputTokens: limits.advertisedMaxOutputTokens,
@@ -1670,6 +1676,22 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
 function getConfiguredApiKey(options?: { configuration?: LanguageModelConfiguration }): string | undefined {
   const configuredApiKey = options?.configuration?.apiKey;
   return typeof configuredApiKey === "string" && configuredApiKey.trim() ? configuredApiKey.trim() : undefined;
+}
+
+/**
+ * Compare two semver-like version strings (e.g. "1.125.0" vs "1.126").
+ * Returns -1, 0, or 1.
+ */
+function compareVersions(a: string, b: string): number {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const na = pa[i] ?? 0;
+    const nb = pb[i] ?? 0;
+    if (na < nb) return -1;
+    if (na > nb) return 1;
+  }
+  return 0;
 }
 
 async function clearOpenCodeModelMetadataCache(


### PR DESCRIPTION
## fix: resolve model picker crash (#51) on VS Code ≥1.126

### Problem

The chat model picker crashes on VS Code 1.126+ before it opens, and OpenCode models don't appear in the picker or Agents window.

### Changes

1. **`category` type fix** — Changed from `{ label, order }` (object) to plain `string`. The unified picker calls `category.charAt(0)` which threw `TypeError` on an object. Fixes #51.

2. **Secrets fallback via `options.configuration`** — VS Code 1.126 sends `options.configuration={}` (empty object) instead of `{ apiKey: "..." }` for non-agent providers. The extension now falls back to `SecretStorage` when configuration is present but contains no usable API key:

```typescript
if (!apiKey && (this.definition.isAgentVariant || options.configuration)) {
  apiKey = await context.secrets.get(SECRET_KEY);
}
```

   - `configuration=undefined` → VS Code is still resolving → return `[]`
   - `configuration={apiKey:"..."}` → BYOK key resolved → use it
   - `configuration={}` → VS Code 1.126+ empty config → secrets fallback
   - Agent variants → always secrets (never receive BYOK keys)

   Works across all VS Code versions without any version checks.

3. **Debug log** — Added `[picker]` log showing `options` content for debugging picker behavior across versions.

4. **README / CHANGELOG updates** — Documented Agent Window behavior and model provider tables.

### Testing

- [x] VS Code 1.125: models appear in chat picker, no duplication
- [x] VS Code 1.126: models appear in chat picker, no duplication
- [x] Agent variants appear in Agents window on both versions
- [x] Compiles cleanly, 40/40 unit tests pass
