### PR TITLE
fix: GLM 5.3 always-thinking (force-on) — fixes #162

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ All notable changes to the **OpenCode Go BYOK Provider** extension are documente
 
 - **DeepSeek / Mimo thinking content no longer leaks into the chat transcript.** `treatReasoningAsContent` was mis-detecting native-reasoning families as "no reasoning in body" and echoing their `reasoning_content` as plain chat text. The decision now comes from the provider strategy (always `false` for DeepSeek and Mimo), so chain-of-thought stays in the thinking panel.
 
+- **`[Thinking]` GLM 5.3+ can no longer be disabled (HTTP 400, #162).** GLM 5.3 and later reject `thinking: { type: "disabled" }` with _"This model always engages in thinking and cannot be disabled; please use low, high, or max"_. `GlmThinking` now detects GLM 5.3+ by version and forces thinking on (default `high`; the picker exposes only `high`/`max` and hides `off`), mirroring the Kimi K2.7-code force-on fix. A defensive retry pattern in `retry.ts` also strips `thinking` when the upstream reports it cannot be disabled, so any stale cached `off` is recovered automatically. Unit tests added for version detection, forced-on resolution, payload shape and picker schema.
+
 ## [0.6.0] — 2026-08-13
 
 ### Added

--- a/docs/features/02-20260517-per-model-thinking-controls.md
+++ b/docs/features/02-20260517-per-model-thinking-controls.md
@@ -59,6 +59,8 @@ The feature adds explicit settings under the `opencodego.thinking.*` namespace:
 
 These settings act as persistent defaults and as a fallback when the VS Code model picker does not expose native model configuration controls.
 
+> **GLM 5.3+ cannot disable thinking (issue #162).** GLM 5.3 and later reject `thinking: { type: "disabled" }` with _"This model always engages in thinking and cannot be disabled"_. The `glm` strategy detects 5.3+ by version, forces thinking on (default `high`), and hides `off` from the picker — mirroring the Kimi K2.7-code force-on behavior. A defensive retry pattern also strips `thinking` when the upstream reports it cannot be disabled.
+
 ### Native Model Configuration Schema
 
 Thinking-capable models publish a `configurationSchema` through `LanguageModelChatInformation`.

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -66,8 +66,10 @@ const RECOVERABLE_ERROR_PATTERNS: {
     describe: () => "removed thinking field (model requires disabled)",
   },
   // "This model always engages in thinking and cannot be disabled" (GLM 5.3+)
+  // Scoped to thinking-related phrasing so unrelated "cannot be disabled"
+  // errors never trigger a thinking-strip retry.
   {
-    pattern: /cannot be disabled/i,
+    pattern: /always engages in thinking|thinking.*cannot be disabled/i,
     patch: (body) => {
       const next = { ...body };
       delete next.thinking;

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -65,6 +65,16 @@ const RECOVERABLE_ERROR_PATTERNS: {
     },
     describe: () => "removed thinking field (model requires disabled)",
   },
+  // "This model always engages in thinking and cannot be disabled" (GLM 5.3+)
+  {
+    pattern: /cannot be disabled/i,
+    patch: (body) => {
+      const next = { ...body };
+      delete next.thinking;
+      return next;
+    },
+    describe: () => "removed thinking field (model cannot disable thinking)",
+  },
   // Generic "invalid thinking" — strip the field entirely
   {
     pattern: /invalid thinking/i,

--- a/src/test/retry.test.ts
+++ b/src/test/retry.test.ts
@@ -35,6 +35,12 @@ describe("analyzeHttp400ForRetry — thinking errors", () => {
     assert.deepEqual(result.body, { model: "glm-5.3" });
     assert.match(result.reason, /cannot disable thinking/i);
   });
+
+  it("does not patch unrelated errors that merely contain 'cannot be disabled'", () => {
+    const body = { model: "glm-5.3", thinking: { type: "disabled" } };
+    const result = analyzeHttp400ForRetry("feature X cannot be disabled for this account", body);
+    assert.equal(result, undefined);
+  });
 });
 
 describe("analyzeHttp400ForRetry — temperature errors", () => {

--- a/src/test/retry.test.ts
+++ b/src/test/retry.test.ts
@@ -24,6 +24,17 @@ describe("analyzeHttp400ForRetry — thinking errors", () => {
     assert.ok(result, "should be recoverable");
     assert.deepEqual(result.body, { model: "test", temperature: 0.2 });
   });
+
+  it("patches GLM 'cannot be disabled' by removing thinking (issue #162)", () => {
+    const body = { model: "glm-5.3", thinking: { type: "disabled" } };
+    const result = analyzeHttp400ForRetry(
+      "Upstream request failed: [1210] This model always engages in thinking and cannot be disabled; please use low, high, or max",
+      body,
+    );
+    assert.ok(result, "should be recoverable");
+    assert.deepEqual(result.body, { model: "glm-5.3" });
+    assert.match(result.reason, /cannot disable thinking/i);
+  });
 });
 
 describe("analyzeHttp400ForRetry — temperature errors", () => {

--- a/src/test/thinking.test.ts
+++ b/src/test/thinking.test.ts
@@ -262,6 +262,64 @@ describe("GLMThinking — picker schema", () => {
   });
 });
 
+describe("GLMThinking — glm-5.3 always-thinking (issue #162)", () => {
+  it("forces glm='high' through resolve even with no override (defensive default)", () => {
+    const resolved = resolveThinkingConfig({ modelId: "glm-5.3", workspace: defaultSettings });
+    assert.equal(resolved.settings.glm, "high");
+  });
+
+  it("forces glm='high' even when override requests 'off' (stale cache)", () => {
+    const resolved = resolveThinkingConfig({
+      modelId: "glm-5.3",
+      workspace: defaultSettings,
+      modelConfiguration: { reasoningEffort: "off" },
+    });
+    assert.equal(resolved.settings.glm, "high");
+  });
+
+  it("respects a valid 'max' override for glm-5.3", () => {
+    const resolved = resolveThinkingConfig({
+      modelId: "glm-5.3",
+      workspace: defaultSettings,
+      modelConfiguration: { reasoningEffort: "max" },
+    });
+    assert.equal(resolved.settings.glm, "max");
+  });
+
+  it("glm-5.3 with glm='high' emits reasoning_effort: 'high' (never disabled)", () => {
+    const payload = thinkingProviderFor("glm-5.3").buildPayload({ ...defaultSettings, glm: "high" });
+    assert.deepEqual(payload, { reasoning_effort: "high" });
+  });
+
+  it("glm-5.3 with glm='max' emits reasoning_effort: 'max'", () => {
+    const payload = thinkingProviderFor("glm-5.3").buildPayload({ ...defaultSettings, glm: "max" });
+    assert.deepEqual(payload, { reasoning_effort: "max" });
+  });
+
+  it("picker schema exposes only high/max (no 'off') and defaults to 'high'", () => {
+    const schema = thinkingProviderFor("glm-5.3").schema();
+    assert.ok(schema, "expected schema to be defined");
+    const reasoningEffort = schema.properties.reasoningEffort as Record<string, unknown>;
+    assert.deepEqual(reasoningEffort.enum, ["high", "max"]);
+    assert.deepEqual(reasoningEffort.enumItemLabels, ["High", "Max"]);
+    assert.equal(reasoningEffort.default, "high");
+  });
+
+  it("detects glm-5.3 variants (dot/hyphen, free/suffix) as always-thinking", () => {
+    for (const id of ["glm-5.3", "glm-5.3-free", "glm-5-3", "glm-5.10", "glm-5.3-code"]) {
+      const resolved = resolveThinkingConfig({ modelId: id, workspace: defaultSettings });
+      assert.equal(resolved.settings.glm, "high", `expected ${id} to force thinking on`);
+    }
+  });
+
+  it("still allows glm-5.2 / glm-5.1 / glm-5 to disable thinking", () => {
+    for (const id of ["glm-5.2", "glm-5.1", "glm-5"]) {
+      const payload = thinkingProviderFor(id).buildPayload({ ...defaultSettings, glm: "off" });
+      assert.deepEqual(payload, { thinking: { type: "disabled" } }, `expected ${id} to allow disabled`);
+    }
+  });
+});
+
 describe("QwenThinking — payload per endpoint", () => {
   it("chat endpoint with qwen='off' emits enable_thinking: false", () => {
     const payload = thinkingProviderFor("qwen3.6-plus").buildPayload({ ...defaultSettings, qwen: "off" });

--- a/src/thinking/glm.ts
+++ b/src/thinking/glm.ts
@@ -10,7 +10,20 @@ import { schemaFromReasoningOptions, effortProperty, type ThinkingSchema } from 
 import type { ResolvedModelMetadata } from "../models/metadata";
 import type { ThinkingSettings, ThinkingFamily, BuildThinkingPayloadOptions } from "./types";
 
+// Standard GLM models accept off/high/max (issue #61).
 const GLM_EFFORTS = ["off", "high", "max"] as const;
+// GLM 5.3+ always engage in thinking and reject `disabled` (issue #162); the
+// upstream accepts high/max reasoning effort, so we expose only those.
+const GLM_ALWAYS_THINKING_EFFORTS = ["high", "max"] as const;
+
+/**
+ * GLM 5.3 and later cannot disable thinking (Zhipu API constraint — the same
+ * class of issue as Kimi K2.7-code in #25). Detected by version so future 5.x
+ * releases are covered automatically.
+ */
+function isAlwaysThinking(modelId: string): boolean {
+  return /^glm-5[.\-](?:[3-9]|\d{2,})/i.test(modelId);
+}
 
 export class GlmThinking extends BaseThinkingProvider {
   readonly family: ThinkingFamily = "glm";
@@ -20,24 +33,51 @@ export class GlmThinking extends BaseThinkingProvider {
   }
 
   schema(metadata?: ResolvedModelMetadata): ThinkingSchema | undefined {
-    return (
-      schemaFromReasoningOptions(metadata) ?? {
+    const fromOptions = schemaFromReasoningOptions(metadata);
+    if (fromOptions) return fromOptions;
+
+    // GLM 5.3+ cannot disable thinking — expose only the effort levels the
+    // upstream accepts, defaulting to "high" (defensive against stale cache).
+    if (isAlwaysThinking(this.modelId)) {
+      return {
         properties: {
           reasoningEffort: effortProperty({
-            enum: GLM_EFFORTS,
-            labels: ["Off", "High", "Max"],
-            descriptions: ["Fastest responses", "Greater reasoning depth", "Maximum reasoning effort"],
-            default: "off",
+            enum: GLM_ALWAYS_THINKING_EFFORTS,
+            labels: ["High", "Max"],
+            descriptions: ["Greater reasoning depth", "Maximum reasoning effort"],
+            default: "high",
           }),
         },
-      }
-    );
+      };
+    }
+
+    return {
+      properties: {
+        reasoningEffort: effortProperty({
+          enum: GLM_EFFORTS,
+          labels: ["Off", "High", "Max"],
+          descriptions: ["Fastest responses", "Greater reasoning depth", "Maximum reasoning effort"],
+          default: "off",
+        }),
+      },
+    };
   }
 
   applyOverride(settings: ThinkingSettings, override: Record<string, unknown>): ThinkingSettings {
-    let next = this.applyEffort(settings, override, "glm", GLM_EFFORTS);
-    next = this.applyMode(next, override, "glm", GLM_EFFORTS);
+    const efforts = isAlwaysThinking(this.modelId) ? GLM_ALWAYS_THINKING_EFFORTS : GLM_EFFORTS;
+    let next = this.applyEffort(settings, override, "glm", efforts);
+    next = this.applyMode(next, override, "glm", efforts);
     return next;
+  }
+
+  normalize(settings: ThinkingSettings): ThinkingSettings {
+    // GLM 5.3+ forces thinking on regardless of picker selection (defensive —
+    // the picker only exposes effort levels, but VS Code may cache a stale
+    // "off" value). The upstream rejects `thinking: { type: "disabled" }`.
+    if (isAlwaysThinking(this.modelId) && settings.glm === "off") {
+      return { ...settings, glm: "high" };
+    }
+    return settings;
   }
 
   buildPayload(thinking: ThinkingSettings, _opts?: BuildThinkingPayloadOptions): Record<string, unknown> {


### PR DESCRIPTION
## Summary

Fixes #162 — GLM 5.3 (and later) rejects `thinking: { type: "disabled" }` with HTTP 400:
> "This model always engages in thinking and cannot be disabled; please use low, high, or max"

### Changes
- **`src/thinking/glm.ts`** — `GlmThinking` now detects GLM 5.3+ by version (`/^glm-5[.\-](?:[3-9]|\d{2,})/i`) and forces thinking on (default `high`). The model picker exposes only `high`/`max` and hides `off`, mirroring the existing Kimi K2.7-code force-on behavior. `normalize()` upgrades any stale `off` override to `high` so cached settings can't trigger the 400.
- **`src/retry.ts`** — added a defensive recovery pattern: when the upstream reports it "cannot be disabled" / "always engages in thinking", the `thinking` field is stripped from the body so a retry succeeds instead of looping.
- **Tests** — `src/test/thinking.test.ts` (version detection, forced-on resolution, payload shape, picker schema) and `src/test/retry.test.ts` (cannot-be-disabled recovery).

### Verification
- `npm test` — 333/333 pass
- `npm run lint` — all 7 gates pass (Editorconfig, ESLint, Markdown, Prettier, Shell, TypeScript, Tests)

PEACE BE UPON YOU