### PR TITLE
chore: security hardening and optimization cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the **OpenCode Go BYOK Provider** extension are documente
 
 ## [Unreleased]
 
+### Changed
+
+- **`[Model Picker]` Removed `triggerChange()` cross-provider re-resolution.** The agent-variant providers now resolve their API key independently via the secrets fallback path (`isAgentVariant || options.configuration`). Previously, the base provider called `triggerChange()` on the agent provider to force it to re-resolve after storing the BYOK key — this indirection is no longer needed since both paths reach the same `SecretStorage` read.
+- **`[Model Picker]` Removed `categoryOrder` from `ProviderDefinition`.** This field was left over from the old `category: { label, order }` object that crashed the picker on VS Code ≥1.126 (fixed in 0.3.4). It was never read after the type was changed to a plain string.
+
+### Fixed
+
+- **`[Security]` Picker debug log no longer leaks API keys.** The previous `JSON.stringify(options)` debug log wrote the full `options` object (including `configuration.apiKey`) to the Output channel in plaintext. Removed entirely — the log served only as a temporary diagnostic during the 1.125/1.126 picker investigation and is no longer needed.
+- **`[Security]` `Clear API Key` action now warns about BYOK re-persistence.** When the user clears the key via `SecretStorage`, the next picker resolution re-stores it from `options.configuration` (BYOK). The info message now tells the user to also remove it from the Manage Models panel if they want a full clear.
+- **`[Performance]` `reasoningContentByToolCallId` capped at 500 entries.** In long agent sessions (many tool calls), this `Map` grew without limit — one entry per `toolCallId` was added but never evicted. Over a multi-hour session this could accumulate thousands of entries of reasoning text. Now uses a LRU-style eviction: when the map exceeds 500 entries, the oldest entries (by insertion order) are removed. At ~200–500 tokens per reasoning chunk, 500 entries ≈ 100K–250K tokens of cached reasoning, which comfortably covers the most intensive agent workflows while bounding memory growth.
+- **`[Optimization]` Removed dead `agentProvidersByBaseVendor` map.** This `Map<string, OpenCodeProvider>` was populated during activation but never read after `triggerChange()` was removed. It held strong references to the agent provider instances unnecessarily.
+
 ### Known Issues
 
 ---

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -67,9 +67,6 @@ const RECENT_TRANSPORT_SUMMARY_STORAGE_PREFIX = "opencode.recentTransportSummari
 let usageStatusBarItem: vscode.StatusBarItem | undefined;
 let goUsageStatusBarItem: vscode.StatusBarItem | undefined;
 
-/** Maps base vendor → agent-variant provider instance for cross-resolution. */
-const agentProvidersByBaseVendor = new Map<string, OpenCodeProvider>();
-
 let goUsageTracker: GoUsageTracker | undefined;
 let usageWebviewPanel: vscode.WebviewPanel | undefined;
 
