### PR TITLE
docs(streaming): refresh treatReasoningAsContent JSDoc for the family-aware rule

### DIFF
--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -989,8 +989,11 @@ class OpenAiResponseExtractor extends BaseResponseExtractor {
      *
      * CONTRACT:
      * - Only set for Go-gateway requests where `reasoning_effort` is NOT in the
-     *   payload (i.e. MiMo thinking is OFF). When thinking IS on, the model
-     *   genuinely uses reasoning_content for CoT → goes to thinking panel.
+     *   payload AND the model genuinely stops reasoning without an explicit
+     *   effort (the verified case is MiMo thinking OFF). Reasoning-first
+     *   families (DeepSeek V4) keep producing real CoT even when thinking is
+     *   off, so their `reasoning_content` goes to the thinking panel — see
+     *   {@link modelAlwaysReasons}.
      * - Zen gateway and all non-Go models are never affected.
      */
     private readonly treatReasoningAsContent = false,


### PR DESCRIPTION
## What

Doc-only follow-up to #150 (nit flagged in review, non-blocking).

The `treatReasoningAsContent` constructor param JSDoc still read *"i.e. MiMo thinking is OFF"*, which is stale since #150 made the flag family-aware: the workaround now applies only to models that genuinely stop reasoning without an explicit effort (verified: MiMo), while reasoning-first families (DeepSeek V4) keep their genuine CoT in the thinking panel.

Updated the CONTRACT block to describe the real rule and reference `modelAlwaysReasons`.

## Verification

Doc-only change — compile, 276 unit tests, strict lint all green.