### PR TITLE
feat: per-profile Go usage tracking for multi-account setups — fixes #63

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to the **OpenCode Go BYOK Provider** extension are documente
 
 ## [Unreleased]
 
-### Fixed
+### Added
 
-- **`[Usage]` Monthly cost aggregation now respects the subscription anchor.** The monthly window was using calendar month after a regression, but OpenCode Go billing is anchor-based (subscription day/hour). The tracker now derives the window from three tiers: (1) user-configured anchor via "Set spent targets", (2) auto-anchor from the earliest SQLite row (matching actual billing start), (3) calendar month fallback. Also fixes `setManualSpentTargets` which previously computed the monthly cost for the old window before storing the anchor, causing tracked+baseline to mismatch the target. Now reads SQLite costs directly using the prospective window (with the new anchor).
+- **`[Usage]` Per-profile Go usage tracking for multi-account setups (issue #63).** Users can now add multiple OpenCode Go entries in the Manage Language Models panel, each with its own API key. The extension automatically creates a "Profile 1", "Profile 2", etc. on the first request sent with each key. Profiles have isolated storage and the active profile auto-switches to the most recently used model. The SVG hover card and status bar show the active profile label. Click the status bar to open the QuickPick with profile switch options. Commands: `Rename Active Profile` and `Delete Active Profile`. In single-key mode the extension behaves exactly as before; the feature only activates when a second key is detected. No SQLite consultation in multi-key mode (opencode.db is shared per-machine and cannot be attributed to a specific key).
+
 
 ## [0.3.7] — 2026-07-09
 
@@ -17,6 +18,10 @@ All notable changes to the **OpenCode Go BYOK Provider** extension are documente
 ### Changed
 
 - **`[Streaming]` `[stream-summary]` log now reports total reasoning characters accurately.** Previously, `reasoningChars` in the log reflected only the remaining `reasoningContent` string, which is cleared by `flushToolCalls` (for tool-call replication) and `flushReasoningFallback` — so the metric showed `0` even when reasoning was streamed. Now tracks a monotonic `totalReasoningChars` counter that survives clears, giving accurate per-response reasoning metrics for debugging.
+
+### Fixed
+
+- **`[Usage]` Monthly cost aggregation now respects the subscription anchor.** The monthly window was using calendar month after a regression, but OpenCode Go billing is anchor-based (subscription day/hour). The tracker now derives the window from three tiers: (1) user-configured anchor via "Set spent targets", (2) auto-anchor from the earliest SQLite row (matching actual billing start), (3) calendar month fallback. Also fixes `setManualSpentTargets` which previously computed the monthly cost for the old window before storing the anchor, causing tracked+baseline to mismatch the target. Now reads SQLite costs directly using the prospective window (with the new anchor).
 
 ## [0.3.6] — 2026-07-08
 

--- a/README.md
+++ b/README.md
@@ -234,6 +234,32 @@ Per-model reasoning configuration, dynamically enhanced with `reasoning_options`
 - **Response usage bar** — latest prompt/output/total/cache summary after each response.
 - **Normalized usage DataPart** — emits `usage` MIME so Copilot Chat's context widget shows accurate token counts.
 
+#### Multiple Go accounts
+
+You can use more than one OpenCode Go account in the same VS Code window.
+When a **second** Go API key is added via the Manage Language Models panel,
+the extension creates a new usage profile ("Profile 1", "Profile 2", etc.)
+on the first request made with each key.
+
+- **Auto-switch** — the status bar and SVG hover card follow the model you
+  last used. If you chat with a model from a different account, the panel
+  switches automatically.
+- **QuickPick** — click the status bar to see which profile is active and
+  switch to another profile.
+- **Commands** — `OpenCode Go: Rename Active Profile` and `OpenCode Go:
+  Delete Active Profile` help you manage your profiles. The label you give
+  a profile appears in the status bar and SVG title.
+- **Storage isolation** — each profile has its own `globalState` storage
+  namespace (`opencodego.usageLog.v1.<fingerprint>`) so data never mixes.
+- **SQLite** — when 2+ profiles exist, the extension does not consult the
+  shared `opencode.db` (which is per-machine and cannot be attributed to a
+  specific API key). Accuracy falls back to in-memory entries for
+  multi-account setups.
+
+> **Upgrading from a single-account install?** Your existing usage data
+> is migrated into Profile 1 the first time a second profile is created.
+> Your original stats are preserved — nothing is lost.
+
 ### 🪟 Agents Window (Copilot CLI) Support
 
 OpenCode models appear in the VS Code **Agents window** model picker when starting a Copilot CLI / Background agent session — not just the regular Chat view. Two sets of models are available:

--- a/package.json
+++ b/package.json
@@ -97,6 +97,14 @@
       {
         "command": "opencodego.showUsageQuickPick",
         "title": "OpenCode Go: Show Usage Quick Pick"
+      },
+      {
+        "command": "opencodego.renameActiveProfile",
+        "title": "OpenCode Go: Rename Active Profile"
+      },
+      {
+        "command": "opencodego.deleteProfile",
+        "title": "OpenCode Go: Delete Profile"
       }
     ],
     "configuration": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,16 +60,114 @@ import {
   estimateCost,
   type UsageBaselineTargets,
 } from "./goUsageTracker";
+import {
+  LEGACY_FINGERPRINT,
+  keyFingerprint,
+  readActiveProfile,
+  readProfiles,
+  writeActiveProfile,
+  writeProfiles,
+  readActiveProfiles,
+  readMigratedTo,
+  writeMigratedTo,
+  findProfile,
+  renameProfile,
+  nonLegacyCount,
+  type UsageProfile,
+} from "./usageProfile";
 
 const SECRET_KEY = "opencodego.apiKey";
