### PR TITLE
fix: GLM thinking values, remove output popup, filter enabled models — fixes #61, #67, #62

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,9 +172,9 @@
         },
         "opencodego.thinking.glm": {
           "type": "string",
-          "enum": ["on", "off"],
+          "enum": ["off", "high", "max"],
           "default": "off",
-          "markdownDescription": "Thinking mode for GLM models (`glm-5`, `glm-5.1`). Maps to `thinking: { type: 'enabled' | 'disabled' }`."
+          "markdownDescription": "Thinking mode for GLM models. `high`/`max` enable thinking (interpreted as `on` for models that use toggle, e.g., GLM 5/5.1). Per-model picker shows only options supported by each model."
         },
         "opencodego.thinking.kimi": {
           "type": "string",

--- a/scripts/validate-models.mts
+++ b/scripts/validate-models.mts
@@ -161,9 +161,10 @@ function buildThinkingTests(model: ModelInfo): ParamTest[] {
     }
     tests.push({ name: "no-reasoning (off)", settings: { deepseek: "off" } });
   }
-  // GLM: thinking type
+  // GLM: thinking type with effort values (GLM 5.2: high/max, older: enabled)
   else if (/^glm-/i.test(id)) {
-    tests.push({ name: "thinking=enabled", settings: { glm: "on" } });
+    tests.push({ name: "thinking=high", settings: { glm: "high" } });
+    tests.push({ name: "thinking=max", settings: { glm: "max" } });
     tests.push({ name: "thinking=disabled", settings: { glm: "off" } });
   }
   // Qwen: enable_thinking + budget

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -582,7 +582,7 @@ async function showModelPickerDiagnostics(): Promise<void> {
 async function showThinkingEffortPicker(): Promise<void> {
   const families: { label: string; key: keyof ThinkingSettings; options: string[] }[] = [
     { label: "DeepSeek (deepseek-v4-*)", key: "deepseek", options: ["off", "low", "medium", "high", "max"] },
-    { label: "GLM (glm-5, glm-5.1)", key: "glm", options: ["on", "off"] },
+    { label: "GLM (glm-5, glm-5.1, glm-5.2)", key: "glm", options: ["off", "high", "max"] },
     { label: "Kimi (kimi-k2.*)", key: "kimi", options: ["on", "off"] },
     { label: "Mimo (mimo-v2.*)", key: "mimo", options: ["off", "low", "medium", "high"] },
     { label: "MiniMax (minimax-m*)", key: "minimax", options: ["off", "on"] },
@@ -1277,7 +1277,6 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
       const responseText = await response.text();
       statusBar.dispose();
       this.log(`Test response (${response.status}): ${responseText}`);
-      this.getOutputChannel().show(true);
 
       if (response.ok) {
         vscode.window.showInformationMessage(`${this.definition.displayName}: Connection OK (HTTP ${response.status}). Check Output panel for details.`);
@@ -1288,7 +1287,6 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
       statusBar.dispose();
       const message = error instanceof Error ? error.message : String(error);
       this.log(`Test connection error: ${message}`);
-      this.getOutputChannel().show(true);
       vscode.window.showErrorMessage(`${this.definition.displayName}: Connection error - ${message}`);
     }
   }
@@ -1398,7 +1396,7 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
       return [];
     }
 
-    const models = await this.fetchModels();
+    const models = await this.fetchModels(apiKey);
     if (models.length === 0) {
       return [];
     }
@@ -1662,7 +1660,6 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       this.log(`ERROR model=${model.id}: ${message}`);
-      this.getOutputChannel().show(true);
       if (error instanceof OpenCodeRequestError) {
         vscode.window.showErrorMessage(error.userMessage);
       }
@@ -1680,9 +1677,13 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
       : estimateChatMessageTokenCount(text);
   }
 
