### PR TITLE
Add force think tag stripping to fix blank code boxes appearing while subagents are running

### DIFF
--- a/src/core/transport.ts
+++ b/src/core/transport.ts
@@ -42,6 +42,12 @@ export interface StreamRequestOptions {
    * - "always" — strip for every model
    */
   stripThinkTags?: "never" | "auto" | "always";
+  /**
+   * Force think-tag stripping regardless of stripThinkTags mode.
+   * Set to true when the request is a subagent/tool-call invocation
+   * to prevent <think> tags in content from rendering as blank code blocks.
+   */
+  forceStripThinkTags?: boolean;
 }
 
 export interface TransportRequestSummary {

--- a/src/provider/OpenCodeProvider.ts
+++ b/src/provider/OpenCodeProvider.ts
@@ -678,8 +678,8 @@ export class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCo
     if (registeredCount > 0) {
       this.log(
         `Models registered: count=${String(registeredCount)} provider=${this.definition.vendor}` +
-          ` first=${firstModelId} last=${lastModelId}` +
-          (this.definition.isAgentVariant ? " (agents)" : ""),
+        ` first=${firstModelId} last=${lastModelId}` +
+        (this.definition.isAgentVariant ? " (agents)" : ""),
       );
     }
 
@@ -901,6 +901,11 @@ export class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCo
 
     try {
       const contextWindowOutputBuffer = limits.advertisedMaxOutputTokens;
+      // Subagent/tool-call requests always have tools present. Force
+      // think-tag stripping for these requests to prevent <think> tags
+      // in content from rendering as blank code blocks in the chat UI.
+      const isToolCallRequest = Array.isArray(options.tools) && options.tools.length > 0;
+      const forceStripThinkTags = isToolCallRequest || undefined;
 
       if (routing.endpointKind === "messages") {
         await runStreamAnthropicMessages({
@@ -921,6 +926,7 @@ export class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCo
           capacityLimitedModelNotes: CAPACITY_LIMITED_MODEL_NOTES,
           onTransportSummary,
           stripThinkTags: settings.stripThinkTags,
+          forceStripThinkTags,
         });
         return;
       }
@@ -944,6 +950,7 @@ export class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCo
           capacityLimitedModelNotes: CAPACITY_LIMITED_MODEL_NOTES,
           onTransportSummary,
           stripThinkTags: settings.stripThinkTags,
+          forceStripThinkTags,
           onReasoningContent: (toolCallIds, reasoningContent) => {
             this.storeReasoningContent(toolCallIds, reasoningContent);
           },
@@ -971,6 +978,7 @@ export class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCo
           capacityLimitedModelNotes: CAPACITY_LIMITED_MODEL_NOTES,
           onTransportSummary,
           stripThinkTags: settings.stripThinkTags,
+          forceStripThinkTags,
           onReasoningContent: (toolCallIds, reasoningContent) => {
             this.storeReasoningContent(toolCallIds, reasoningContent);
           },
@@ -997,6 +1005,7 @@ export class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCo
         capacityLimitedModelNotes: CAPACITY_LIMITED_MODEL_NOTES,
         onTransportSummary,
         stripThinkTags: settings.stripThinkTags,
+        forceStripThinkTags,
         treatReasoningAsContent: thinkingProviderFor(rawModelId).treatReasoningAsContent(routing.endpointUrl, settings.thinking),
         onReasoningContent: (toolCallIds, reasoningContent) => {
           this.storeReasoningContent(toolCallIds, reasoningContent);

--- a/src/provider/OpenCodeProvider.ts
+++ b/src/provider/OpenCodeProvider.ts
@@ -678,8 +678,8 @@ export class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCo
     if (registeredCount > 0) {
       this.log(
         `Models registered: count=${String(registeredCount)} provider=${this.definition.vendor}` +
-        ` first=${firstModelId} last=${lastModelId}` +
-        (this.definition.isAgentVariant ? " (agents)" : ""),
+          ` first=${firstModelId} last=${lastModelId}` +
+          (this.definition.isAgentVariant ? " (agents)" : ""),
       );
     }
 

--- a/src/transports/anthropic.ts
+++ b/src/transports/anthropic.ts
@@ -6,7 +6,7 @@ import { extractAnthropicParts } from "./extract";
 
 /** Anthropic Messages API transport (Claude-family / MiniMax m2.x / Qwen 3.x-plus). */
 export async function streamAnthropicMessages(options: StreamRequestOptions): Promise<void> {
-  const thinkFilter = createThinkTagFilter(options.stripThinkTags, options.modelId);
+  const thinkFilter = createThinkTagFilter(options.stripThinkTags, options.modelId, options.forceStripThinkTags);
   const extractor = new AnthropicResponseExtractor(
     options.onReasoningContent,
     createReasoningDebugger(options.output, options.debugReasoning),

--- a/src/transports/chatCompletions.ts
+++ b/src/transports/chatCompletions.ts
@@ -8,7 +8,7 @@ import { reportProgressPart } from "./streamParts";
 
 /** OpenAI-compatible chat-completions transport. */
 export async function streamChatCompletions(options: StreamRequestOptions): Promise<void> {
-  const thinkFilter = createThinkTagFilter(options.stripThinkTags, options.modelId);
+  const thinkFilter = createThinkTagFilter(options.stripThinkTags, options.modelId, options.forceStripThinkTags);
   // Display decision: whether `reasoning_content` should be surfaced as visible
   // text instead of a thinking part. Computed UPSTREAM by the thinking provider
   // strategy from the resolved thinking config — not inferred from the body

--- a/src/transports/google.ts
+++ b/src/transports/google.ts
@@ -7,7 +7,7 @@ import { extractChatCompletionParts } from "./extract";
 
 /** Google Generative Language API transport (Gemini via Zen). */
 export async function streamGoogleGenerateContent(options: StreamRequestOptions): Promise<void> {
-  const thinkFilter = createThinkTagFilter(options.stripThinkTags, options.modelId);
+  const thinkFilter = createThinkTagFilter(options.stripThinkTags, options.modelId, options.forceStripThinkTags);
   const extractor = new OpenAiResponseExtractor(
     options.onReasoningContent,
     createReasoningDebugger(options.output, options.debugReasoning),

--- a/src/transports/responses.ts
+++ b/src/transports/responses.ts
@@ -7,7 +7,7 @@ import { extractChatCompletionParts } from "./extract";
 
 /** OpenAI Responses API transport (GPT-family models). */
 export async function streamResponsesApi(options: StreamRequestOptions): Promise<void> {
-  const thinkFilter = createThinkTagFilter(options.stripThinkTags, options.modelId);
+  const thinkFilter = createThinkTagFilter(options.stripThinkTags, options.modelId, options.forceStripThinkTags);
   const extractor = new OpenAiResponseExtractor(
     options.onReasoningContent,
     createReasoningDebugger(options.output, options.debugReasoning),

--- a/src/transports/thinkTags.ts
+++ b/src/transports/thinkTags.ts
@@ -32,8 +32,13 @@ export function shouldStripThinkTags(mode: "never" | "auto" | "always" | undefin
   return /^minimax-m/i.test(modelId);
 }
 
-export function createThinkTagFilter(mode: "never" | "auto" | "always" | undefined, modelId: string): ThinkTagFilter | undefined {
-  return shouldStripThinkTags(mode, modelId) ? new ThinkTagFilter() : undefined;
+export function createThinkTagFilter(
+  mode: "never" | "auto" | "always" | undefined,
+  modelId: string,
+  forceOverride?: boolean,
+): ThinkTagFilter | undefined {
+  const effective = forceOverride ? "always" : mode;
+  return shouldStripThinkTags(effective, modelId) ? new ThinkTagFilter() : undefined;
 }
 
 export class ThinkTagFilter {


### PR DESCRIPTION
## 📝 What does this change?

Force think-tag stripping when tools are present in the request (subagent/tool-call invocations). This prevents <think> tags in content from rendering as blank code blocks in the chat UI when using a subagent, flooding the chat with blank code boxes.

The trigger is tool-call detection (options.tools.length > 0), not model-specific. The ThinkTagFilter is a no-op for models that don't emit think tags, so this is safe for all models.

## 🧪 How did you test it?

Tested with **MiMo v2.5**

## ✅ Checklist

- [x] `npm run compile` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] `npm run package` produces a VSIX
- [x] I tested it works
- [x] I updated docs/CHANGELOG if needed