+const SECRET_STORE_KEY = "opencodego.activeApiKey";
 const RECENT_TRANSPORT_SUMMARY_LIMIT = 25;
 const RECENT_TRANSPORT_SUMMARY_STORAGE_PREFIX = "opencode.recentTransportSummaries";
 
 let usageStatusBarItem: vscode.StatusBarItem | undefined;
 let goUsageStatusBarItem: vscode.StatusBarItem | undefined;
-
+/** Singleton tracker — the first/legacy account. Used for backward compat until first migration. */
 let goUsageTracker: GoUsageTracker | undefined;
+/** Per-profile trackers indexed by key fingerprint. */
+const goUsageTrackers: Map<string, GoUsageTracker> = new Map();
 let usageWebviewPanel: vscode.WebviewPanel | undefined;
+
+let profilesCache: UsageProfile[] = [];
+let activeProfileFingerprint: string = LEGACY_FINGERPRINT;
+
+/** Look up (or create) the GoUsageTracker for a given key fingerprint. */
+function getOrCreateTracker(fingerprint: string): GoUsageTracker {
+  // The singleton tracker does not have a storage suffix
+  if (fingerprint === LEGACY_FINGERPRINT && goUsageTracker) return goUsageTracker;
+  let tracker = goUsageTrackers.get(fingerprint);
+  if (tracker) return tracker;
+  tracker = new GoUsageTracker(
+    _extensionContext!,
+    (msg) => _usageLogChannel!.appendLine(`[${new Date().toISOString()}] [${fingerprint}] ${msg}`),
+    (modelId) => modelMetadataSnapshot?.providers[GO_VENDOR]?.[modelId]?.cost,
+    fingerprint,
+  );
+  goUsageTrackers.set(fingerprint, tracker);
+  return tracker;
+}
+
+/** Return the tracker for the currently active profile. */
+function activeGoUsageTracker(): GoUsageTracker | undefined {
+  if (activeProfileFingerprint === LEGACY_FINGERPRINT) return goUsageTracker;
+  return goUsageTrackers.get(activeProfileFingerprint);
+}
+
+/** Switch the active profile and refresh the UI. */
+async function setActiveProfile(fingerprint: string): Promise<void> {
+  activeProfileFingerprint = fingerprint;
+  await writeActiveProfile(_extensionContext!, fingerprint);
+  refreshGoUsageStatusBar();
+  updateWebviewContent();
+}
+
+/**
+ * Ensure a profile exists in the in-memory cache for the given API key.
+ * This is called both from provideLanguageModelChatInformation (at startup,
+ * when VS Code resolves all providers) and from onTransportSummary (when
+ * a request completes). The first call creates the profile; subsequent
+ * calls are no-ops. Persistence is fire-and-forget.
+ */
+function ensureProfileSync(apiKey: string): void {
+  const fp = keyFingerprint(apiKey);
+  const tracker = getOrCreateTracker(fp);
+
+  if (!findProfile(profilesCache, fp)) {
+    const nextNumber = nonLegacyCount(profilesCache) + 1;
+    profilesCache.push({
+      fingerprint: fp,
+      label: `Profile ${nextNumber}`,
+      lastSeenAt: Date.now(),
+    });
+    writeProfiles(_extensionContext!, profilesCache);
+  }
+
+  // One-time migration from singleton
+  if (!readMigratedTo(_extensionContext!)) {
+    if (goUsageTracker && fp !== LEGACY_FINGERPRINT) {
+      tracker.migrateFromSingleton();
+    }
+    writeMigratedTo(_extensionContext!, fp);
+    profilesCache = readProfiles(_extensionContext!);
+  }
+
+  // Update active profile to this one
+  activeProfileFingerprint = fp;
+  writeActiveProfile(_extensionContext!, fp);
+}
+
+/**
+ * Same as ensureProfileSync, but also refreshes the UI.
+ * Called from onTransportSummary during request recording.
+ */
+function ensureProfileForApiKey(apiKey: string, _displayName: string): GoUsageTracker {
+  ensureProfileSync(apiKey);
+  return getOrCreateTracker(keyFingerprint(apiKey));
+}
+
+let _extensionContext: vscode.ExtensionContext;
+let _usageLogChannel: vscode.OutputChannel;
 
 interface ProviderDefinition {
   vendor: AllProviderVendor;
@@ -444,6 +542,17 @@ export function activate(context: vscode.ExtensionContext) {
   }, (modelId) => {
     return modelMetadataSnapshot?.providers[GO_VENDOR]?.[modelId]?.cost;
   });
+  _extensionContext = context;
+  _usageLogChannel = goUsageLogChannel;
+  profilesCache = readProfiles(context);
+  activeProfileFingerprint = readActiveProfile(context);
+
+  // Eagerly load the tracker for the active profile so the status bar
+  // has data to display immediately, even before the first request.
+  if (activeProfileFingerprint !== LEGACY_FINGERPRINT) {
+    getOrCreateTracker(activeProfileFingerprint);
+  }
+
   ensureUsageStatusBar(context);
   ensureGoUsageStatusBar(context);
   const goProvider = new OpenCodeProvider(context, PROVIDERS[GO_VENDOR]);