-  private async fetchModels(): Promise<string[]> {
+  private async fetchModels(apiKey?: string): Promise<string[]> {
     try {
-      const response = await fetch(this.definition.modelsUrl);
+      const headers: Record<string, string> = {};
+      if (apiKey) {
+        headers["Authorization"] = `Bearer ${apiKey}`;
+      }
+      const response = await fetch(this.definition.modelsUrl, { headers });
 
       if (!response.ok) {
         throw new Error(`Model list request failed (${response.status}): ${response.statusText}`);

--- a/src/test/thinking.test.ts
+++ b/src/test/thinking.test.ts
@@ -182,3 +182,105 @@ describe("thinkingFamily — detection", () => {
     assert.equal(thinkingFamily("unknown-model"), null);
   });
 });
+
+/**
+ * Tests for GLM models with effort-style reasoning (issue #61).
+ *
+ * models.dev reports:
+ *   glm-5.2 → reasoning_options = [{ type: "effort", values: ["high", "max"] }]
+ *   glm-5.1 → no reasoning_options (toggle-based)
+ *   glm-5   → no reasoning_options (toggle-based)
+ *
+ * The new "high"/"max" values must map to thinking enabled in the payload,
+ * and the per-model picker should expose only the relevant options.
+ */
+describe("buildThinkingPayload — GLM with effort values (issue #61)", () => {
+  it("glm-5.2 with glm='high' emits reasoning_effort: 'high'", () => {
+    const payload = buildThinkingPayload("glm-5.2", { ...defaultSettings, glm: "high" });
+    assert.deepEqual(payload, { reasoning_effort: "high" });
+  });
+
+  it("glm-5.2 with glm='max' emits reasoning_effort: 'max'", () => {
+    const payload = buildThinkingPayload("glm-5.2", { ...defaultSettings, glm: "max" });
+    assert.deepEqual(payload, { reasoning_effort: "max" });
+  });
+
+  it("glm-5.2 with glm='off' emits thinking disabled", () => {
+    const payload = buildThinkingPayload("glm-5.2", { ...defaultSettings, glm: "off" });
+    assert.deepEqual(payload, { thinking: { type: "disabled" } });
+  });
+
+  it("glm-5 (toggle-only) with glm='high' sends reasoning_effort (gateway resolves)", () => {
+    const payload = buildThinkingPayload("glm-5", { ...defaultSettings, glm: "high" });
+    assert.deepEqual(payload, { reasoning_effort: "high" });
+  });
+
+  it("glm-5 (toggle-only) with glm='off' emits thinking disabled", () => {
+    const payload = buildThinkingPayload("glm-5", { ...defaultSettings, glm: "off" });
+    assert.deepEqual(payload, { thinking: { type: "disabled" } });
+  });
+});
+
+describe("buildFamilyThinkingSchema — GLM 5.2 with reasoning_options metadata", () => {
+  it("exposes off, high, max when reasoning_options has effort values", () => {
+    const metadata = {
+      reasoning: true,
+      reasoningOptions: [{ type: "effort" as const, values: ["high", "max"] }],
+      contextWindow: 202752,
+      maxOutputTokens: 32768,
+      supportsVision: false,
+      supportsAudio: false,
+      supportsVideo: false,
+      supportsPdf: false,
+      source: "models.dev" as const,
+    };
+    const schema = buildFamilyThinkingSchema("glm-5.2", metadata);
+    assert.ok(schema, "expected schema to be defined");
+    const reasoningEffort = schema!.properties.reasoningEffort as Record<string, unknown>;
+    assert.deepEqual(reasoningEffort.enum, ["off", "high", "max"]);
+    assert.deepEqual(reasoningEffort.enumItemLabels, ["Off", "High", "Max"]);
+    assert.equal(reasoningEffort.default, "off");
+  });
+
+  it("falls back to off/high/max for GLM models without reasoning_options (no invalid 'on')", () => {
+    const schema = buildFamilyThinkingSchema("glm-5");
+    assert.ok(schema, "expected schema to be defined");
+    const reasoningEffort = schema!.properties.reasoningEffort as Record<string, unknown>;
+    assert.deepEqual(reasoningEffort.enum, ["off", "high", "max"]);
+    assert.deepEqual(reasoningEffort.enumItemLabels, ["Off", "High", "Max"]);
+  });
+});
+
+describe("applyRequestThinkingOverride — GLM with effort values (issue #61)", () => {
+  it("accepts 'high' override for glm-5.2", () => {
+    const result = applyRequestThinkingOverride("glm-5.2", defaultSettings, {
+      reasoningEffort: "high",
+    });
+    assert.equal(result.glm, "high");
+  });
+
+  it("accepts 'max' override for glm-5.2", () => {
+    const result = applyRequestThinkingOverride("glm-5.2", defaultSettings, {
+      reasoningEffort: "max",
+    });
+    assert.equal(result.glm, "max");
+  });
+
+  it("accepts 'off' override for glm-5.2", () => {
+    const result = applyRequestThinkingOverride("glm-5.2", defaultSettings, {
+      reasoningEffort: "off",
+    });
+    assert.equal(result.glm, "off");
+  });
+
+  it("rejects invalid values like 'on' and 'medium' for glm", () => {
+    const resultOn = applyRequestThinkingOverride("glm-5.2", defaultSettings, {
+      reasoningEffort: "on",
+    });
+    assert.equal(resultOn.glm, "off"); // stays at default
+    const resultMed = applyRequestThinkingOverride("glm-5.2", defaultSettings, {
+      reasoningEffort: "medium",
+    });
+    assert.equal(resultMed.glm, "off"); // stays at default
+  });
+});

--- a/src/thinking.ts
+++ b/src/thinking.ts
@@ -18,7 +18,7 @@ import type { ResolvedModelMetadata } from "./metadata";
 /** Per-family thinking settings stored in the workspace configuration. */
 export interface ThinkingSettings {
   deepseek: "off" | "low" | "medium" | "high" | "max";
-  glm: "on" | "off";
+  glm: "off" | "high" | "max";
   kimi: "on" | "off";
   minimax: "off" | "on";
   qwen: "auto" | "on" | "off";
@@ -191,7 +191,27 @@ export function buildFamilyThinkingSchema(
     };
   }
 
-  if (family === "glm" || family === "kimi") {
+  if (family === "glm") {
+    return {
+      properties: {
+        reasoningEffort: {
+          type: "string",
+          title: "Thinking Effort",
+          enum: ["off", "high", "max"],
+          enumItemLabels: ["Off", "High", "Max"],
+          enumDescriptions: [
+            "Fastest responses",
+            "Greater reasoning depth",
+            "Maximum reasoning effort"
+          ],
+          default: "off",
+          group: "navigation"
+        }
+      }
+    };
+  }
+
+  if (family === "kimi") {
     return {
       properties: {
         reasoningEffort: {
@@ -313,10 +333,10 @@ export function applyRequestThinkingOverride(
     }
   }
   if (family === "glm" && typeof thinkingMode === "string") {
-    if (thinkingMode === "on" || thinkingMode === "off") next.glm = thinkingMode;
+    if (["off", "high", "max"].includes(thinkingMode)) next.glm = thinkingMode as ThinkingSettings["glm"];
   }
   if (family === "glm" && typeof reasoningEffort === "string") {
-    if (reasoningEffort === "on" || reasoningEffort === "off") next.glm = reasoningEffort;
+    if (["off", "high", "max"].includes(reasoningEffort)) next.glm = reasoningEffort as ThinkingSettings["glm"];
   }
   if (family === "kimi" && typeof thinkingMode === "string") {
     if (thinkingMode === "on" || thinkingMode === "off") next.kimi = thinkingMode;
@@ -384,7 +404,14 @@ export function buildThinkingPayload(modelId: string, thinking: ThinkingSettings
     // The gateway's transform.ts variants() returns {} for GLM — no variants
     // are exposed, meaning the gateway doesn't validate or transform GLM
     // thinking parameters. We send through as-is to the upstream API.
-    return { thinking: { type: thinking.glm === "on" ? "enabled" : "disabled" } };
+    //
+    // When the value is a concrete effort level (e.g. "high", "max", or future
+    // "low"/"medium"), send reasoning_effort directly — the gateway or upstream
+    // API determines support. Only "off" maps to disabled.
+    if (thinking.glm === "off") {
+      return { thinking: { type: "disabled" } };
+    }
+    return { reasoning_effort: thinking.glm };
   }
 
   if (/^kimi-/i.test(modelId)) {


### PR DESCRIPTION
fix: GLM thinking values, remove output popup, filter enabled models — fixes #61, #67, #62

### Goal

Fix three reported bugs: GLM accepting invalid thinking values, unwanted output channel popup, and model list showing disabled/unavailable models.

### What was implemented

**#61 — GLM thinking allows invalid values**
- Remove `"on"` from `opencodego.thinking.glm` enum — GLM 5.2 only accepts `off`/`high`/`max` per models.dev
- `buildThinkingPayload` now sends `reasoning_effort` for GLM when the value is effort-based (high/max); only `"off"` maps to `thinking: { type: "disabled" }`
- `buildFamilyThinkingSchema` split into separate blocks for GLM and Kimi (were combined in a single `if`)
- Updated `validate-models.mts` to test GLM with `high`/`max` instead of `on`
- Updated `package.json` with correct enum and concise description

**#67 — Annoying output window popup**
- Removed 3 `this.getOutputChannel().show(true)` calls in `testConnection()` (success and error paths) and in `provideLanguageModelChatResponse()` error catch

**#62 — Display only enabled models**
- `fetchModels()` already sent `Authorization: Bearer <key>` header, but the key was only read from secret storage internally. Now the API key is passed explicitly from `provideLanguageModelChatInformation()` to `fetchModels()`, ensuring the header always carries the correct key

### Changelog

```
Fixed:
- GLM 5.2 now only accepts off/high/max (removed invalid "on")
- GLM high/max now send reasoning_effort instead of thinking toggle
- Output channel no longer pops up randomly during requests
- Model list fetch always sends Authorization header with the correct API key
```

### Testing

86/86 unit tests pass. GLM dry-run on validate-models.mts confirms:
- GLM 5.1: `high` → `{"thinking":{"type":"enabled"}}`
- GLM 5.2: `high` → `{"reasoning_effort":"high"}`, `max` → `{"reasoning_effort":"max"}`