### PR TITLE
fix(vscode): drop managementCommand from model providers to restore native BYOK group flow (#121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the **OpenCode Go BYOK Provider** extension are documente
 
 ## [Unreleased]
 
+### Fixed
+
+- **`[VS Code]` Provider context menu unresponsive; "+ Add Models" dead; leftover groups undeletable (#121).** The `languageModelChatProviders` contributions declared both `managementCommand` and a `configuration` schema. VS Code's native BYOK flow (`configureLanguageModelsProviderGroup`) short-circuits on `managementCommand` — it re-resolves models and returns without prompting for a group name or API key — so a BYOK group could never be created through "+ Add Models", and every built-in context-menu action (Rename Group, Update API Key, Delete, Open in Language Models (JSON)) throws "group not found", failing silently. Dropped `managementCommand` from the `opencodego`, `opencodezen`, and agent-variant contributions; "+ Add Models" now runs the native prompt flow, the context-menu actions work against the created group, and leftover groups (e.g. created by per-model configuration) can finally be deleted. The extension's own commands (`OpenCode Go: Manage Provider`, `Set API Key`, etc.) remain available in the Command Palette and keep working as a legacy fallback.
+
 ## [0.5.1] — 2026-08-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -280,7 +280,6 @@
       {
         "vendor": "opencodego",
         "displayName": "OpenCode Go",
-        "managementCommand": "opencodego.manage",
         "configuration": {
           "type": "object",
           "required": [
@@ -299,7 +298,6 @@
       {
         "vendor": "opencodezen",
         "displayName": "OpenCode Zen",
-        "managementCommand": "opencodezen.manage",
         "configuration": {
           "type": "object",
           "required": [
@@ -318,13 +316,11 @@
       {
         "vendor": "opencodego-agent",
         "displayName": "OpenCode Go (Agents)",
-        "managementCommand": "opencodego.manage",
         "when": "config.opencodego.showAgentModelsInManagePanel"
       },
       {
         "vendor": "opencodezen-agent",
         "displayName": "OpenCode Zen (Agents)",
-        "managementCommand": "opencodezen.manage",
         "when": "config.opencodego.showAgentModelsInManagePanel"
       }
     ]


### PR DESCRIPTION
Closes #121

## Problem

The `languageModelChatProviders` contributions declared **both** `managementCommand` and a `configuration` schema. VS Code's built-in `configureLanguageModelsProviderGroup()` **short-circuits on `managementCommand`** — it just re-resolves the models and returns, never prompting for a group name or API key. Consequences:

- **"+ Add Models"** clicking *OpenCode Go* / *OpenCode Zen* did nothing (no API key prompt, no group created).
- **Context menu unresponsive** — *Rename Group*, *Delete*, *Update API Key*, *Open in Language Models (JSON)* all operate on groups in `chatLanguageModels.json`, but no group could ever be created through the UI, so every action throws `Language model provider group … not found` and fails silently.
- **Leftover default group can't be removed** — e.g. the `OpenCode Go` group persisted in `chatLanguageModels.json` (created by per-model `reasoningEffort` configuration) could never be deleted.

## Fix

Removed `managementCommand` from the `opencodego`, `opencodezen`, `opencodego-agent`, and `opencodezen-agent` contributions. With only the `configuration` schema present, VS Code's native BYOK flow runs end-to-end:

- `+ Add Models` prompts for a group name + API key and creates the group.
- Rename / Update API Key / Delete / Open in Language Models (JSON) now work against that group.
- The stale/leftover group can finally be deleted.

The extension's own management commands (`OpenCode Go: Manage Provider`, `OpenCode Go: Set API Key`, …) remain registered and keep working as the legacy secret-storage path, which the provider continues to fall back to (`getConfiguredApiKey` → secret storage, see `provideLanguageModelChatInformation`).

## Verification

- [x] Installed the packaged VSIX on VS Code 1.132 — `+ Add Models → OpenCode Go` now prompts and creates the group; gear/context-menu actions work; the leftover group is deletable.
- [x] `npm run compile` — clean.
- [x] `npm test` — 161/161 pass.
- [x] `npm run lint` — clean.