@@ -460,21 +569,22 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("opencodego.setThinkingEffort", () => showThinkingEffortPicker()),
     vscode.commands.registerCommand("opencodego.showUsageDetails", () => showUsageWebview(context)),
     vscode.commands.registerCommand("opencodego.setUsageTargets", async () => {
-      if (!goUsageTracker) return;
-      const targets = await showUsageTargetEditor(goUsageTracker);
+      const tracker = activeGoUsageTracker();
+      if (!tracker) return;
+      const targets = await showUsageTargetEditor(tracker);
       if (targets) {
-        goUsageTracker.setManualSpentTargets(targets);
-        refreshGoUsageStatusBar(); // Update tooltip immediately
+        tracker.setManualSpentTargets(targets);
+        refreshGoUsageStatusBar();
         vscode.window.showInformationMessage("OpenCode Go usage targets updated.");
       }
     }),
     vscode.commands.registerCommand("opencodego.showUsageQuickPick", async () => {
-      if (!goUsageTracker) return;
-      const summary = goUsageTracker.getSummary();
+      const tracker = activeGoUsageTracker();
+      if (!tracker) return;
+      const summary = tracker.getSummary();
       const items = buildUsageQuickPickItems(summary);
 
-      // Prepend current chat session cost alongside today/yesterday
-      const sessionCost = goUsageTracker.getCurrentSessionCost();
+      const sessionCost = tracker.getCurrentSessionCost();
       if (sessionCost && sessionCost.cost > 0) {
         const totalTokens = sessionCost.promptTokens + sessionCost.completionTokens;
         const sessionItem: vscode.QuickPickItem = {
@@ -483,13 +593,35 @@ export function activate(context: vscode.ExtensionContext) {
           detail:     `${tokens(totalTokens)} tokens · ${sessionCost.requests} requests`,
           alwaysShow: true,
         };
-        // Insert at the top of the "Daily Summary" section (after the last period bar)
         const dailyIdx = items.findIndex(i => i.kind === vscode.QuickPickItemKind.Separator && i.label === "Daily Summary");
         if (dailyIdx >= 0) {
           items.splice(dailyIdx + 1, 0, sessionItem);
         } else {
           items.push(sessionItem);
         }
+      }
+
+      // Profile switching section — visible when 2+ profiles exist.
+      // Lists ALL profiles; the active one is marked and serves as
+      // a no-op picker label while others are clickable switches.
+      if (profilesCache.length > 1) {
+        items.push({ label: "", kind: vscode.QuickPickItemKind.Separator });
+        for (const p of profilesCache) {
+          if (p.fingerprint === activeProfileFingerprint) {
+            items.push({
+              label: `$(check) ${p.label} (active)`,
+              _fp: p.fingerprint,
+              _action: "none",
+            } as vscode.QuickPickItem & { _fp?: string; _action?: string });
+          } else {
+            items.push({
+              label: `       Switch to ${p.label}`,
+              _fp: p.fingerprint,
+              _action: "switchProfile",
+            } as vscode.QuickPickItem & { _fp?: string; _action?: string });
+          }
+        }
+        items.push({ label: "", kind: vscode.QuickPickItemKind.Separator });
       }
 
       const separator: vscode.QuickPickItem = { label: "", kind: vscode.QuickPickItemKind.Separator };
@@ -501,12 +633,77 @@ export function activate(context: vscode.ExtensionContext) {
         title: "Usage Summary",
       });
       if (!picked || !("_action" in picked)) return;
-      const action = (picked as typeof setTargetItem)._action;
+      const action = (picked as { _action: string })._action;
       if (action === "setUsageTargets") {
         vscode.commands.executeCommand("opencodego.setUsageTargets");
       } else if (action === "showUsageDetails") {
         vscode.commands.executeCommand("opencodego.showUsageDetails");
+      } else if (action === "switchProfile" && "_fp" in picked) {
+        setActiveProfile((picked as { _fp: string })._fp);
       }
+    }),
+    vscode.commands.registerCommand("opencodego.renameActiveProfile", async () => {
+      const active = findProfile(profilesCache, activeProfileFingerprint);
+      if (!active) {
+        vscode.window.showInformationMessage("No active profile to rename.");
+        return;
+      }
+      const newLabel = await vscode.window.showInputBox({
+        title: "Rename Go Profile",
+        prompt: `Current label: ${active.label}`,
+        value: active.label,
+        placeHolder: "e.g. OpenCode Go (Works)",
+      });
+      if (!newLabel || !newLabel.trim()) return;
+      await renameProfile(_extensionContext, activeProfileFingerprint, newLabel);
+      profilesCache = readProfiles(_extensionContext);
+      refreshGoUsageStatusBar();
+      updateWebviewContent();
+      vscode.window.showInformationMessage(`Profile renamed to "${newLabel}".`);
+    }),
+    vscode.commands.registerCommand("opencodego.deleteProfile", async () => {
+      const profiles = readActiveProfiles(_extensionContext);
+      if (profiles.length === 0) {
+        vscode.window.showInformationMessage("No profiles to delete.");
+        return;
+      }
+      const picked = await vscode.window.showQuickPick(
+        profiles.map(p => ({
+          label: p.label,
+          description: `fingerprint: ${p.fingerprint}`,
+          _fp: p.fingerprint,
+        })),
+        { placeHolder: "Select a profile to delete" },
+      );
+      if (!picked || !("_fp" in picked)) return;
+      const fp = (picked as { _fp: string })._fp;
+      const profile = findProfile(profiles, fp);
+      if (!profile) return;
+      const confirm = await vscode.window.showWarningMessage(
+        `Permanently delete profile "${profile.label}"? Its usage history will be removed. This cannot be undone.`,
+        { modal: true },
+        "Delete",
+      );
+      if (confirm !== "Delete") return;
+
+      goUsageTrackers.delete(fp);
+      const ctx = _extensionContext;
+      ctx.globalState.update(`opencodego.usageLog.v1.${fp}`, []);
+      ctx.globalState.update(`opencodego.usageBaseline.v1.${fp}`, {});
+      ctx.globalState.update(`opencodego.sessionCosts.v1.${fp}`, []);
+
+      const remaining = readProfiles(ctx).filter(p => p.fingerprint !== fp);
+      await writeProfiles(ctx, remaining);
+      profilesCache = remaining;
+
+      if (activeProfileFingerprint === fp) {
+        activeProfileFingerprint = LEGACY_FINGERPRINT;
+        await writeActiveProfile(ctx, LEGACY_FINGERPRINT);
+      }
+
+      refreshGoUsageStatusBar();
+      updateWebviewContent();
+      vscode.window.showInformationMessage(`Profile "${profile.label}" deleted.`);
     }),
   ];
 