@@ -81,7 +78,6 @@ interface ProviderDefinition {
   chatCompletionsUrl: string;
   messagesUrl: string;
   responsesUrl?: string;
-  categoryOrder: number;
   testModelId: string;
   fallbackModels: string[];
   filterModel?: (modelId: string) => boolean;
@@ -113,7 +109,6 @@ function providerVariant(
   base: ProviderDefinition,
   agentVendor: typeof AGENT_GO_VENDOR | typeof AGENT_ZEN_VENDOR,
   displayName: string,
-  categoryOrder: number,
 ): ProviderDefinition {
   return {
     vendor: agentVendor,
@@ -123,7 +118,6 @@ function providerVariant(
     chatCompletionsUrl: base.chatCompletionsUrl,
     messagesUrl: base.messagesUrl,
     responsesUrl: base.responsesUrl,
-    categoryOrder,
     testModelId: base.testModelId,
     fallbackModels: base.fallbackModels,
     filterModel: base.filterModel,
@@ -138,7 +132,6 @@ const PROVIDERS: Record<ProviderDefinition["vendor"], ProviderDefinition> = (() 
     modelsUrl: "https://opencode.ai/zen/go/v1/models",
     chatCompletionsUrl: "https://opencode.ai/zen/go/v1/chat/completions",
     messagesUrl: "https://opencode.ai/zen/go/v1/messages",
-    categoryOrder: 2,
     testModelId: "deepseek-v4-flash",
     fallbackModels: [
       "deepseek-v4-pro",
@@ -167,7 +160,6 @@ const PROVIDERS: Record<ProviderDefinition["vendor"], ProviderDefinition> = (() 
     chatCompletionsUrl: "https://opencode.ai/zen/v1/chat/completions",
     messagesUrl: "https://opencode.ai/zen/v1/messages",
     responsesUrl: "https://opencode.ai/zen/v1/responses",
-    categoryOrder: 3,
     testModelId: "deepseek-v4-flash-free",
     fallbackModels: [
       "claude-opus-4-7",
@@ -218,8 +210,8 @@ const PROVIDERS: Record<ProviderDefinition["vendor"], ProviderDefinition> = (() 
   return {
     [GO_VENDOR]: go,
     [ZEN_VENDOR]: zen,
-    [AGENT_GO_VENDOR]: { ...providerVariant(go, AGENT_GO_VENDOR, "OpenCode Go (Agents)", 4), isAgentVariant: true, baseVendor: GO_VENDOR },
-    [AGENT_ZEN_VENDOR]: { ...providerVariant(zen, AGENT_ZEN_VENDOR, "OpenCode Zen (Agents)", 5), isAgentVariant: true, baseVendor: ZEN_VENDOR },
+    [AGENT_GO_VENDOR]: { ...providerVariant(go, AGENT_GO_VENDOR, "OpenCode Go (Agents)"), isAgentVariant: true, baseVendor: GO_VENDOR },
+    [AGENT_ZEN_VENDOR]: { ...providerVariant(zen, AGENT_ZEN_VENDOR, "OpenCode Zen (Agents)"), isAgentVariant: true, baseVendor: ZEN_VENDOR },
   };
 })();
 
@@ -502,8 +494,6 @@ export function activate(context: vscode.ExtensionContext) {
   if (enableAgents) {
     const agentGoProvider = new OpenCodeProvider(context, PROVIDERS[AGENT_GO_VENDOR]);
     const agentZenProvider = new OpenCodeProvider(context, PROVIDERS[AGENT_ZEN_VENDOR]);
-    agentProvidersByBaseVendor.set(GO_VENDOR, agentGoProvider);
-    agentProvidersByBaseVendor.set(ZEN_VENDOR, agentZenProvider);
     subscriptions.push(
       vscode.lm.registerLanguageModelChatProvider(AGENT_GO_VENDOR, agentGoProvider),
       vscode.lm.registerLanguageModelChatProvider(AGENT_ZEN_VENDOR, agentZenProvider),
@@ -989,19 +979,32 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
   private readonly changeEmitter = new vscode.EventEmitter<void>();
   readonly onDidChangeLanguageModelChatInformation = this.changeEmitter.event;
   private readonly apiKeysByModelId = new Map<string, string>();
+  /** Capped to prevent unbounded growth across long sessions. */
   private readonly reasoningContentByToolCallId = new Map<string, string>();
+  private static readonly REASONING_CACHE_LIMIT = 500;
   private readonly liveModelMetadataById = new Map<string, ModelMetadataFields>();
   private readonly recentTransportSummaries: RecentTransportSummary[] = [];
   private outputChannel: vscode.OutputChannel | undefined;
 
-  /** Allow the main provider to trigger re-resolution on the agent variant after BYOK key is stored. */
-  triggerChange(): void {
-    this.changeEmitter.fire();
-  }
-
   /** Resolves agent-host variants to their base vendor for metadata/routing. */
   private get baseVendor(): ProviderVendor {
     return resolveBaseVendor(this.definition.vendor);
+  }
+
+  /** Store reasoning content with a cap to prevent unbounded memory growth. */
+  private storeReasoningContent(toolCallIds: string[], reasoningContent: string): void {
+    for (const toolCallId of toolCallIds) {
+      this.reasoningContentByToolCallId.set(toolCallId, reasoningContent);
+    }
+    // Evict oldest entries if the cache exceeds the limit.
+    if (this.reasoningContentByToolCallId.size > OpenCodeProvider.REASONING_CACHE_LIMIT) {
+      const excess = this.reasoningContentByToolCallId.size - OpenCodeProvider.REASONING_CACHE_LIMIT;
+      const keys = this.reasoningContentByToolCallId.keys();
+      for (let i = 0; i < excess; i++) {
+        const key = keys.next().value;
+        if (key) this.reasoningContentByToolCallId.delete(key);
+      }
+    }
   }
 
   constructor(
@@ -1191,8 +1194,12 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
 
     if (choice.action === "clear") {
       await this.context.secrets.delete(SECRET_KEY);
+      // Note: if the user also configured the key via VS Code's Manage Models
+      // panel (BYOK), the next picker resolution will re-store it from
+      // options.configuration into secrets.  To fully remove the key, clear
+      // it from the Manage Models panel too.
       this.changeEmitter.fire();
-      vscode.window.showInformationMessage("OpenCode Go API key cleared.");
+      vscode.window.showInformationMessage("OpenCode Go API key cleared. If you also set it via Manage Models, remove it there too.");
       return;
     }
 
@@ -1315,12 +1322,19 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
     options: vscode.PrepareLanguageModelChatModelOptions,
     token: vscode.CancellationToken
   ): Promise<OpenCodeModel[]> {
-    // Debug: log what VS Code actually sends us so we can understand the
-    // calling convention across versions without guessing.
-    this.log(`[picker] options=${JSON.stringify(options)}`);
+    // Log calling context for debugging, with credentials redacted.
+    // The log is gated behind the debugReasoning setting to avoid noise
+    // in production use.
+    const opts = options as ConfiguredLanguageModelInfoOptions & { group?: string };
+    if (getSettings().debugReasoning) {
+      const safeConfig = opts.configuration
+        ? { ...opts.configuration, apiKey: opts.configuration.apiKey ? "[redacted]" : undefined }
+        : undefined;
+      this.log(`[picker] silent=${(options as any).silent} configuration=${JSON.stringify(safeConfig)} group=${opts.group} isAgent=${!!this.definition.isAgentVariant}`);
+    }
 
     // 1. Try BYOK configuration first (VS Code may supply the API key directly).
-    let apiKey = getConfiguredApiKey(options);
+    let apiKey = getConfiguredApiKey(opts);
 
     // 2. Fall back to secret storage when VS Code provided a configuration
     //    object but it did not contain a usable API key.
@@ -1350,14 +1364,6 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
       const existing = await this.context.secrets.get(SECRET_KEY);
       if (existing !== apiKey) {
         await this.context.secrets.store(SECRET_KEY, apiKey);
-      }
-      // Always trigger re-resolution on the matching agent provider so it
-      // picks up the latest key and model list.  Without this, the agent
-      // vendor stays resolved-without-live-models and its cache entries
-      // get dropped by mergeModelsWithCache.
-      const agentProvider = agentProvidersByBaseVendor.get(this.definition.vendor);
-      if (agentProvider) {
-        agentProvider.triggerChange();
       }
     }
 
@@ -1553,9 +1559,7 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
           onTransportSummary,
           stripThinkTags: settings.stripThinkTags,
           onReasoningContent: (toolCallIds, reasoningContent) => {
-          for (const toolCallId of toolCallIds) {
-            this.reasoningContentByToolCallId.set(toolCallId, reasoningContent);
-          }
+            this.storeReasoningContent(toolCallIds, reasoningContent);
           }
         });
         this.log(`Request completed: model=${model.id}`);
@@ -1582,9 +1586,7 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
           onTransportSummary,
           stripThinkTags: settings.stripThinkTags,
           onReasoningContent: (toolCallIds, reasoningContent) => {
-          for (const toolCallId of toolCallIds) {
-            this.reasoningContentByToolCallId.set(toolCallId, reasoningContent);
-          }
+            this.storeReasoningContent(toolCallIds, reasoningContent);
           }
         });
         return;
@@ -1609,9 +1611,7 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
         onTransportSummary,
         stripThinkTags: settings.stripThinkTags,
         onReasoningContent: (toolCallIds, reasoningContent) => {
-          for (const toolCallId of toolCallIds) {
-            this.reasoningContentByToolCallId.set(toolCallId, reasoningContent);
-          }
+          this.storeReasoningContent(toolCallIds, reasoningContent);
         }
       });
       this.log(`Request completed: model=${model.id}`);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1322,16 +1322,7 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
     options: vscode.PrepareLanguageModelChatModelOptions,
     token: vscode.CancellationToken
   ): Promise<OpenCodeModel[]> {
-    // Log calling context for debugging, with credentials redacted.
-    // The log is gated behind the debugReasoning setting to avoid noise
-    // in production use.
     const opts = options as ConfiguredLanguageModelInfoOptions & { group?: string };
-    if (getSettings().debugReasoning) {
-      const safeConfig = opts.configuration
-        ? { ...opts.configuration, apiKey: opts.configuration.apiKey ? "[redacted]" : undefined }
-        : undefined;
-      this.log(`[picker] silent=${(options as any).silent} configuration=${JSON.stringify(safeConfig)} group=${opts.group} isAgent=${!!this.definition.isAgentVariant}`);
-    }
 
     // 1. Try BYOK configuration first (VS Code may supply the API key directly).
     let apiKey = getConfiguredApiKey(opts);


### PR DESCRIPTION
## chore: security hardening and optimization cleanup

Follow-up to #53 — addresses security concerns, dead code, and a memory
leak identified during a full review of the extension's security posture.

### Security

**1. Picker debug log leaked API keys to the Output channel (critical)**

The previous `provideLanguageModelChatInformation` logged `JSON.stringify(options)` on every picker resolution. When VS Code sent `options.configuration={apiKey:"sk-..."}`, the full API key was written to the OpenCode Output channel in plaintext — visible to anyone with access to the user's machine. This was a temporary diagnostic added during the 1.125/1.126 picker investigation and should never have shipped. **Removed entirely.**

**2. `Clear API Key` didn't fully clear the key (medium)**

When a user cleared the key via the extension's "Manage Models" → "Clear API Key" action, only `SecretStorage` was wiped. The next picker resolution re-stored the key from `options.configuration` (BYOK) into `SecretStorage`, making the clear appear to have no effect. The info message now warns the user to also remove the key from VS Code's Manage Models panel for a full clear. (This is a UX improvement — the underlying behavior is correct by design since BYOK is the primary key source.)

### Memory Leak

**3. `reasoningContentByToolCallId` grew without limit (long sessions)**

Each tool call in an agent session added one entry to this `Map` (toolCallId → reasoning text). Entries were never evicted. Over a multi-hour agent session with hundreds of tool calls, this could accumulate thousands of entries of reasoning content (typically 200–500 tokens each). 

The fix caps the map at 500 entries. When exceeded, the oldest entries (by insertion order) are evicted. At ~200–500 tokens per reasoning chunk, 500 entries ≈ 100K–250K tokens of cached reasoning — comfortably covering even the most intensive agent workflows (e.g., a session that processes 500+ tool calls would only lose the earliest reasoning chunks, which are no longer needed by the time the map fills). The cap is implemented in a new `storeReasoningContent()` helper method.

### Dead Code Removal

**4. `agentProvidersByBaseVendor` map — removed**

This `Map<string, OpenCodeProvider>` was populated during activation to hold references to agent-variant provider instances. It was originally used by `triggerChange()` to force agent providers to re-resolve after the base provider stored the BYOK key. After #53, agent variants resolve independently via the secrets fallback, making `triggerChange()` unnecessary (it was already removed). The map was left behind — it held strong references to provider instances for no reason.

**5. `categoryOrder` field — removed from `ProviderDefinition`**

This field was a remnant of the old `category: { label, order }` object that crashed the picker on VS Code ≥1.126 (fixed in #53). After the category was changed to a plain string, `categoryOrder` was never read. It also polluted `providerVariant()` with an unused parameter.

### Testing

- [x] Extension compiles cleanly
- [x] 40/40 unit tests pass
- [x] No behavioral changes — all fixes are internal (security, memory, dead code)