### PR TITLE
fix(provider): duplicate OpenCode models after per-model config (e.g. reasoningEffort) (#131)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,13 @@ jobs:
       - name: 🔎 Lint source and maintenance docs
         env:
           # The `shellcheck` npm package downloads its binary from GitHub
-          # releases on first run, which flakes in CI (socket hang up / rate
-          # limits). Use the runner's system binary instead.
-          SHELLCHECKJS_BIN: /usr/bin/shellcheck
+          # releases on first run (flaky in CI), and its SHELLCHECKJS_BIN
+          # validator requires a user-writable binary. Install via apt and
+          # point it at a writable copy in the runner's temp dir.
+          SHELLCHECKJS_BIN: ${{ runner.temp }}/shellcheck
         run: |
           sudo apt-get update && sudo apt-get install -y shellcheck
+          cp /usr/bin/shellcheck "$SHELLCHECKJS_BIN"
           npm run lint
 
       - name: 🎨 Check formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,14 @@ jobs:
         run: npm run compile
 
       - name: 🔎 Lint source and maintenance docs
-        run: npm run lint
+        env:
+          # The `shellcheck` npm package downloads its binary from GitHub
+          # releases on first run, which flakes in CI (socket hang up / rate
+          # limits). Use the runner's system binary instead.
+          SHELLCHECKJS_BIN: /usr/bin/shellcheck
+        run: |
+          sudo apt-get update && sudo apt-get install -y shellcheck
+          npm run lint
 
       - name: 🎨 Check formatting
         run: npm run format:check

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2049,6 +2049,15 @@ class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCodeModel
     // (issue #106, see step 2 below).
     if (apiKey) {
       await this.markByokGroupConfigured();
+    } else if (opts.configuration !== undefined) {
+      // A group call with a non-undefined configuration that carries no API
+      // key is a per-model configuration group (only `settings`, no key —
+      // e.g. a `reasoningEffort` picked in the model picker). VS Code
+      // resolves its configuration to `{}` here. The groupless call already
+      // served the models via SecretStorage, so serving them again would
+      // duplicate every model (issue #131). The per-model settings still
+      // apply at request time via `modelConfiguration`.
+      return [];
     }
 
     // 2. Fall back to the extension's own secret storage when BYOK did not


### PR DESCRIPTION
Closes #131

## Problem

Setting a per-model option (e.g. `reasoningEffort`) in the model picker creates a settings-only group in `chatLanguageModels.json`. VS Code then calls `provideLanguageModelChatInformation` once per configured group, and the settings-only group resolves to `configuration: {}` — no `apiKey`. The extension's SecretStorage fallback ran on **both** the groupless call and the group call, serving every model twice (7 → 14 in the report).

The #106 fix only suppresses the groupless call when an `apiKey`-bearing group call was observed, so it doesn't cover this path.

## Fix

A group call whose `configuration` is present but carries no API key is now treated as a per-model configuration group and returns `[]` — the groupless call already served the models. Verified against the VS Code source (`languageModels.ts`): the groupless call passes no `configuration`, group calls always do, so this can't suppress the groupless path.

Per-model settings (e.g. `reasoningEffort`) are applied at request time via `modelConfiguration` and are unaffected.

## Verification

- [x] `npm test` 180/180, `npm run lint` (strict + tsc) green.
- [x] Scenarios preserved: #86 (key via command, no group), #106/#63 (groups carrying an `apiKey`), agent variants (no configuration schema → `configuration` always `undefined`).