### PR TITLE
fix: wire up payload trimmer to fix DeepSeek 400 "Upstream response was not valid JSON" on large sessions (#104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the **OpenCode Go BYOK Provider** extension are documented here.
 
+## [0.4.6] — unreleased
+
+### Fixed
+
+- **`[Streaming]` DeepSeek 400 "Upstream response was not valid JSON" on large sessions — wire up the dead payload trimmer (#104).** The OpenCode Go gateway rejects request bodies over ~400 KB with a wrapped 4xx/5xx, even when the model's token context window is far from full, because the limit is raw JSON bytes, not tokens. Long sessions accumulate history past that ceiling. The extension already shipped a byte-aware trimmer (`messageTrimmer.ts`, `MAX_PAYLOAD_BYTES = 380_000`, `MESSAGE_BYTE_BUDGET = 200_000` per endpoint) but **no code path ever called it** — it was dead code. The trimmer is now wired into the request path in `provideLanguageModelChatResponse()` after the image-history trim, pruning older conversation turns (preserving the system prompt, the most recent turns, and tool-call atomicity) to the endpoint's byte budget across all four endpoints. A safety net converts the pathological single-turn-over-limit case into a clear "start a new chat session" error instead of the cryptic upstream 400. Added `src/test/messageTrimmer.test.ts` (6 unit tests). Diagnostic log line `[payload-trim] Trimmed messages from N to M...` appears in the Output channel when trimming fires. Documented in `docs/issues/45-20260804-payload-trimmer.md`.
+
 ## [0.4.5] — 2026-08-03
 
 ### Fixed

--- a/docs/issues/45-20260804-payload-trimmer.md
+++ b/docs/issues/45-20260804-payload-trimmer.md
@@ -1,0 +1,113 @@
+# Issue #45 — DeepSeek 400 "Upstream response was not valid JSON" on large sessions (payload trimmer dead code)
+
+**Date:** 2026-08-04
+**Status:** ✅ Resolved
+**Related:** GitHub Issue [#104](https://github.com/ltmoerdani/opencode-copilot-chat/issues/104)
+**Reporter:** [@aotr](https://github.com/aotr)
+**Extension version affected:** 0.4.5
+**Fixed in:** 0.4.6 (unreleased)
+
+## Problem
+
+Sending a message in a long session fails with:
+
+```
+OpenCode Go API request failed (400) model=deepseek-v4-flash payloadBytes=563749:
+Error from provider (Console Go): Upstream request failed: [server_error]
+Upstream response was not valid JSON
+```
+
+The OpenCode Go gateway rejects request bodies over ~400 KB with a wrapped
+4xx/5xx, even when the model's token context window (e.g. 1M tokens on
+`deepseek-v4-flash`) is nowhere near full — the limit is raw JSON bytes, not
+tokens. Long sessions accumulate history past that ceiling.
+
+### Steps to reproduce
+
+1. Build a long session (~500 KB+ of accumulated context / file attachments).
+2. Send a message.
+
+## Root Cause (Evidence-Based)
+
+### Location
+
+The extension ships a byte-aware trimmer, `messageTrimmer.ts`, with:
+
+- `MAX_PAYLOAD_BYTES = 380_000` (hard ceiling)
+- `MESSAGE_BYTE_BUDGET = 200_000` per endpoint kind
+- `trimApiMessages()` — prunes older conversation turns while preserving the
+  system prompt, the most recent turns, and tool-call atomicity.
+
+Its header documents the exact failure mode: *"The OpenCode Go API proxy
+returns HTTP 500 when the JSON request body exceeds ~400 KB."*
+
+**However, no code path ever calls `trimApiMessages()`.** A grep across the
+extension's `src/` shows it is referenced only inside `messageTrimmer.ts`
+itself. The safety net is dead code — it was never wired into the request
+path. A 563 KB body therefore goes straight to the gateway and gets rejected.
+
+### Why issue #83 / PR #84 did not fix this
+
+Issue #83 (DeepSeek 400 on a ~754 K-token prompt) was fixed by capping
+`maxOutputTokens` in `modelLimits()` so prompt + completion never exceeds the
+token context window. That bounds *tokens*, not raw *bytes* — a request can
+still exceed the gateway's ~400 KB byte ceiling while being well inside the
+token window. Two independent limits, two fixes.
+
+## Fix
+
+### 1. Wire the trimmer into the request path (`src/extension.ts`)
+
+After the existing image-history trim, prune `apiMessages` to the endpoint's
+byte budget before any request body is built:
+
+```typescript
+const messageBudget = MESSAGE_BYTE_BUDGET[routing.endpointKind]
+  ?? MESSAGE_BYTE_BUDGET["chat-completions"];
+const trimmedMessages = trimApiMessages(apiMessages, messageBudget);
+if (trimmedMessages.length < apiMessages.length) {
+  this.log(`[payload-trim] Trimmed messages from ${apiMessages.length} to
+    ${trimmedMessages.length} (${messageBudget} byte budget) to stay under
+    the gateway payload limit.`);
+  apiMessages.splice(0, apiMessages.length, ...trimmedMessages);
+}
+```
+
+All four endpoints (`chat-completions`, `messages`, `responses`, `google`)
+share this single path, so one trim covers every routed model.
+
+### 2. Safety net for pathological single turns (`src/extension.ts`)
+
+If even the guaranteed minimum context alone exceeds the gateway limit (e.g.
+a single turn carrying a very large attachment), fail with a clear,
+actionable error instead of the cryptic upstream 400:
+
+```typescript
+if (JSON.stringify(apiMessages).length > MAX_PAYLOAD_BYTES) {
+  throw new OpenCodeRequestError(
+    "OpenCode Go payload too large (messages exceed 380000 bytes)...",
+    "Start a new chat session to continue.",
+  );
+}
+```
+
+### 3. Unit tests (`src/test/messageTrimmer.test.ts`)
+
+Six cases covering: short-conversation fast path, system-prompt survival,
+guaranteed recent turns, tool-call/tool-result atomicity, budget
+enforcement, and per-endpoint budget exports.
+
+## Behavior after fix
+
+| Session | Before | After |
+|---|---|---|
+| Short session | Works | Works (fast path, untouched) |
+| Long session > 400 KB | Cryptic 400 | Oldest turns trimmed; request succeeds |
+| Single giant turn | Cryptic 400 | Clear "start a new chat" error |
+
+## Validation
+
+- `npm run compile` — clean.
+- `npm test` — new trimmer suite 6/6 pass; no regressions (the 9
+  `usageProfile.test.ts` failures are pre-existing on `main` with Node 22).
+- `npm run test-retry` (E2E mock server) — 7/7 pass.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,6 +28,11 @@ import {
   resolveModelRouting,
 } from "./routing";
 import {
+  MAX_PAYLOAD_BYTES,
+  MESSAGE_BYTE_BUDGET,
+  trimApiMessages,
+} from "./messageTrimmer";
+import {
   buildFamilyThinkingSchema,
   buildQwenAnthropicThinkingPayload,
   buildThinkingPayload,
@@ -2148,6 +2153,29 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
     const trimmedCount = trimOldImagesFromHistoryInPlace(apiMessages);
     if (trimmedCount > 0) {
       this.log(`[history-trim] Replaced ${trimmedCount} old image(s) with placeholder text to bound payload (kept most recent ${MAX_HISTORY_IMAGES_KEPT}).`);
+    }
+
+    // Bound the raw JSON request body against the OpenCode Go gateway's
+    // ~400 KB payload limit (see messageTrimmer.ts). Long sessions can exceed
+    // that ceiling even when the model's token context window is far from
+    // full, because the gateway rejects on raw bytes, not tokens — surfacing
+    // as a cryptic `400 Upstream response was not valid JSON` (issue #104).
+    // Prune older turns to the endpoint's byte budget while preserving the
+    // system prompt, the most recent turns, and tool-call atomicity.
+    const messageBudget = MESSAGE_BYTE_BUDGET[routing.endpointKind] ?? MESSAGE_BYTE_BUDGET["chat-completions"];
+    const trimmedMessages = trimApiMessages(apiMessages, messageBudget);
+    if (trimmedMessages.length < apiMessages.length) {
+      this.log(`[payload-trim] Trimmed messages from ${apiMessages.length} to ${trimmedMessages.length} (${messageBudget} byte budget) to stay under the gateway payload limit.`);
+      apiMessages.splice(0, apiMessages.length, ...trimmedMessages);
+    }
+    // Safety net: if even the guaranteed minimum context alone exceeds the
+    // gateway limit (e.g. a single turn with a very large attachment), fail
+    // with a clear, actionable message instead of the cryptic upstream 400.
+    if (JSON.stringify(apiMessages).length > MAX_PAYLOAD_BYTES) {
+      throw new OpenCodeRequestError(
+        `OpenCode Go payload too large (messages exceed ${MAX_PAYLOAD_BYTES} bytes). The current conversation is too large for the gateway's request limit. Start a new chat session to continue.`,
+        `OpenCode Go rejected the request: the conversation is too large for the gateway's ~400 KB request limit. Start a new chat session to continue.`,
+      );
     }
 
     const thinkingPayload = buildThinkingPayload(rawModelId, settings.thinking, hasImageInput && metadata.supportsVision);

--- a/src/messageTrimmer.ts
+++ b/src/messageTrimmer.ts
@@ -1,0 +1,142 @@
+// ---------------------------------------------------------------------------
+// Byte-aware message trimming for the OpenCode Go gateway payload limit.
+// ---------------------------------------------------------------------------
+// The OpenCode Go API proxy rejects request bodies over ~400 KB with a
+// wrapped 4xx/5xx (observed as "Upstream request failed: ... Upstream
+// response was not valid JSON"). Long chat sessions plus tool definitions
+// can exceed that ceiling even when the model's token context window (e.g.
+// 1M tokens on deepseek-v4-flash) is nowhere near full, because the request
+// is raw JSON bytes, not tokens.
+//
+// This module provides `trimApiMessages()`, which prunes older conversation
+// turns while preserving:
+//   - The system prompt (first message)
+//   - The most recent conversation turns (guaranteed minimum context)
+//   - Tool-call / tool-result atomicity
+// ---------------------------------------------------------------------------
+
+/** Hard uncompressed payload limit enforced by the gateway (bytes). */
+export const MAX_PAYLOAD_BYTES = 380_000;
+
+/**
+ * Message byte budgets for the trimmer.
+ *
+ * These budgets control how large the messages portion of the payload is
+ * allowed to grow before trimming kicks in. They sit well below
+ * `MAX_PAYLOAD_BYTES` to leave headroom for the rest of the request body
+ * (model name, tool definitions, temperature, stream flag, etc.), which can
+ * add ~80-100 KB on top of the messages.
+ */
+const MESSAGE_BUDGET_CHAT_COMPLETIONS = 200_000;
+const MESSAGE_BUDGET_MESSAGES = 200_000;
+const MESSAGE_BUDGET_RESPONSES = 200_000;
+const MESSAGE_BUDGET_GOOGLE = 200_000;
+
+/** Map endpoint kind -> byte budget for the messages array (pre-compression). */
+export const MESSAGE_BYTE_BUDGET: Record<string, number> = {
+  "chat-completions": MESSAGE_BUDGET_CHAT_COMPLETIONS,
+  messages: MESSAGE_BUDGET_MESSAGES,
+  responses: MESSAGE_BUDGET_RESPONSES,
+  google: MESSAGE_BUDGET_GOOGLE,
+};
+
+/**
+ * Trim `messages` so the JSON-serialized size of the messages array stays
+ * within `maxMessageBytes`. Always preserves the first message (system
+ * prompt). Keeps the last `MIN_TURNS` conversation turns unconditionally so
+ * the model retains recent context, then adds older turns newest-first as
+ * long as they fit within the byte budget. Drops whole turns — a turn is
+ * everything from a user message up to (but not including) the next user
+ * message — which guarantees tool-call / tool-result pairs are never broken.
+ *
+ * The function is generic: it accepts and returns the caller's own message
+ * type `T` as long as it has at least a `role` field.
+ *
+ * @returns A new array with the same message objects (not cloned). If no
+ *          trimming is needed the original array is returned.
+ */
+export function trimApiMessages<T extends { role?: unknown }>(
+  messages: readonly T[],
+  maxMessageBytes: number,
+): T[] {
+  // Fast path — short conversations don't need trimming.
+  if (messages.length <= 2) {
+    return [...messages];
+  }
+  const sizes = messages.map((m) => JSON.stringify(m).length);
+  const totalSize = sizes.reduce((a, b) => a + b, 0);
+  if (totalSize <= maxMessageBytes) {
+    return [...messages];
+  }
+  // ------------------------------------------------------------------
+  // Find user-message boundaries. The first message is always a user
+  // message (the system prompt). Subsequent user messages mark the
+  // start of new conversation turns.
+  // ------------------------------------------------------------------
+  const userIndices = [0]; // system prompt
+  for (let i = 1; i < messages.length; i++) {
+    if (messages[i].role === "user") {
+      userIndices.push(i);
+    }
+  }
+  // ------------------------------------------------------------------
+  // Always keep the system prompt.
+  // ------------------------------------------------------------------
+  const keep = new Set<number>([0]);
+  let usedBytes = sizes[0];
+  // ------------------------------------------------------------------
+  // Phase 1 — Guaranteed minimum context.
+  // Always keep the last MIN_TURNS conversation turns, even if they
+  // exceed the byte budget. This ensures the model always has enough
+  // recent context to give coherent answers.
+  // ------------------------------------------------------------------
+  const MIN_TURNS = 2;
+  const totalTurns = userIndices.length - 1; // excluding system prompt
+  const guaranteedTurns = Math.min(MIN_TURNS, totalTurns);
+  for (let ui = userIndices.length - 1; ui >= userIndices.length - guaranteedTurns; ui--) {
+    const turnStart = userIndices[ui];
+    const turnEnd = ui + 1 < userIndices.length ? userIndices[ui + 1] : messages.length;
+    let turnSize = 0;
+    for (let i = turnStart; i < turnEnd; i++) {
+      turnSize += sizes[i];
+    }
+    for (let i = turnStart; i < turnEnd; i++) {
+      keep.add(i);
+    }
+    usedBytes += turnSize;
+  }
+  // ------------------------------------------------------------------
+  // Phase 2 — Fill remaining budget with older turns (newest first).
+  // Walk backwards from the oldest guaranteed turn, adding additional
+  // turns as long as they fit within the byte budget.
+  // ------------------------------------------------------------------
+  const startUi = userIndices.length - 1 - guaranteedTurns;
+  for (let ui = startUi; ui >= 1; ui--) {
+    const turnStart = userIndices[ui];
+    const turnEnd = ui + 1 < userIndices.length ? userIndices[ui + 1] : messages.length;
+    let turnSize = 0;
+    for (let i = turnStart; i < turnEnd; i++) {
+      turnSize += sizes[i];
+    }
+    if (usedBytes + turnSize <= maxMessageBytes) {
+      for (let i = turnStart; i < turnEnd; i++) {
+        keep.add(i);
+      }
+      usedBytes += turnSize;
+    } else {
+      // This turn doesn't fit — and all older turns are even less
+      // recent, so they don't fit either.
+      break;
+    }
+  }
+  // ------------------------------------------------------------------
+  // Reconstruct in original order.
+  // ------------------------------------------------------------------
+  const kept: T[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    if (keep.has(i)) {
+      kept.push(messages[i]);
+    }
+  }
+  return kept;
+}

--- a/src/test/messageTrimmer.test.ts
+++ b/src/test/messageTrimmer.test.ts
@@ -1,0 +1,129 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  MAX_PAYLOAD_BYTES,
+  MESSAGE_BYTE_BUDGET,
+  trimApiMessages,
+} from "../messageTrimmer.js";
+
+/**
+ * Unit tests for the byte-aware payload trimmer (issue #104).
+ *
+ * CONTEXT / ROOT CAUSE:
+ * The OpenCode Go gateway rejects request bodies over ~400 KB with a cryptic
+ * `400 Upstream response was not valid JSON` even when the model's token
+ * context window is far from full, because the limit is raw JSON bytes, not
+ * tokens. Long sessions accumulate history past that ceiling. The fix trims
+ * older conversation turns (preserving the system prompt, the most recent
+ * turns, and tool-call atomicity) before the body is built.
+ */
+
+interface Msg {
+  role: string;
+  content: string;
+  tool_call_id?: string;
+  tool_calls?: Array<{ id: string }>;
+}
+
+function msg(role: string, content: string): Msg {
+  return { role, content };
+}
+
+function bigMsg(role: string, kBytes: number): Msg {
+  return { role, content: "x".repeat(kBytes * 1024) };
+}
+
+describe("trimApiMessages", () => {
+  it("leaves short conversations untouched", () => {
+    const messages = [msg("user", "hi"), msg("assistant", "hello")];
+    const out = trimApiMessages(messages, MESSAGE_BYTE_BUDGET["chat-completions"]);
+    assert.equal(out.length, 2);
+    assert.equal(out[0].content, "hi");
+    assert.equal(out[1].content, "hello");
+  });
+
+  it("keeps the system prompt when trimming", () => {
+    const messages = [
+      msg("system", "you are a helpful assistant"),
+      // ~600 KB of history, way over the 200 KB budget
+      ...Array.from({ length: 20 }, (_, i) => [bigMsg("user", 15), bigMsg("assistant", 15)]).flat(),
+    ];
+    const out = trimApiMessages(messages, MESSAGE_BYTE_BUDGET["chat-completions"]);
+    assert.ok(out.length < messages.length, "expected trimming");
+    assert.equal(out[0].content, "you are a helpful assistant", "system prompt must survive");
+  });
+
+  it("keeps the most recent turns (guaranteed minimum context)", () => {
+    const messages = [
+      msg("system", "s"),
+      // 12 turns x 10 KB each = ~240 KB, over the 100 KB budget
+      ...Array.from({ length: 12 }, (_, i) => [bigMsg("user", 10), bigMsg("assistant", 10)]).flat(),
+      msg("user", "q-last"),
+      msg("assistant", "a-last"),
+    ];
+    const out = trimApiMessages(messages, 100 * 1024);
+    assert.ok(out.length < messages.length, "expected trimming");
+    assert.equal(out[out.length - 1].content, "a-last", "last turn kept");
+    assert.equal(out[out.length - 2].content, "q-last", "penultimate message kept");
+  });
+
+  it("never splits a tool-call / tool-result pair", () => {
+    const messages = [
+      msg("system", "s"),
+      // Oldest turn — must be dropped (over budget)
+      bigMsg("user", 40),
+      { ...msg("assistant", ""), tool_calls: [{ id: "call_old" }] },
+      { ...msg("tool", "result"), tool_call_id: "call_old" },
+      bigMsg("assistant", 40),
+      // Middle turn — kept by the guaranteed-minimum-context phase
+      bigMsg("user", 40),
+      bigMsg("assistant", 1),
+      // Recent turn with a tool call — must survive intact
+      msg("user", "recent question"),
+      { ...msg("assistant", ""), tool_calls: [{ id: "call_new" }] },
+      { ...msg("tool", "result"), tool_call_id: "call_new" },
+      msg("assistant", "done"),
+    ];
+    const out = trimApiMessages(messages, 100 * 1024);
+    assert.ok(out.length < messages.length, "expected trimming");
+    const hasCall = out.some((m) => m.role === "assistant" && m.tool_calls);
+    const hasResult = out.some((m) => m.role === "tool");
+    assert.equal(hasCall, hasResult, "tool call and result must be kept or dropped together");
+    assert.ok(
+      out.some((m) => m.tool_calls?.some((t) => t.id === "call_new")),
+      "recent tool call must survive",
+    );
+    assert.ok(
+      out.some((m) => m.tool_call_id === "call_new"),
+      "recent tool result must survive",
+    );
+    assert.ok(
+      !out.some((m) => m.tool_calls?.some((t) => t.id === "call_old")),
+      "old tool call must be dropped",
+    );
+  });
+
+  it("keeps the resulting messages within the byte budget when possible", () => {
+    const messages = [
+      msg("system", "s"),
+      // ~200 KB of old history (10 x 20 KB turns)
+      ...Array.from({ length: 10 }, (_, i) => [bigMsg("user", 10), bigMsg("assistant", 10)]).flat(),
+      msg("user", "recent question"),
+      msg("assistant", "recent answer"),
+    ];
+    const budget = 100 * 1024;
+    const out = trimApiMessages(messages, budget);
+    const size = JSON.stringify(out).length;
+    assert.ok(size <= budget, `trimmed payload ${size} must fit ${budget}`);
+    assert.equal(out[0].content, "s");
+    assert.equal(out[out.length - 1].content, "recent answer");
+  });
+
+  it("exports a per-endpoint budget for every routed endpoint kind", () => {
+    for (const kind of ["chat-completions", "messages", "responses", "google"]) {
+      const budget = MESSAGE_BYTE_BUDGET[kind];
+      assert.ok(typeof budget === "number" && budget > 0, `budget for ${kind}`);
+      assert.ok(budget < MAX_PAYLOAD_BYTES, `${kind} budget ${budget} stays under ${MAX_PAYLOAD_BYTES}`);
+    }
+  });
+});


### PR DESCRIPTION
### Environment
- Extension: `opencode-copilot-chat` 0.4.5 (latest)
- Provider: OpenCode Go, model `deepseek-v4-flash` (also occurs across other models)
- VS Code: latest, macOS

### What happened
Sending a message in a long session fails with:

```
OpenCode Go API request failed (400) model=deepseek-v4-flash payloadBytes=563749: Error from provider (Console Go): Upstream request failed: [server_error] Upstream response was not valid JSON
```

### Steps to reproduce
1. Build a long session (~500KB+ of accumulated context / file attachments).
2. Send a message.

### Expected
The extension keeps the request body under the gateway's limit — it ships tooling for exactly this.

### Root cause
`out/messageTrimmer.js` defines `trimApiMessages()` with a 200KB messages budget and `MAX_PAYLOAD_BYTES = 380_000`, and its header states: *"The OpenCode Go API proxy returns HTTP 500 when the JSON request body exceeds ~400 KB."* But no code path calls `trimApiMessages` — a grep across `out/` shows it is referenced only inside `messageTrimmer.js` itself. The safety net is never wired up, so a 563KB body goes straight to the gateway and gets rejected.

#83 / PR #84 fixed context-window overflow by capping `maxOutputTokens` via `modelLimits()`, but that does not bound the raw request body, so this case still fails on the gateway body-size limit.

### Suggestion
Invoke `trimApiMessages()` with `MESSAGE_BYTE_BUDGET[endpointKind]` before `JSON.stringify(body)` in the request path (`out/streaming.js`), preserving the system prompt and tool-call atomicity as the module documents.

### Workaround
Starting a new chat session keeps the payload small and avoids the failure.