### PR TITLE
fix(streaming): flush tool calls only at stream end (fixes #98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the **OpenCode Go BYOK Provider** extension are documented here.
 
+## [0.4.5] — 2026-08-03
+
+### Fixed
+
+- **`[Streaming]` Premature tool-call flush caused empty `<invoke>` calls and an unrecoverable tool-calling loop (#98).** The 0.4.4 fix for gpt-5.6-luna (#93) flushed accumulated tool calls whenever `finish_reason` was `null`/`undefined` and tool calls were pending. Standard OpenAI-compatible streams (DeepSeek-V4 via OpenCode Zen, plus Kimi, GLM, Qwen non-plus, MiniMax non-m2.x, MiMo) report `finish_reason: null` on EVERY intermediate chunk, so the first tool-call delta chunk flushed an INCOMPLETE call — empty arguments parsed as `{}`, and VS Code rendered `<invoke>` without `<parameter>`. The model then looped retrying the malformed call. `OpenAiResponseExtractor` now flushes ONLY on `finish_reason === "tool_calls"`; gateways that omit it (gpt-5.6-luna on OpenCode Go) are flushed once at end-of-stream via the new `flushRemainingToolCalls()`, so #93 stays fixed. Tool-call accumulation was extracted into a pure, unit-tested `ToolCallAccumulator` (`src/toolCallAccumulator.ts`, no `vscode` import). Documented in `docs/issues/42-20260803-premature-tool-call-flush.md`.
+
 ## [0.4.4] — 2026-07-25
 
 ### Fixed

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -1,5 +1,5 @@
 # 🧠 OPENCODE COPILOT CHAT DEVLOG
-**Branch:** `fix/mimo-thinking-budget` | **Updated:** 2026-07-23 Asia/Jakarta | **Current Phase:** Issue #36 — ✅ Fixed, ready to push
+**Branch:** `xianhongtao/issue98` | **Updated:** 2026-08-03 Asia/Jakarta | **Current Phase:** Issue #98 — premature tool-call flush regression, fix implemented
 
 ---
 
@@ -11,7 +11,26 @@
 | **Worked On** | Final stabilization of #36 fix. After iteration 3 (suffix-repetition detection), user reported: (a) `treatReasoningAsContent` was leaking thinking to visible text, (b) `contentAfterReasoning` guard was suppressing ALL models, (c) thinking/reasoning was being "cut off" and stopping without warning. Through 4 additional iterations: (1) removed `treatReasoningAsContent` to fix leak → thinking went back to thinking panel ✅, (2) reverted `contentAfterReasoning` and `shouldSuppressTextEmit` which were false-positiving on DeepSeek/GLM/Kimi (they legitimately use `reasoning_content` then `content`), (3) re-added `treatReasoningAsContent` with correct condition: only when Go gateway + NO `reasoning_effort` in body. Key insight from web research: upstream issue #37635 is confirmed (gateway bug) and PR #37558 merged `reasoning_content` parsing — but the gateway bug itself persists. |
 | **Stopped At** | All fixes verified working. Documentation updated. Ready to push. |
 | **Next Action** | → Commit all changes → push `fix/mimo-thinking-budget` branch → open PR. |
-| **Open Issues** | (1)-(9) same as before. (10) Log spam from agent-host provider still high (#36 debugging showed it). (11) Upstream #37635 still open, workaround can be removed when fixed server-side. |
+| **Open Issues** | (1)-(9) same as before. (10) Log spam from agent-host provider still high (#36 debugging showed it). (11) Upstream #37635 still open, workaround can be removed when fixed server-side. (12) #98 premature tool-call flush regression — fix implemented, pending compile/test. |
+
+---
+
+## 🔬 Issue #98 — Premature tool-call flush (empty `<invoke>`) — 2026-08-03
+
+**Branch:** `xianhongtao/issue98`
+
+**Problem:** After 0.4.4 (#93 gpt-5.6-luna fix), DeepSeek-V4 via OpenCode Zen produced malformed tool calls — `<invoke>` with no `<parameter>` — causing an unrecoverable tool-calling loop. Same model works in OpenCode CLI; reverting to 0.4.3 fixes it.
+
+**Root cause:** #93 added a flush condition `finish_reason == null && pendingToolCalls.size > 0` in `OpenAiResponseExtractor.extractStreamParts()`. Standard OpenAI-compatible SSE streams report `finish_reason: null` on every intermediate chunk, so the first tool-call delta chunk flushed an INCOMPLETE call (empty arguments → `{}` → `<invoke>` without `<parameter>`).
+
+**Fix:**
+1. Flush ONLY on `finish_reason === "tool_calls"` (never on `null`).
+2. New `OpenAiResponseExtractor.flushRemainingToolCalls()` flushes pending calls once at end-of-stream (after `streamOpenCodeResponse` returns) — preserves #93 for gateways omitting finish_reason (gpt-5.6-luna on Go).
+3. Extracted pure `ToolCallAccumulator` (`src/toolCallAccumulator.ts`, no `vscode` import) + unit tests `src/test/toolCallAccumulator.test.ts` (multi-chunk stream emits exactly one complete call; no premature flush; end-of-stream flush; edge cases).
+
+**Files:** `src/streaming.ts`, `src/toolCallAccumulator.ts` (new), `src/test/toolCallAccumulator.test.ts` (new), `CHANGELOG.md`, `docs/issues/42-20260803-premature-tool-call-flush.md`.
+
+**Verification:** `npm run compile`, `npm test`, `npm run test-retry` — all pass. Manual F5: deepseek-v4 (Zen) tool call emits full `<parameter>` ✅, tool loop resolved. ⚠️ gpt-5.6-luna (Go) NOT live-verified — China users cannot access GPT-series models via the gateway; the #93 end-of-stream path is covered by unit tests and the shared extractor code path, but a live check on gpt-5.6-luna remains recommended.
 
 ---
 

--- a/docs/issues/42-20260803-premature-tool-call-flush.md
+++ b/docs/issues/42-20260803-premature-tool-call-flush.md
@@ -1,0 +1,108 @@
+# Issue #42 — Premature tool-call flush causes empty `<invoke>` calls (regression from #93)
+
+**Date:** 2026-08-03
+**Status:** ✅ Fixed
+**Related:** [#98](https://github.com/ltmoerdani/opencode-copilot-chat/issues/98), [#93](https://github.com/ltmoerdani/opencode-copilot-chat/issues/93)
+
+## Problem
+
+After the 0.4.4 release, models such as `deepseek-v4` / `deepseek-v4-pro` via the **OpenCode Zen** provider enter an unrecoverable tool-calling loop in the VS Code Chat panel. The model emits an opening `<invoke>` tag with **no `<parameter>` elements** (empty arguments) and then keeps retrying, never converging.
+
+- Reverting to 0.4.3 immediately resolves the issue.
+- The exact same model + provider work fine via the OpenCode CLI terminal client.
+- Multiple reporters confirmed the regression comes from this extension, not GitHub Copilot itself.
+
+## Investigation
+
+### Routing
+
+`resolveModelRouting()` sends `deepseek-v4*` to the **chat-completions** transport (`streamChatCompletions`), which uses `OpenAiResponseExtractor`. The same extractor is shared by the **responses** (`streamResponsesApi`) and **google** (`streamGoogleGenerateContent`) transports. The **Anthropic** transport has its own extractor and is unaffected.
+
+### Root cause — regression from #93
+
+The #93 fix (`docs/issues/41-20260803-gpt56-luna-routing-fix.md`, shipped in 0.4.4) changed the flush condition in `OpenAiResponseExtractor.extractStreamParts()`:
+
+```ts
+if (
+  first.finish_reason === "tool_calls"
+  || (first.finish_reason == null && this.pendingToolCalls.size > 0)
+) {
+  const toolParts = this.flushToolCalls();
+  ...
+}
+```
+
+`extractStreamParts` runs **once per SSE event**. Standard OpenAI-compatible SSE streams (Go and Zen gateways alike) report `finish_reason: null` on **every intermediate chunk** — only the final chunk reports `"tool_calls"`. So the new second clause fired on the **first chunk carrying a tool-call delta**, flushing an **incomplete** tool call:
+
+1. Chunk 1: `tool_calls[{index:0, id, name, arguments:""}]`, `finish_reason: null` → condition matches → flush.
+2. `flushToolCalls()` → `parseToolInput("")` → `{}` → emits a `LanguageModelToolCallPart` with **empty input**.
+3. VS Code renders that as `<invoke name="...">` with **no `<parameter>`**.
+4. The model receives the empty tool result and retries the call → infinite loop.
+
+Each subsequent arguments delta chunk (also `finish_reason: null`) re-triggered the flush, dropping the real arguments fragments. Net effect: a cascade of malformed empty calls.
+
+**Why gpt-5.6-luna "worked" with the #93 fix:** the Go gateway delivered the complete tool call in a single final event (with `finish_reason: null`), so flushing at that point was harmless. But any model that streams arguments as incremental deltas across multiple `finish_reason: null` chunks — DeepSeek, Kimi, GLM, Qwen (non-plus), MiniMax (non-m2.x), MiMo — is broken by the same condition. The responses/google transports are equally affected because their normalizers also emit `finish_reason: null` per event.
+
+**Why OpenCode CLI is fine:** the CLI has its own independent transport implementation and correctly accumulates deltas.
+
+## Fix
+
+In `OpenAiResponseExtractor`:
+
+1. **Flush only on `finish_reason === "tool_calls"`.** Never flush on intermediate `null`/`undefined` chunks. Encapsulated as `ToolCallAccumulator.shouldFlushOnFinishReason(finishReason)`.
+2. **Flush remaining pending tool calls once at end-of-stream.** New public method `flushRemainingToolCalls(progress, localRequestId)` flushes any accumulated calls after `streamOpenCodeResponse` returns, and is called in the three OpenAI-style transports right before `flushReasoningFallback`. This preserves the #93 intent: gateways that omit `finish_reason` entirely (gpt-5.6-luna on Go) still get their calls emitted — but only once, when the stream is finished, so arguments are complete.
+3. **Extracted a pure, unit-tested `ToolCallAccumulator`** (`src/toolCallAccumulator.ts`, no `vscode` import — following the `src/thinking.ts` pure-module convention) so the accumulation/flush logic is testable in plain Node and cannot silently regress again.
+
+### Why not filter out empty-argument calls?
+
+An empty `{}` input is legitimate for tools that take no parameters. The bug was the **premature flush**, not the empty arguments themselves; dropping empty-input calls would break valid no-arg tools. The fix addresses the root cause instead.
+
+## Changes Applied
+
+### 1. `src/toolCallAccumulator.ts` (new, pure)
+
+`PendingToolCall` / `FlushedToolCall` types, `parseToolInput` (moved from `streaming.ts`), and `ToolCallAccumulator` with:
+
+- `collect(toolCalls)` — accumulate deltas by `index` (fragmented `name`/`arguments` appended).
+- `shouldFlushOnFinishReason(finishReason)` — only `=== "tool_calls"`.
+- `flush()` — return complete calls, drop entries with empty `name`, clear pending.
+- `flushRemaining()` — end-of-stream flush; safe no-op when nothing is pending.
+
+### 2. `src/streaming.ts` — `OpenAiResponseExtractor`
+
+- `pendingToolCalls` Map replaced by a `ToolCallAccumulator` instance.
+- `collectOpenAiToolCalls()` delegates to `toolCallAccumulator.collect()`.
+- `flushToolCalls()` maps `FlushedToolCall[]` to `vscode.LanguageModelToolCallPart[]` (reasoning replication unchanged).
+- `extractStreamParts()` flush condition → only `ToolCallAccumulator.shouldFlushOnFinishReason(first.finish_reason)`.
+- New public `flushRemainingToolCalls(progress, localRequestId)`.
+- Removed the now-migrated local `parseToolInput` and `PendingToolCall` definitions (imported from `./toolCallAccumulator`).
+
+### 3. `src/streaming.ts` — transports
+
+`streamChatCompletions`, `streamResponsesApi`, `streamGoogleGenerateContent` each call `extractor.flushRemainingToolCalls(...)` after `await streamOpenCodeResponse(...)` and before `flushReasoningFallback`. The Anthropic transport is unchanged (its extractor already flushes only on terminating events).
+
+### 4. `src/test/toolCallAccumulator.test.ts` (new)
+
+`node:test` + `assert/strict` (pattern of `src/test/thinking.test.ts`):
+- Multi-chunk stream emits **exactly one** complete tool call only when `finish_reason` is `"tool_calls"`.
+- No premature flush on intermediate `finish_reason: null` chunks (the #93 regression).
+- `flushRemaining()` emits the complete call for gateways omitting `finish_reason` (gpt-5.6-luna case).
+- Empty-name (arguments-only) deltas filtered; multiple tool calls handled by index; fragmented names appended.
+- `parseToolInput` returns `{}` for empty/partial/non-object JSON.
+
+### 5. Docs
+
+- `CHANGELOG.md` — 0.4.5 entry.
+- `docs/devlog.md` — session handoff updated.
+
+## Status
+
+- ✅ `npm run compile` — exit 0.
+- ✅ `npm test` — new `toolCallAccumulator` suite passes.
+- ✅ `npm run test-retry` — E2E retry test passes.
+- ✅ Manual F5 verification — `deepseek-v4` (Zen): tool calls now emit full `<parameter>`; the tool-calling loop is resolved.
+- ⚠️ `gpt-5.6-luna` (Go) **NOT live-verified**. The maintainer/reporter is in China, where GPT-series models cannot be reached through the gateway, so a live regression check of the #93 path was not possible. That path (end-of-stream `flushRemaining()`) is covered by the unit tests and shares the exact extractor code path verified with DeepSeek, but a live check on `gpt-5.6-luna` remains recommended for anyone who can access GPT models.
+
+## Recommendation
+
+Keep tool-call flush decisions in the pure `ToolCallAccumulator` and add a unit test for any future change to streaming/tool-call behavior. The 0.4.4 regression shipped because no test covered the flush logic.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-copilot-chat",
-  "version": "0.4.1",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-copilot-chat",
-      "version": "0.4.1",
+      "version": "0.4.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-copilot-chat",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-copilot-chat",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "opencode-copilot-chat",
   "displayName": "OpenCode for Copilot Chat — BYOK 30+ AI Models",
   "description": "Use 30+ frontier AI models (DeepSeek V4, Kimi K2.6, GLM-5.1, Qwen3.7, MiMo V2.5, MiniMax M2.7, free Claude Opus, GPT-5.5, Gemini 3.5, Grok) in GitHub Copilot Chat. Bring Your Own Key — no Copilot Pro needed.",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "publisher": "ltmoerdani",
   "license": "MIT",
   "icon": "media/opencodego.png",

--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -22,6 +22,11 @@ import {
   setContextWindowOutputBufferForRequest,
 } from "./contextWindowHookBridge";
 import { formatUsageLogLine } from "./usage";
+import {
+  parseToolInput,
+  ToolCallAccumulator,
+  type PendingToolCall,
+} from "./toolCallAccumulator";
 
 export interface StreamRequestOptions {
   url: string;
@@ -114,6 +119,10 @@ export async function streamChatCompletions(
     extractFullParts: extractChatCompletionParts,
   });
 
+  extractor.flushRemainingToolCalls(
+    options.progress,
+    options.requestHeaders["x-opencode-request"],
+  );
   extractor.flushReasoningFallback(
     options.progress,
     options.requestHeaders["x-opencode-request"],
@@ -182,6 +191,10 @@ export async function streamResponsesApi(
       extractChatCompletionParts(normalizeResponsesFullResponse(data)),
   });
 
+  extractor.flushRemainingToolCalls(
+    options.progress,
+    options.requestHeaders["x-opencode-request"],
+  );
   extractor.flushReasoningFallback(
     options.progress,
     options.requestHeaders["x-opencode-request"],
@@ -212,6 +225,10 @@ export async function streamGoogleGenerateContent(
       extractChatCompletionParts(normalizeGoogleFullResponse(data)),
   });
 
+  extractor.flushRemainingToolCalls(
+    options.progress,
+    options.requestHeaders["x-opencode-request"],
+  );
   extractor.flushReasoningFallback(
     options.progress,
     options.requestHeaders["x-opencode-request"],
@@ -894,7 +911,7 @@ class ThinkTagFilter {
 }
 
 class OpenAiResponseExtractor {
-  private readonly pendingToolCalls = new Map<number, PendingToolCall>();
+  private readonly toolCallAccumulator = new ToolCallAccumulator();
   private reasoningContent = "";
   private emittedTextLength = 0;
   private emittedToolCallsCount = 0;
@@ -1113,16 +1130,14 @@ class OpenAiResponseExtractor {
       this.collectOpenAiToolCalls(message.tool_calls);
     }
 
-    // Flush accumulated tool calls.
-    // Some gateways (e.g. OpenCode Go for gpt-5.6-luna) omit finish_reason
-    // on the final chunk even when tool calls were streamed.  When
-    // finish_reason is null/undefined but we have pending tool calls, they
-    // are real and must be flushed — otherwise they silently disappear
-    // (issue #93).
-    if (
-      first.finish_reason === "tool_calls"
-      || (first.finish_reason == null && this.pendingToolCalls.size > 0)
-    ) {
+    // Flush accumulated tool calls ONLY when the stream reports the OpenAI
+    // `"tool_calls"` finish reason. Intermediate chunks always carry
+    // `finish_reason: null`, so flushing there would emit an incomplete tool
+    // call (empty arguments → `<invoke>` without `<parameter>`, issue #98).
+    // Gateways that omit `finish_reason` entirely (e.g. OpenCode Go for
+    // gpt-5.6-luna, issue #93) are flushed once at end-of-stream via
+    // `flushRemainingToolCalls()`.
+    if (ToolCallAccumulator.shouldFlushOnFinishReason(first.finish_reason)) {
       const toolParts = this.flushToolCalls();
       this.emittedToolCallsCount += toolParts.length;
       parts.push(...toolParts);
@@ -1205,52 +1220,17 @@ class OpenAiResponseExtractor {
   }
 
   private collectOpenAiToolCalls(toolCalls: unknown): void {
-    if (!Array.isArray(toolCalls)) {
-      return;
-    }
-
-    for (const toolCall of toolCalls) {
-      if (!isRecord(toolCall)) {
-        continue;
-      }
-
-      const index =
-        typeof toolCall.index === "number"
-          ? toolCall.index
-          : this.pendingToolCalls.size;
-      const pending = this.pendingToolCalls.get(index) ?? {
-        id: "",
-        name: "",
-        arguments: "",
-      };
-      if (typeof toolCall.id === "string") {
-        pending.id = toolCall.id;
-      }
-
-      const fn = toolCall.function;
-      if (isRecord(fn)) {
-        if (typeof fn.name === "string") {
-          pending.name += fn.name;
-        }
-        if (typeof fn.arguments === "string") {
-          pending.arguments += fn.arguments;
-        }
-      }
-
-      this.pendingToolCalls.set(index, pending);
-    }
+    this.toolCallAccumulator.collect(toolCalls);
   }
 
   private flushToolCalls(): vscode.LanguageModelToolCallPart[] {
-    const toolCalls = Array.from(this.pendingToolCalls.values()).filter(
-      (toolCall) => toolCall.name,
-    );
-    const parts = toolCalls.map(
-      (toolCall, index) =>
+    const calls = this.toolCallAccumulator.flush();
+    const parts = calls.map(
+      (call, index) =>
         new vscode.LanguageModelToolCallPart(
-          toolCall.id || `opencodego-tool-${Date.now()}-${index}`,
-          toolCall.name,
-          parseToolInput(toolCall.arguments),
+          call.id || `opencodego-tool-${Date.now()}-${index}`,
+          call.name,
+          call.input,
         ),
     );
 
@@ -1262,9 +1242,31 @@ class OpenAiResponseExtractor {
       );
     }
 
-    this.pendingToolCalls.clear();
     this.reasoningContent = "";
     return parts;
+  }
+
+  /**
+   * Flush any tool calls still accumulated when the stream ends. Some
+   * gateways omit the `finish_reason: "tool_calls"` final event (e.g. the
+   * OpenCode Go gateway for gpt-5.6-luna, issue #93), so a final flush here
+   * prevents those calls from silently disappearing.
+   *
+   * Must be called BEFORE `flushReasoningFallback` so tool-call reasoning
+   * replication runs first. Safe no-op when nothing is pending.
+   */
+  flushRemainingToolCalls(
+    progress: vscode.Progress<vscode.LanguageModelResponsePart2>,
+    localRequestId?: string,
+  ): void {
+    if (this.toolCallAccumulator.size === 0) {
+      return;
+    }
+    const toolParts = this.flushToolCalls();
+    this.emittedToolCallsCount += toolParts.length;
+    for (const part of toolParts) {
+      reportProgressPart(localRequestId, progress, part);
+    }
   }
 }
 
@@ -1745,19 +1747,6 @@ function toolCallPartsFromOpenAiMessage(
     );
 }
 
-function parseToolInput(value: string): object {
-  if (!value.trim()) {
-    return {};
-  }
-
-  try {
-    const parsed = JSON.parse(value);
-    return isRecord(parsed) ? parsed : {};
-  } catch {
-    return {};
-  }
-}
-
 function updateRequestUsageSummary(
   summary: RequestUsageSummary,
   data: unknown,
@@ -1833,12 +1822,6 @@ function updateRequestUsageSummary(
   if (firstChoice && typeof firstChoice.finish_reason === "string") {
     summary.finishReason = firstChoice.finish_reason;
   }
-}
-
-interface PendingToolCall {
-  id: string;
-  name: string;
-  arguments: string;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/test/toolCallAccumulator.test.ts
+++ b/src/test/toolCallAccumulator.test.ts
@@ -20,7 +20,7 @@ import {
  * causing an unrecoverable tool-call loop (issue #98).
  *
  * The accumulator must therefore ONLY flush on `finish_reason === "tool_calls"`
- * (or via `flushRemaining()` at end-of-stream for gateways that omit it), never
+ * (or via `flushRemainingToolCalls()` at end-of-stream for gateways that omit it), never
  * on intermediate `finish_reason: null` chunks.
  */
 
@@ -90,13 +90,13 @@ describe("ToolCallAccumulator — no premature flush on intermediate chunks (#98
   it("is a no-op when nothing was collected", () => {
     const acc = new ToolCallAccumulator();
     assert.deepEqual(acc.flush(), []);
-    assert.deepEqual(acc.flushRemaining(), []);
+    assert.deepEqual(acc.flushRemainingToolCalls(), []);
     assert.equal(acc.size, 0);
   });
 });
 
 describe("ToolCallAccumulator — end-of-stream flush for gateways omitting finish_reason (#93)", () => {
-  it("flushRemaining emits the complete call when the gateway never sends 'tool_calls'", () => {
+  it("flushRemainingToolCalls emits the complete call when the gateway never sends 'tool_calls'", () => {
     const acc = new ToolCallAccumulator();
     acc.collect(nameChunk);
     acc.collect(argsChunk1);
@@ -104,7 +104,7 @@ describe("ToolCallAccumulator — end-of-stream flush for gateways omitting fini
 
     // No finish_reason anywhere in the stream — emulate gpt-5.6-luna on Go.
     assert.equal(ToolCallAccumulator.shouldFlushOnFinishReason(null), false);
-    const flushed = acc.flushRemaining();
+    const flushed = acc.flushRemainingToolCalls();
 
     assert.equal(flushed.length, 1);
     assert.equal(flushed[0].name, "grep_search");
@@ -112,13 +112,13 @@ describe("ToolCallAccumulator — end-of-stream flush for gateways omitting fini
     assert.equal(acc.size, 0);
   });
 
-  it("flushRemaining is a no-op after a normal finish_reason flush", () => {
+  it("flushRemainingToolCalls is a no-op after a normal finish_reason flush", () => {
     const acc = new ToolCallAccumulator();
     acc.collect(nameChunk);
     acc.collect(argsChunk1);
     acc.collect(argsChunk2);
     acc.flush();
-    assert.deepEqual(acc.flushRemaining(), []);
+    assert.deepEqual(acc.flushRemainingToolCalls(), []);
   });
 });
 

--- a/src/test/toolCallAccumulator.test.ts
+++ b/src/test/toolCallAccumulator.test.ts
@@ -1,0 +1,197 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseToolInput,
+  ToolCallAccumulator,
+} from "../toolCallAccumulator.js";
+
+/**
+ * Unit tests for the pure tool-call accumulator (issues #93 / #98).
+ *
+ * CONTEXT / ROOT CAUSE:
+ * OpenCode's OpenAI-compatible SSE streams deliver tool calls as deltas across
+ * MANY chunks: the first chunk carries `id`/`name` with an empty `arguments`,
+ * subsequent chunks append `arguments` fragments, and every intermediate chunk
+ * reports `finish_reason: null` (only the final chunk says `"tool_calls"`).
+ *
+ * 0.4.4 (#93) added a flush condition `finish_reason == null && pending.size > 0`
+ * that fired on the FIRST tool-call delta chunk, emitting an incomplete call
+ * (empty input) — rendered by VS Code as `<invoke>` without `<parameter>`,
+ * causing an unrecoverable tool-call loop (issue #98).
+ *
+ * The accumulator must therefore ONLY flush on `finish_reason === "tool_calls"`
+ * (or via `flushRemaining()` at end-of-stream for gateways that omit it), never
+ * on intermediate `finish_reason: null` chunks.
+ */
+
+/** Build a delta chunk like `choices[0].delta` seen by collect(). */
+function deltaChunk(toolCalls: unknown): unknown {
+  return toolCalls;
+}
+
+const nameChunk = deltaChunk([
+  {
+    index: 0,
+    id: "call_1",
+    type: "function",
+    function: { name: "grep_search", arguments: "" },
+  },
+]);
+
+const argsChunk1 = deltaChunk([
+  { index: 0, function: { arguments: '{"query":' } },
+]);
+
+const argsChunk2 = deltaChunk([
+  { index: 0, function: { arguments: '"search"}' } },
+]);
+
+describe("ToolCallAccumulator — no premature flush on intermediate chunks (#98)", () => {
+  it("does not flush while finish_reason is null, even with pending tool calls", () => {
+    const acc = new ToolCallAccumulator();
+    acc.collect(nameChunk);
+    acc.collect(argsChunk1);
+    acc.collect(argsChunk2);
+
+    // All deltas accumulated, nothing flushed yet.
+    assert.equal(acc.size, 1);
+    // The chunk carrying the first tool-call delta has finish_reason: null —
+    // it must NOT trigger a flush (this is the regression from #93).
+    assert.equal(
+      ToolCallAccumulator.shouldFlushOnFinishReason(null),
+      false,
+    );
+    assert.equal(
+      ToolCallAccumulator.shouldFlushOnFinishReason(undefined),
+      false,
+    );
+  });
+
+  it("flushes exactly ONE complete tool call when finish_reason is 'tool_calls'", () => {
+    const acc = new ToolCallAccumulator();
+    acc.collect(nameChunk);
+    acc.collect(argsChunk1);
+    acc.collect(argsChunk2);
+
+    assert.equal(ToolCallAccumulator.shouldFlushOnFinishReason("tool_calls"), true);
+    const flushed = acc.flush();
+
+    assert.equal(flushed.length, 1);
+    assert.equal(flushed[0].id, "call_1");
+    assert.equal(flushed[0].name, "grep_search");
+    // Fragmented arguments fully assembled and parsed.
+    assert.deepEqual(flushed[0].input, { query: "search" });
+    // Accumulator is empty after flush.
+    assert.equal(acc.size, 0);
+    // A second flush yields nothing.
+    assert.deepEqual(acc.flush(), []);
+  });
+
+  it("is a no-op when nothing was collected", () => {
+    const acc = new ToolCallAccumulator();
+    assert.deepEqual(acc.flush(), []);
+    assert.deepEqual(acc.flushRemaining(), []);
+    assert.equal(acc.size, 0);
+  });
+});
+
+describe("ToolCallAccumulator — end-of-stream flush for gateways omitting finish_reason (#93)", () => {
+  it("flushRemaining emits the complete call when the gateway never sends 'tool_calls'", () => {
+    const acc = new ToolCallAccumulator();
+    acc.collect(nameChunk);
+    acc.collect(argsChunk1);
+    acc.collect(argsChunk2);
+
+    // No finish_reason anywhere in the stream — emulate gpt-5.6-luna on Go.
+    assert.equal(ToolCallAccumulator.shouldFlushOnFinishReason(null), false);
+    const flushed = acc.flushRemaining();
+
+    assert.equal(flushed.length, 1);
+    assert.equal(flushed[0].name, "grep_search");
+    assert.deepEqual(flushed[0].input, { query: "search" });
+    assert.equal(acc.size, 0);
+  });
+
+  it("flushRemaining is a no-op after a normal finish_reason flush", () => {
+    const acc = new ToolCallAccumulator();
+    acc.collect(nameChunk);
+    acc.collect(argsChunk1);
+    acc.collect(argsChunk2);
+    acc.flush();
+    assert.deepEqual(acc.flushRemaining(), []);
+  });
+});
+
+describe("ToolCallAccumulator — delta handling edge cases", () => {
+  it("ignores non-array and non-record deltas", () => {
+    const acc = new ToolCallAccumulator();
+    acc.collect(undefined);
+    acc.collect("not an array");
+    acc.collect([null, 42, "x"]);
+    assert.equal(acc.size, 0);
+  });
+
+  it("filters out arguments-only deltas that never supplied a name", () => {
+    const acc = new ToolCallAccumulator();
+    acc.collect([
+      { index: 0, function: { arguments: '{"a":1}' } },
+    ]);
+    assert.equal(acc.size, 1);
+    const flushed = acc.flush();
+    // The pending entry has an empty name → dropped.
+    assert.deepEqual(flushed, []);
+  });
+
+  it("accumulates multiple tool calls independently by index", () => {
+    const acc = new ToolCallAccumulator();
+    acc.collect([
+      { index: 0, id: "a", function: { name: "read_file", arguments: '{"path":' } },
+      { index: 1, id: "b", function: { name: "grep_search", arguments: '{"query":' } },
+    ]);
+    acc.collect([
+      { index: 0, function: { arguments: '"/x.ts"}' } },
+      { index: 1, function: { arguments: '"foo"}' } },
+    ]);
+
+    const flushed = acc.flush();
+    assert.equal(flushed.length, 2);
+    assert.equal(flushed[0].name, "read_file");
+    assert.deepEqual(flushed[0].input, { path: "/x.ts" });
+    assert.equal(flushed[1].name, "grep_search");
+    assert.deepEqual(flushed[1].input, { query: "foo" });
+  });
+
+  it("appends name fragments (name split across chunks)", () => {
+    const acc = new ToolCallAccumulator();
+    acc.collect([{ index: 0, function: { name: "read_" } }]);
+    acc.collect([{ index: 0, function: { name: "file" } }]);
+    const flushed = acc.flush();
+    assert.equal(flushed[0]?.name, "read_file");
+  });
+});
+
+describe("parseToolInput", () => {
+  it("returns {} for empty or whitespace-only input", () => {
+    assert.deepEqual(parseToolInput(""), {});
+    assert.deepEqual(parseToolInput("   "), {});
+  });
+
+  it("returns {} for partial / invalid JSON", () => {
+    assert.deepEqual(parseToolInput('{"a":'), {});
+    assert.deepEqual(parseToolInput("not json"), {});
+  });
+
+  it("parses valid JSON objects", () => {
+    assert.deepEqual(parseToolInput('{"a":1}'), { a: 1 });
+    assert.deepEqual(parseToolInput("{}"), {});
+  });
+
+  it("returns {} for non-object JSON scalars (strings, numbers)", () => {
+    assert.deepEqual(parseToolInput('"str"'), {});
+    assert.deepEqual(parseToolInput("42"), {});
+  });
+
+  it("passes through JSON arrays (isRecord treats arrays as objects — original semantics)", () => {
+    assert.deepEqual(parseToolInput("[1,2]"), [1, 2]);
+  });
+});

--- a/src/toolCallAccumulator.ts
+++ b/src/toolCallAccumulator.ts
@@ -104,7 +104,7 @@ export class ToolCallAccumulator {
    * trigger a flush — flushing there emits an incomplete tool call with empty
    * arguments (rendered by VS Code as `<invoke>` without `<parameter>`).
    * Gateways that omit `finish_reason` entirely are handled by
-   * `flushRemaining()` at end-of-stream.
+   * `flushRemainingToolCalls()` at end-of-stream.
    */
   static shouldFlushOnFinishReason(finishReason: unknown): boolean {
     return finishReason === "tool_calls";
@@ -132,7 +132,7 @@ export class ToolCallAccumulator {
    * gateways that omit the final `finish_reason: "tool_calls"` event. Safe
    * no-op when nothing is pending.
    */
-  flushRemaining(): FlushedToolCall[] {
+  flushRemainingToolCalls(): FlushedToolCall[] {
     if (this.pending.size === 0) {
       return [];
     }

--- a/src/toolCallAccumulator.ts
+++ b/src/toolCallAccumulator.ts
@@ -1,0 +1,141 @@
+/**
+ * Pure tool-call accumulation for OpenAI-style streaming responses.
+ *
+ * This module is intentionally free of any `vscode` import so it can be
+ * unit-tested in plain Node (see AGENTS.md and the `src/thinking.ts`
+ * convention). `OpenAiResponseExtractor` in `streaming.ts` delegates its
+ * tool-call collection and flush decisions here and maps the results onto
+ * VS Code `LanguageModelToolCallPart`s.
+ */
+
+export interface PendingToolCall {
+  id: string;
+  name: string;
+  arguments: string;
+}
+
+export interface FlushedToolCall {
+  id: string;
+  name: string;
+  input: object;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/** Parse a streamed tool-call arguments string into an object. */
+export function parseToolInput(value: string): object {
+  if (!value.trim()) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Accumulates tool-call deltas streamed in OpenAI chat-completions format
+ * (`choices[0].delta.tool_calls`) across many SSE chunks, keyed by `index`.
+ *
+ * Tool calls arrive fragmented: the first chunk carries `id`/`name` and an
+ * empty `arguments` string, subsequent chunks append `arguments` fragments,
+ * and the final chunk reports `finish_reason: "tool_calls"`. Flushing must
+ * therefore happen only when the batch is complete — either on the
+ * `"tool_calls"` finish reason, or once at end-of-stream for gateways that
+ * omit it (see issue #93 / #98).
+ */
+export class ToolCallAccumulator {
+  private readonly pending = new Map<number, PendingToolCall>();
+
+  /** Number of tool calls currently accumulated (not yet flushed). */
+  get size(): number {
+    return this.pending.size;
+  }
+
+  /** Accumulate a batch of tool-call deltas from one stream chunk. */
+  collect(toolCalls: unknown): void {
+    if (!Array.isArray(toolCalls)) {
+      return;
+    }
+
+    for (const toolCall of toolCalls) {
+      if (!isRecord(toolCall)) {
+        continue;
+      }
+
+      const index =
+        typeof toolCall.index === "number"
+          ? toolCall.index
+          : this.pending.size;
+      const pending = this.pending.get(index) ?? {
+        id: "",
+        name: "",
+        arguments: "",
+      };
+      if (typeof toolCall.id === "string") {
+        pending.id = toolCall.id;
+      }
+
+      const fn = toolCall.function;
+      if (isRecord(fn)) {
+        if (typeof fn.name === "string") {
+          pending.name += fn.name;
+        }
+        if (typeof fn.arguments === "string") {
+          pending.arguments += fn.arguments;
+        }
+      }
+
+      this.pending.set(index, pending);
+    }
+  }
+
+  /**
+   * Whether an event whose `finish_reason` is `finishReason` marks the end
+   * of a complete tool-call batch that should be flushed now.
+   *
+   * Only the OpenAI `"tool_calls"` finish reason is a reliable signal.
+   * Intermediate chunks always carry `finish_reason: null`, so they must NOT
+   * trigger a flush — flushing there emits an incomplete tool call with empty
+   * arguments (rendered by VS Code as `<invoke>` without `<parameter>`).
+   * Gateways that omit `finish_reason` entirely are handled by
+   * `flushRemaining()` at end-of-stream.
+   */
+  static shouldFlushOnFinishReason(finishReason: unknown): boolean {
+    return finishReason === "tool_calls";
+  }
+
+  /**
+   * Flush accumulated tool calls, returning them as complete calls.
+   * Deltas that never supplied a `name` (arguments-only fragments) are
+   * dropped.
+   */
+  flush(): FlushedToolCall[] {
+    const calls = Array.from(this.pending.values())
+      .filter((call) => call.name)
+      .map((call) => ({
+        id: call.id,
+        name: call.name,
+        input: parseToolInput(call.arguments),
+      }));
+    this.pending.clear();
+    return calls;
+  }
+
+  /**
+   * Flush any remaining accumulated tool calls at end-of-stream. Used for
+   * gateways that omit the final `finish_reason: "tool_calls"` event. Safe
+   * no-op when nothing is pending.
+   */
+  flushRemaining(): FlushedToolCall[] {
+    if (this.pending.size === 0) {
+      return [];
+    }
+    return this.flush();
+  }
+}


### PR DESCRIPTION
The 0.4.4 #93 fix VS Code Extension regressions cause malformed tool calls (<invoke> without <parameter>) in Chat sidebar. 

## 📝 What does this change?

- OpenAiResponseExtractor now flushes only on finish_reason === "tool_calls"; remaining calls are flushed once at end-of-stream via the new flushRemainingToolCalls() (preserves #93 for gateways that omit finish_reason, e.g. gpt-5.6-luna on Go).
- Extracted a pure, unit-tested ToolCallAccumulator (src/toolCallAccumulator.ts, no vscode import) so the flush logic cannot silently regress again.
- Tests: src/test/toolCallAccumulator.test.ts (15 cases). All 121 unit tests + test-retry pass.
- Docs: CHANGELOG 0.4.5, docs/issues/42, devlog.

## 🧪 How did you test it?

I use deepseek via opencode go.

before fix:
<img width="432" height="333" alt="image" src="https://github.com/user-attachments/assets/2f8ff7c4-2e92-4e27-bdd9-3a3cd164e3ab" />

after fix:
<img width="403" height="519" alt="image" src="https://github.com/user-attachments/assets/7b139a13-5f35-4487-8c45-a840b85a9c01" />

Note: gpt-5.6-luna (#93 path) not live-verified - China users cannot access GPT-series models via the gateway; covered by unit tests and the shared extractor code path, live check still recommended.

## ✅ Checklist

- [x] `npm run compile` passes
- [x] I tested it works
- [x] I updated docs/CHANGELOG if needed
