### PR TITLE
Fix infinite looping for MiMo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ All notable changes to the **OpenCode Go BYOK Provider** extension are documente
 
 ### Fixed
 
-- **`[Thinking]` Sampling-level `repetition_penalty` for MiMo curbs infinite thinking loops (#36, https://github.com/XiaomiMiMo/MiMo-Code/issues/914).** A `repetition_penalty: 1.2` is now applied unconditionally in every MiMo payload (regardless of reasoning effort) to suppress the degenerate token-repeat pattern that triggered the Go gateway's infinite-loop detector upstream. This is a third mitigation layer alongside the `budget_tokens` cap and suffix-repetition stream detection shipped earlier. Applies with reasoning off (where the loop fires less often) and on; does not trip `bodyRequestsThinking()` so the gateway workaround path is unaffected.
+- **`[Thinking]` Sampling-level `repetition_penalty` for MiMo curbs infinite thinking loops (#36).** A `repetition_penalty: 1.2` is now applied unconditionally in every MiMo payload (regardless of reasoning effort) to suppress the degenerate token-repeat pattern that triggered the Go gateway's infinite-loop detector upstream. This is a third mitigation layer alongside the `budget_tokens` cap and suffix-repetition stream detection shipped earlier. Applies with reasoning off (where the loop fires less often) and on; does not trip `bodyRequestsThinking()` so the gateway workaround path is unaffected.
 
 - **DeepSeek / Mimo thinking content no longer leaks into the chat transcript.** `treatReasoningAsContent` was mis-detecting native-reasoning families as "no reasoning in body" and echoing their `reasoning_content` as plain chat text. The decision now comes from the provider strategy (always `false` for DeepSeek and Mimo), so chain-of-thought stays in the thinking panel.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ All notable changes to the **OpenCode Go BYOK Provider** extension are documente
 
 ### Fixed
 
+- **`[Thinking]` Sampling-level `repetition_penalty` for MiMo curbs infinite thinking loops (#36, https://github.com/XiaomiMiMo/MiMo-Code/issues/914).** A `repetition_penalty: 1.2` is now applied unconditionally in every MiMo payload (regardless of reasoning effort) to suppress the degenerate token-repeat pattern that triggered the Go gateway's infinite-loop detector upstream. This is a third mitigation layer alongside the `budget_tokens` cap and suffix-repetition stream detection shipped earlier. Applies with reasoning off (where the loop fires less often) and on; does not trip `bodyRequestsThinking()` so the gateway workaround path is unaffected.
+
 - **DeepSeek / Mimo thinking content no longer leaks into the chat transcript.** `treatReasoningAsContent` was mis-detecting native-reasoning families as "no reasoning in body" and echoing their `reasoning_content` as plain chat text. The decision now comes from the provider strategy (always `false` for DeepSeek and Mimo), so chain-of-thought stays in the thinking panel.
 
 ## [0.6.0] — 2026-08-13

--- a/src/test/thinking.test.ts
+++ b/src/test/thinking.test.ts
@@ -175,14 +175,14 @@ describe("DeepSeekThinking — display (native reasoning model)", () => {
 });
 
 describe("MimoThinking — payload + display (native reasoning model)", () => {
-  it("mimo 'off' emits empty object", () => {
+  it("mimo 'off' emits only repetition_penalty", () => {
     const payload = thinkingProviderFor("mimo-v2.5").buildPayload({ ...defaultSettings, mimo: "off" });
-    assert.deepEqual(payload, {});
+    assert.deepEqual(payload, { repetition_penalty: 1.2 });
   });
 
-  it("mimo 'medium' emits reasoning_effort + budget_tokens", () => {
+  it("mimo 'medium' emits reasoning_effort + budget_tokens + repetition_penalty", () => {
     const payload = thinkingProviderFor("mimo-v2.5").buildPayload({ ...defaultSettings, mimo: "medium" });
-    assert.deepEqual(payload, { reasoning_effort: "medium", budget_tokens: 16384 });
+    assert.deepEqual(payload, { reasoning_effort: "medium", budget_tokens: 16384, repetition_penalty: 1.2 });
   });
 
   it("never surfaces reasoning_content as visible text (native reasoning model)", () => {

--- a/src/thinking/mimo.ts
+++ b/src/thinking/mimo.ts
@@ -57,6 +57,8 @@ export class MimoThinking extends BaseThinkingProvider {
     return {
       reasoning_effort: thinking.mimo,
       ...(mimoBudget !== undefined ? { budget_tokens: mimoBudget } : {}),
+      // Fixes infinite-loop: https://github.com/XiaomiMiMo/MiMo-Code/issues/914
+      repetition_penalty: 1.2,
     };
   }
 

--- a/src/thinking/mimo.ts
+++ b/src/thinking/mimo.ts
@@ -50,15 +50,16 @@ export class MimoThinking extends BaseThinkingProvider {
   }
 
   buildPayload(thinking: ThinkingSettings, _opts?: BuildThinkingPayloadOptions): Record<string, unknown> {
+    // Fixes infinite-loop: https://github.com/XiaomiMiMo/MiMo-Code/issues/914
+    const base: Record<string, unknown> = { repetition_penalty: 1.2 };
     if (thinking.mimo === "off") {
-      return {};
+      return base;
     }
     const mimoBudget = MIMO_BUDGET_MAP[thinking.mimo];
     return {
+      ...base,
       reasoning_effort: thinking.mimo,
       ...(mimoBudget !== undefined ? { budget_tokens: mimoBudget } : {}),
-      // Fixes infinite-loop: https://github.com/XiaomiMiMo/MiMo-Code/issues/914
-      repetition_penalty: 1.2,
     };
   }
 

--- a/src/thinking/mimo.ts
+++ b/src/thinking/mimo.ts
@@ -16,6 +16,9 @@ import type { ThinkingSettings, ThinkingFamily, BuildThinkingPayloadOptions } fr
 
 const MIMO_EFFORTS = ["off", "low", "medium", "high"] as const;
 
+/** Sampling-level repetition penalty — applied unconditionally to curb infinite thinking loops. */
+const MIMO_REPETITION_PENALTY = 1.2;
+
 /** Effort → reasoning-token budget cap (conservative; see buildPayload). */
 const MIMO_BUDGET_MAP: Record<string, number | undefined> = {
   low: 8192,
@@ -51,7 +54,7 @@ export class MimoThinking extends BaseThinkingProvider {
 
   buildPayload(thinking: ThinkingSettings, _opts?: BuildThinkingPayloadOptions): Record<string, unknown> {
     // Fixes infinite-loop: https://github.com/XiaomiMiMo/MiMo-Code/issues/914
-    const base: Record<string, unknown> = { repetition_penalty: 1.2 };
+    const base: Record<string, unknown> = { repetition_penalty: MIMO_REPETITION_PENALTY };
     if (thinking.mimo === "off") {
       return base;
     }


### PR DESCRIPTION
## 📝 What does this change?

Adds `repetition_penalty: 1.2` to MiMo payloads to fix infinite-thinking-loop observed in MiMo v2.5 / v2.5 Pro.

https://github.com/XiaomiMiMo/MiMo-Code/issues/914 - Important excerpt from the `Root Cause Analysis` section: NVIDIA community notes that repetition_penalty=1.2 mitigates MiMo "Thought Loop" failure mode

Contrary to most information I found on this issue, it does seem to happen when reasoning is off in MiMo too, it just seems to be less frequent, so I added it for both reasoning on and off.

## 🧪 How did you test it?

Tested with **MiMo v2.5 / v2.5 Pro** on **High** and **Off** reasoning effort, no longer loops endlessly.

## ✅ Checklist

- [x] `npm run compile` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (324/324)
- [x] `npm run package` produces a VSIX
- [x] I tested it works
- [x] I updated docs/CHANGELOG