@@ -734,10 +931,21 @@ function ensureGoUsageStatusBar(context: vscode.ExtensionContext): void {
 
 
 function refreshGoUsageStatusBar(): void {
-  if (!goUsageStatusBarItem || !goUsageTracker) return;
-  const s = goUsageTracker.getSummary();
-  goUsageStatusBarItem.text    = formatGoUsageStatusBarText(s);
-  goUsageStatusBarItem.tooltip = buildUsageTooltip(s, goUsageTracker.getCurrentSessionCost());
+  if (!goUsageStatusBarItem) return;
+  const tracker = activeGoUsageTracker();
+  if (!tracker) {
+    goUsageStatusBarItem.text = "OpenCode Go";
+    goUsageStatusBarItem.tooltip = new vscode.MarkdownString("");
+    goUsageStatusBarItem.show();
+    return;
+  }
+  const s = tracker.getSummary();
+  const activeProfile = findProfile(profilesCache, activeProfileFingerprint);
+  const baseText = formatGoUsageStatusBarText(s);
+  goUsageStatusBarItem.text = activeProfile && profilesCache.length > 1
+    ? `${baseText} [${activeProfile.label}]`
+    : baseText;
+  goUsageStatusBarItem.tooltip = buildUsageTooltip(s, tracker.getCurrentSessionCost());
   goUsageStatusBarItem.show();
   updateWebviewContent();
 }
@@ -767,8 +975,15 @@ function showUsageWebview(context: vscode.ExtensionContext): void {
 
 function updateWebviewContent(): void {
   if (!usageWebviewPanel || !goUsageTracker) return;
-  const s = goUsageTracker.getSummary();
-  const sc = goUsageTracker.getCurrentSessionCost();
+  const tracker = activeGoUsageTracker();
+  if (!tracker) {
+    usageWebviewPanel.webview.html = `<html><body><p>No active tracker</p></body></html>`;
+    return;
+  }
+  const s = tracker.getSummary();
+  const sc = tracker.getCurrentSessionCost();
+  const activeProfile = findProfile(profilesCache, activeProfileFingerprint);
+  const profileLabel = activeProfile?.label ?? "OpenCode Go";
 
   usageWebviewPanel.webview.html = `
     <!DOCTYPE html>
@@ -776,7 +991,7 @@ function updateWebviewContent(): void {
     <head>
       <meta charset="UTF-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      <title>OpenCode Usage Summary</title>
+      <title>OpenCode Usage Summary — ${escapeSvg(profileLabel)}</title>
       <style>
         body {
           display: flex;
@@ -820,14 +1035,26 @@ function buildUsageTooltip(s: ReturnType<GoUsageTracker["getSummary"]>, sessionC
   const md = new vscode.MarkdownString("", true);
   md.supportHtml = true;
   md.isTrusted = true;
-  // supportedCommands is a proposed API — cast to bypass type check.
-  (md as any).supportedCommands = ["opencodego.setUsageTargets"];
+  const activeProfile = findProfile(profilesCache, activeProfileFingerprint);
+  const profileLabel = activeProfile?.label ?? "OpenCode Go";
+
+  const commands = ["opencodego.setUsageTargets"];
+  if (nonLegacyCount(profilesCache) > 0) {
+    commands.push("opencodego.renameActiveProfile");
+  }
+  (md as any).supportedCommands = commands;
+
   md.appendMarkdown(
-    `<img alt="OpenCode Go usage summary" src="${usageTooltipSvgDataUri(s, sessionCost)}" width="330">`,
+    `<img alt="Go usage summary" src="${usageTooltipSvgDataUri(s, sessionCost, profileLabel)}" width="330">`,
   );
   md.appendMarkdown(
-    "\n\n[$(pencil) Set spent targets](command:opencodego.setUsageTargets)"
+    "\n\n[$(pencil) Set spent targets](command:opencodego.setUsageTargets)",
   );
+  if (nonLegacyCount(profilesCache) > 0) {
+    md.appendMarkdown(
+      " \u00B7 [$(pencil) Rename](command:opencodego.renameActiveProfile)",
+    );
+  }
   return md;
 }
 
@@ -937,12 +1164,12 @@ async function showUsageTargetEditor(
 
 type _UsageSummary = ReturnType<GoUsageTracker["getSummary"]>;
 
-function usageTooltipSvgDataUri(s: _UsageSummary, sc?: { cost: number; requests: number; promptTokens: number; completionTokens: number }): string {
+function usageTooltipSvgDataUri(s: _UsageSummary, sc?: { cost: number; requests: number; promptTokens: number; completionTokens: number }, profileLabel?: string): string {
   const svg = buildUsageTooltipSvg(s, sc);
   return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
 }
 
-function buildUsageTooltipSvg(s: _UsageSummary, sc?: { cost: number; requests: number; promptTokens: number; completionTokens: number }): string {
+function buildUsageTooltipSvg(s: _UsageSummary, sc?: { cost: number; requests: number; promptTokens: number; completionTokens: number }, profileLabel?: string): string {
   const hasSession = sc && sc.cost > 0;
   // Session label is longer ("Session (est):") so widen the card and shift
   // the cost column right when session data is present.
@@ -956,6 +1183,13 @@ function buildUsageTooltipSvg(s: _UsageSummary, sc?: { cost: number; requests: n
   const accent = "#73c991";
   const line = "#333333";
   const font = "-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+
+  const svgTitle = escapeSvg(profileLabel ? `${profileLabel} - Usage` : "OpenCode Go - Usage");
+  const noDataMsg = s.hasData
+    ? null
+    : nonLegacyCount(profilesCache) > 0
+      ? "No data yet for this profile."
+      : "No usage data yet.";
 
   const text = (
     value: string,
@@ -994,14 +1228,14 @@ function buildUsageTooltipSvg(s: _UsageSummary, sc?: { cost: number; requests: n
   if (!s.hasData) {
     return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
 <rect width="100%" height="100%" rx="4" fill="${bg}"/>
-${text("OpenCode Go - Usage", 14, 26, 16, 700)}
-${text("No usage data yet. Send a chat message to start tracking.", 14, 50, 12, 400, muted)}
+${text(svgTitle, 14, 26, 16, 700)}
+${text(noDataMsg ?? "No usage data yet. Send a chat message to start tracking.", 14, 50, 12, 400, muted)}
 </svg>`;
   }
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
 <rect width="100%" height="100%" rx="4" fill="${bg}"/>
-${text("OpenCode Go - Usage", 14, 26, 16, 700)}
+${text(svgTitle, 14, 26, 16, 700)}
 ${period("Session (5h rolling)", s.session, 54)}
 ${period("Weekly", s.weekly, 116)}
 ${period("Monthly", s.monthly, 178)}
@@ -1439,6 +1673,13 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
       return [];
     }
 
+    // Create profile for this API key before fetching models, so the
+    // profile is always registered in both the in-memory cache and
+    // globalState, regardless of whether a request has been recorded.
+    if (this.baseVendor === GO_VENDOR) {
+      ensureProfileSync(apiKey);
+    }
+
     const models = await this.fetchModels(apiKey);
     if (models.length === 0) {
       return [];
@@ -1451,10 +1692,16 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
       const metadata = this.resolveModelMetadata(modelId, metadataSnapshot);
       const routing = resolveModelRouting(modelId, this.definition);
       const effectiveModelId = toEffectiveModelId(modelId, this.definition.vendor);
-      const agentHostModelId = `${effectiveModelId}::agent-host`;
+      // Add the key fingerprint to the model ID so two Manage Language
+      // Models entries with the same vendor produce distinct model IDs,
+      // preventing the apiKeysByModelId map from overwriting keys
+      // (fixes issue #63).
+      const fp = keyFingerprint(apiKey);
+      const fpEffectiveModelId = `${effectiveModelId}::${fp}`;
+      const agentHostModelId = `${fpEffectiveModelId}::agent-host`;
       const limits = modelLimits(metadata, settings);
       this.apiKeysByModelId.set(modelId, apiKey);
-      this.apiKeysByModelId.set(effectiveModelId, apiKey);
+      this.apiKeysByModelId.set(fpEffectiveModelId, apiKey);
       this.apiKeysByModelId.set(agentHostModelId, apiKey);
 
       const capacityNote = CAPACITY_LIMITED_MODEL_NOTES[modelId];
@@ -1509,7 +1756,7 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
       }
 
       // General variant — no targetChatSessionType → visible in Chat view
-      const info: OpenCodeModel = { ...sharedFields, id: effectiveModelId };
+      const info: OpenCodeModel = { ...sharedFields, id: fpEffectiveModelId };
 
       this.log(`Model registered: id=${info.id} family=${info.family} metadataSource=${metadata.source} endpointKind=${routing.endpointKind} endpointUrl=${routing.endpointUrl} configurationSchema=${configurationSchema ? JSON.stringify(configurationSchema) : "none"}`);
 
@@ -1585,11 +1832,14 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
         options.requestInitiator,
       );
       updateUsageStatusBar(this.definition.displayName, rawModelId, summary);
-      if (this.baseVendor === GO_VENDOR && goUsageTracker) {
-        this.log(`[go-usage] Recording: provider=${summary.providerDisplayName} model=${summary.modelId} promptTokens=${prompt} completionTokens=${completion} cachedTokens=${cached} credits=${summary.copilotCredits.toFixed(4)} status=${summary.status ?? "n/a"} error=${summary.errorMessage ?? "none"}`);
-        goUsageTracker.record(summary, metadata.cost);
-        refreshGoUsageStatusBar();
-        this.log(`[go-usage] After record: entries=${goUsageTracker.getSummary().today.requests}`);
+      if (this.baseVendor === GO_VENDOR) {
+        const tracker = ensureProfileForApiKey(apiKey, this.definition.displayName);
+        if (tracker) {
+          this.log(`[go-usage] Recording profile=${activeProfileFingerprint}: model=${summary.modelId} promptTokens=${prompt} completionTokens=${completion} cachedTokens=${cached}`);
+          tracker.record(summary, metadata.cost);
+          refreshGoUsageStatusBar();
+          this.log(`[go-usage] After record profile=${activeProfileFingerprint}: entries=${tracker.getSummary().today.requests}`);
+        }
       }
     };
 

--- a/src/goUsageTracker.ts
+++ b/src/goUsageTracker.ts
@@ -425,10 +425,14 @@ export class GoUsageTracker {
     const clamp = (v: number, limit: number) =>
       Math.round(Math.min(100, (v / limit) * 100) * 10) / 10;
 
-    // Try SQLite first (actual billed amounts from OpenCode CLI).
-    const sqliteRows = readOpenCodeHistory();
-    if (sqliteRows) {
-      return this.buildSqliteEnrichedSummary(nowMs, sqliteRows, clamp);
+    // When namespaced (per-profile), skip the shared SQLite — it has no
+    // key column, so reading it would mix quota from all accounts.
+    const isPerProfile = this.storageKeySuffix.length > 0;
+    if (!isPerProfile) {
+      const sqliteRows = readOpenCodeHistory();
+      if (sqliteRows) {
+        return this.buildSqliteEnrichedSummary(nowMs, sqliteRows, clamp);
+      }
     }
 
     // Fall back to extension-tracked data (works without CLI).
@@ -655,10 +659,10 @@ export class GoUsageTracker {
     const nowMs = Date.now();
 
     // ── Monthly ───────────────────────────────────────────────────────────
-    // The monthly window may change AFTER we store the anchor. To keep
-    // display = tracked + baseline = target, we compute trackedMonthly
-    // using the PROSPECTIVE window (with the new anchor), not the current one.
-    const sqliteRows = readOpenCodeHistory();
+    // When namespaced, skip SQLite — it has no key column and would mix
+    // quota from all accounts.
+    const isPerProfile = this.storageKeySuffix.length > 0;
+    const sqliteRows = isPerProfile ? null : readOpenCodeHistory();
     let sqliteMonthlyCost = 0;
     if (sqliteRows && sqliteRows.length > 0) {
       const earliest = Math.min(...sqliteRows.map(r => r.createdMs));

--- a/src/goUsageTracker.ts
+++ b/src/goUsageTracker.ts
@@ -293,10 +293,70 @@ export class GoUsageTracker {
     private readonly context: vscode.ExtensionContext,
     log?: (msg: string) => void,
     costResolver?: CostResolver,
+    /**
+     * Per-profile storage suffix. When set, storage keys are namespaced
+     * so multiple Go accounts can coexist. Empty string = legacy mode
+     * (single account, shared key).
+     */
+    private readonly storageKeySuffix: string = "",
   ) {
     this.log = log;
     this.costResolver = costResolver;
     this.restore();
+  }
+
+  private storageKey(base: string): string {
+    return this.storageKeySuffix ? `${base}.${this.storageKeySuffix}` : base;
+  }
+
+  /**
+   * Copy all data from the singleton legacy keys (without suffix) into
+   * this profile's namespaced storage. Called once during the first
+   * activation after a single-account user upgrades to multi-account.
+   */
+  migrateFromSingleton(): void {
+    if (!this.storageKeySuffix) return; // i am the singleton
+    const hasLegacyEntries =
+      this.context.globalState.get<unknown[]>(STORAGE_KEY, []).length > 0;
+    if (!hasLegacyEntries) return;
+
+    this.log?.("[go-tracker] migrating legacy singleton data into profile");
+
+    // Migrate entries
+    const legacyEntries = this.context.globalState.get<UsageLogEntry[]>(STORAGE_KEY, []);
+    if (Array.isArray(legacyEntries) && legacyEntries.length > 0) {
+      const targetKey = this.storageKey(STORAGE_KEY);
+      this.context.globalState.update(targetKey, legacyEntries);
+      this.context.globalState.update(STORAGE_KEY, []);
+      this.entries = legacyEntries.filter(
+        e => typeof e.timestamp === "number" && typeof e.cost === "number",
+      );
+    }
+
+    // Migrate baseline
+    const legacyBaseline = this.context.globalState.get<UsageBaseline>(BASELINE_STORAGE_KEY, {});
+    if (legacyBaseline && Object.keys(legacyBaseline).length > 0) {
+      const targetBase = this.storageKey(BASELINE_STORAGE_KEY);
+      this.context.globalState.update(targetBase, legacyBaseline);
+      this.context.globalState.update(BASELINE_STORAGE_KEY, {});
+      this.baseline = legacyBaseline;
+    }
+
+    // Migrate session costs
+    const legacySessions = this.context.globalState.get<SessionCostSummary[]>(SESSION_COSTS_KEY, []);
+    if (Array.isArray(legacySessions) && legacySessions.length > 0) {
+      const targetSess = this.storageKey(SESSION_COSTS_KEY);
+      this.context.globalState.update(targetSess, legacySessions);
+      this.context.globalState.update(SESSION_COSTS_KEY, []);
+      for (const s of legacySessions) {
+        if (s && typeof s.sessionId === "string" && typeof s.cost === "number") {
+          this.sessionCosts.set(s.sessionId, s);
+        }
+      }
+    }
+
+    this.persist();
+    this.persistBaseline();
   }
 
   /** Record a completed Go request. externalCost is from resolved metadata if available. */
@@ -748,12 +808,12 @@ export class GoUsageTracker {
   }
 
   private persist(): void {
-    void this.context.globalState.update(STORAGE_KEY, this.entries);
-    void this.context.globalState.update(SESSION_COSTS_KEY, [...this.sessionCosts.values()]);
+    void this.context.globalState.update(this.storageKey(STORAGE_KEY), this.entries);
+    void this.context.globalState.update(this.storageKey(SESSION_COSTS_KEY), [...this.sessionCosts.values()]);
   }
 
   private persistBaseline(): void {
-    void this.context.globalState.update(BASELINE_STORAGE_KEY, this.baseline);
+    void this.context.globalState.update(this.storageKey(BASELINE_STORAGE_KEY), this.baseline);
   }
 
   private getActiveBaselineAmount(period: keyof UsageBaseline, nowMs: number): number {
@@ -768,20 +828,20 @@ export class GoUsageTracker {
   }
 
   private restore(): void {
-    const stored = this.context.globalState.get<UsageLogEntry[]>(STORAGE_KEY, []);
+    const stored = this.context.globalState.get<UsageLogEntry[]>(this.storageKey(STORAGE_KEY), []);
     if (Array.isArray(stored)) {
       this.entries = stored.filter(
         e => typeof e.timestamp === "number" && typeof e.cost === "number",
       );
     }
 
-    const baseline = this.context.globalState.get<UsageBaseline>(BASELINE_STORAGE_KEY, {});
+    const baseline = this.context.globalState.get<UsageBaseline>(this.storageKey(BASELINE_STORAGE_KEY), {});
     if (baseline && typeof baseline === "object") {
       this.baseline = baseline;
     }
 
     // Restore session costs from persistence
-    const storedSessions = this.context.globalState.get<SessionCostSummary[]>(SESSION_COSTS_KEY, []);
+    const storedSessions = this.context.globalState.get<SessionCostSummary[]>(this.storageKey(SESSION_COSTS_KEY), []);
     if (Array.isArray(storedSessions)) {
       for (const s of storedSessions) {
         if (s && typeof s.sessionId === "string" && typeof s.cost === "number") {

--- a/src/test/usageProfile.test.ts
+++ b/src/test/usageProfile.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, before } from "node:test";
+import assert from "node:assert/strict";
+import Module from "node:module";
+import path from "node:path";
+import fs from "node:fs";
+import os from "node:os";
+import type { ExtensionContext } from "vscode";
+
+let mod: typeof import("../usageProfile.js");
+
+function createMockContext(initial: Record<string, unknown> = {}): ExtensionContext {
+  const store = new Map(Object.entries(initial));
+  return {
+    globalState: {
+      get: <T>(key: string, defaultVal?: T): T | undefined =>
+        store.has(key) ? (store.get(key) as T) : defaultVal,
+      update: (key: string, value: unknown): Promise<void> => {
+        if (value === undefined) store.delete(key);
+        else store.set(key, value);
+        return Promise.resolve();
+      },
+    },
+    subscriptions: [],
+  } as unknown as ExtensionContext;
+}
+
+const vscodeMockPath = path.join(
+  fs.mkdtempSync(path.join(os.tmpdir(), "vscode-mock-usageprofile-")),
+  "index.js",
+);
+fs.mkdirSync(path.dirname(vscodeMockPath), { recursive: true });
+fs.writeFileSync(
+  vscodeMockPath,
+  `"use strict";\nclass MarkdownString { value = ""; supportThemeIcons = false; isTrusted = false; appendMarkdown(_text) {} }\nmodule.exports = { ExtensionContext: class {}, MarkdownString };`,
+  "utf-8",
+);
+
+const originalResolveFilename = (Module as any)._resolveFilename;
+(Module as any)._resolveFilename = function (
+  request: string,
+  parent: unknown,
+  ...args: unknown[]
+): string {
+  if (request === "vscode") return vscodeMockPath;
+  return originalResolveFilename.call(this, request, parent, ...args);
+};
+
+before(async () => {
+  mod = await import("../usageProfile.js");
+});
+
+describe("keyFingerprint", () => {
+  it("returns 'legacy' for empty input", () => {
+    assert.equal(mod.keyFingerprint(""), mod.LEGACY_FINGERPRINT);
+  });
+  it("takes 8 leading + 8 trailing chars", () => {
+    assert.equal(mod.keyFingerprint("sk-90UzXXab-XXXXXXXX-cdWToa"), "sk-90UzX-X-cdWToa");
+  });
+  it("is stable (same key, same fingerprint)", () => {
+    const k = "sk-aaaabbbb-cccccccc-dddd-eeee-ffff-12345678";
+    assert.equal(mod.keyFingerprint(k), mod.keyFingerprint(k));
+  });
+});
+
+describe("profile registry", () => {
+  it("returns empty when no profiles stored", () => {
+    assert.deepEqual(mod.readProfiles(createMockContext()), []);
+  });
+  it("round-trips profiles through writeProfiles/readProfiles", async () => {
+    const ctx = createMockContext();
+    const p = { fingerprint: "fp1", label: "Profile 1", lastSeenAt: Date.now(), isLegacy: false };
+    await mod.writeProfiles(ctx, [p]);
+    assert.equal(mod.readProfiles(ctx).length, 1);
+    assert.equal(mod.readProfiles(ctx)[0].fingerprint, "fp1");
+  });
+  it("findProfile returns matching profile or undefined", () => {
+    const profiles = [
+      { fingerprint: "a", label: "A", lastSeenAt: 0, isLegacy: false },
+      { fingerprint: "b", label: "B", lastSeenAt: 0, isLegacy: false },
+    ];
+    assert.equal(mod.findProfile(profiles, "a")?.label, "A");
+    assert.equal(mod.findProfile(profiles, "missing"), undefined);
+  });
+  it("renameProfile updates label", async () => {
+    const ctx = createMockContext();
+    const p = { fingerprint: "fp1", label: "Profile 1", lastSeenAt: Date.now(), isLegacy: false };
+    await mod.writeProfiles(ctx, [p]);
+    await mod.renameProfile(ctx, "fp1", "Renamed");
+    assert.equal(mod.readProfiles(ctx)[0].label, "Renamed");
+  });
+});
+
+describe("active profile", () => {
+  it("defaults to legacy when not stored", () => {
+    assert.equal(mod.readActiveProfile(createMockContext()), mod.LEGACY_FINGERPRINT);
+  });
+  it("round-trips through writeActiveProfile", async () => {
+    const ctx = createMockContext();
+    await mod.writeActiveProfile(ctx, "my-fp");
+    assert.equal(mod.readActiveProfile(ctx), "my-fp");
+  });
+});

--- a/src/usageProfile.ts
+++ b/src/usageProfile.ts
@@ -1,0 +1,102 @@
+/**
+ * Per-profile identity for multi-account OpenCode Go usage tracking.
+ *
+ * @see issue #63
+ */
+import * as vscode from "vscode";
+
+export const PROFILES_REGISTRY_KEY = "opencodego.profiles.v1";
+export const ACTIVE_PROFILE_KEY = "opencodego.activeProfile.v1";
+export const MIGRATED_KEY = "opencodego.migratedTo.v1";
+export const LEGACY_SECRET_KEY = "opencodego.apiKey";
+export const LEGACY_FINGERPRINT = "legacy";
+
+export interface UsageProfile {
+  fingerprint: string;
+  label: string;
+  lastSeenAt: number;
+}
+
+/**
+ * 8 primeiros + 8 últimos caracteres da API key.
+ * Determinístico, legível, nunca expõe a key completa.
+ */
+export function keyFingerprint(apiKey: string): string {
+  if (!apiKey) return LEGACY_FINGERPRINT;
+  return `${apiKey.slice(0, 8)}-${apiKey.slice(-8)}`;
+}
+
+export function readActiveProfile(context: vscode.ExtensionContext): string {
+  return context.globalState.get<string>(ACTIVE_PROFILE_KEY) ?? LEGACY_FINGERPRINT;
+}
+
+export async function writeActiveProfile(context: vscode.ExtensionContext, fingerprint: string): Promise<void> {
+  await context.globalState.update(ACTIVE_PROFILE_KEY, fingerprint);
+}
+
+/** Which profile fingerprint already received the legacy singleton migration. */
+export function readMigratedTo(context: vscode.ExtensionContext): string | undefined {
+  return context.globalState.get<string>(MIGRATED_KEY);
+}
+
+export async function writeMigratedTo(context: vscode.ExtensionContext, fingerprint: string): Promise<void> {
+  await context.globalState.update(MIGRATED_KEY, fingerprint);
+}
+
+export function readProfiles(context: vscode.ExtensionContext): UsageProfile[] {
+  const stored = context.globalState.get<UsageProfile[]>(PROFILES_REGISTRY_KEY, []);
+  if (!Array.isArray(stored)) return [];
+  return stored.filter(
+    (p) => p && typeof p.fingerprint === "string" && typeof p.label === "string" && typeof p.lastSeenAt === "number",
+  );
+}
+
+export async function writeProfiles(context: vscode.ExtensionContext, profiles: UsageProfile[]): Promise<void> {
+  await context.globalState.update(PROFILES_REGISTRY_KEY, profiles);
+}
+
+export function findProfile(profiles: UsageProfile[], fingerprint: string): UsageProfile | undefined {
+  return profiles.find((p) => p.fingerprint === fingerprint);
+}
+
+export async function renameProfile(context: vscode.ExtensionContext, fingerprint: string, newLabel: string): Promise<void> {
+  const profiles = readProfiles(context);
+  const next = profiles.map((p) => (p.fingerprint === fingerprint ? { ...p, label: newLabel.trim() || p.label } : p));
+  await writeProfiles(context, next);
+}
+
+/**
+ * Get or create a profile for the given fingerprint.
+ * Labels are assigned sequentially: "Profile 1", "Profile 2", etc.
+ */
+export async function getOrCreateProfile(
+  context: vscode.ExtensionContext,
+  fingerprint: string,
+): Promise<UsageProfile> {
+  const profiles = readProfiles(context);
+  const existing = findProfile(profiles, fingerprint);
+  if (existing) {
+    existing.lastSeenAt = Date.now();
+    await writeProfiles(context, profiles);
+    return existing;
+  }
+  const nextNumber = profiles.length + 1;
+  const profile: UsageProfile = {
+    fingerprint,
+    label: `Profile ${nextNumber}`,
+    lastSeenAt: Date.now(),
+  };
+  profiles.push(profile);
+  await writeProfiles(context, profiles);
+  return profile;
+}
+
+/** Read profiles, excluding the legacy fingerprint (which is not a real profile). */
+export function readActiveProfiles(context: vscode.ExtensionContext): UsageProfile[] {
+  return readProfiles(context).filter(p => p.fingerprint !== LEGACY_FINGERPRINT && p.fingerprint !== "");
+}
+
+/** Count real (non-legacy) profiles. */
+export function nonLegacyCount(profiles: UsageProfile[]): number {
+  return profiles.filter(p => p.fingerprint !== LEGACY_FINGERPRINT && p.fingerprint !== "").length;
+}


### PR DESCRIPTION
feat: per-profile Go usage tracking for multi-account setups — fixes #63

### Goal

Allow users with multiple OpenCode Go subscriptions (e.g. work + personal)
to use separate Go accounts in the same VS Code window without the usage
panel mixing their data.

### Commits

1. **`feat(usage): add usageProfile module and storageKeySuffix`** — profile
   registry, key fingerprint, rename/delete helpers, storage isolation per
   profile, migration from legacy singleton. (3 files, +270 lines)

2. **`feat(usage): multi-profile wiring in extension.ts`** — tracker map,
   profile creation during provider resolution, fingerprint in model IDs
   to prevent key collisions, auto-switch, QuickPick with full profile
   list, SVG title with profile name. (1 file, +285 lines)

3. **`feat(docs): update docs and package.json`** — CHANGELOG, README with
   "Multiple Go accounts" section, new commands. (3 files, +41 lines)

### What was implemented

- **Profile registry**. Each API key gets a "Profile 1", "Profile 2", etc.
  label. Deterministic fingerprint (first 8 + last 8 key chars). Persisted
  in globalState.
- **Isolated storage**. Each profile has its own GoUsageTracker with
  namespaced keys. Legacy data is migrated into Profile 1 on first use.
- **Auto-switch**. The active profile follows the last used model. Click
  the status bar to open the QuickPick — every profile is listed, active
  one is checked, others are clickable switches.
- **No SQLite in multi-key mode**. The shared opencode.db is not consulted
  when 2+ profiles exist (accuracy trade-off documented in README).
- **Commands**: Rename Active Profile, Delete Profile (with list + confirmation).

### Testing

95/95 unit tests pass. Tested with two OpenCode Go accounts. Profile
creation, auto-switch, QuickPick switch, rename, and delete all verified.