### PR TITLE
fix: trim conversation history to fit context window (prevents 'No response came')

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ All notable changes to the **OpenCode Go BYOK Provider** extension are documente
 
 - **DeepSeek / Mimo thinking content no longer leaks into the chat transcript.** `treatReasoningAsContent` was mis-detecting native-reasoning families as "no reasoning in body" and echoing their `reasoning_content` as plain chat text. The decision now comes from the provider strategy (always `false` for DeepSeek and Mimo), so chain-of-thought stays in the thinking panel.
 
+- **`[Chat]` Conversation history is now trimmed to fit the model context window.** Long multi-turn conversations (or many repeated turns without running Compact Conversation) could grow past the model's context limit, so the upstream rejected the oversized request (HTTP 400) or returned an empty stream — surfacing in VS Code as "No response came". `trimOldMessagesToFitContext` now drops the oldest messages (preserving the system/anchor and the current prompt, and never splitting a tool-call group) until the payload fits the available input budget. This also bounds the request size for models with tight payload limits. Unit tests added in `src/test/messages.test.ts`.
+
 ## [0.6.0] — 2026-08-13
 
 ### Added

--- a/docs/issues/68-20260820-history-trim-context-overflow.md
+++ b/docs/issues/68-20260820-history-trim-context-overflow.md
@@ -1,0 +1,64 @@
+**Status:** ✅ Resolved
+**Fix PR:** (this branch)
+
+# Trim conversation history to fit the model context window
+
+**Topic:** chat / provider / request / payload
+**Updated:** 2026-08-20
+**Tags:** #chat #provider #request #payload #bug
+
+---
+
+## Problem
+
+Two reported symptoms, one root cause:
+
+1. **"No response came" across multiple VS Code windows.** When several windows
+   chat in separate sessions, requests intermittently fail with no response
+   parts emitted.
+2. **Repeated failures that Compact Conversation fixes.** Sending many messages
+   in a row eventually errors every time; running _Compact Conversation_ and then
+   sending one message works again in most cases.
+
+Both point at the same thing: the request payload grows with the full
+conversation history and is never bounded for **text** turns.
+
+## Root cause
+
+`provideLanguageModelChatResponse` builds the wire payload from the entire
+message list. The only history guard was `trimOldImagesFromHistoryInPlace`
+(images only). There was **no text-history truncation**, so a long conversation
+exceeds the model's context window and the upstream either:
+
+- rejects the oversized request with HTTP 400 (empty assistant message,
+  `finish_reason: null`), or
+- hangs / returns an empty stream → VS Code surfaces "No response came".
+
+Compact Conversation shrinks the history, which is why it "fixes" the symptom.
+This also explains the reported Muse Spark 990 KB payload: it is the
+uncompacted conversation history, not a model-specific quirk.
+
+## Fix
+
+New pure module `src/provider/historyTrim.ts` → `trimOldMessagesToFitContext`:
+
+- Computes an input budget = `contextWindow − maxOutputTokens − safetyMargin`
+  (the safety margin is `HISTORY_TRIM_SAFETY_MARGIN_TOKENS = 2048`).
+- Drops the oldest messages until the estimated prompt tokens fit the budget.
+- **Preserves** the first message (system/anchor) and the last message (current
+  prompt).
+- **Never splits a tool-call group** — trimming stops before the first
+  assistant message that carries `tool_calls` (and its following `tool` results),
+  so no tool reference is orphaned (which would itself 400 the request).
+- Mutates the array in place and returns the count removed (logged as
+  `[history-trim]` for diagnostics).
+
+Called in `OpenCodeProvider.provideLanguageModelChatResponse` right after the
+existing image-history trim, before the prompt-token estimate and limit calc.
+
+## Verification
+
+- `src/test/messages.test.ts` — 4 cases: no-op when it fits, drops oldest while
+  keeping anchor + last, never splits a tool group, no-op when only anchor + last
+  remain.
+- `npm test` (337 pass) and `npm run lint` (all 7 gates) green.

--- a/src/config.ts
+++ b/src/config.ts
@@ -167,6 +167,12 @@ export const IMAGE_TOKEN_ESTIMATE = 1024;
 export const MAX_TOOL_RESULT_IMAGE_BYTES = 1_000_000;
 /** Max images kept in conversation history before older ones are placeholder-replaced. */
 export const MAX_HISTORY_IMAGES_KEPT = 2;
+/**
+ * Tokens reserved below the model's input context window when trimming old
+ * conversation history. Keeps the trimmed payload safely under the limit so the
+ * upstream never rejects an oversized request (HTTP 400 / empty "No response").
+ */
+export const HISTORY_TRIM_SAFETY_MARGIN_TOKENS = 2048;
 /** Hard ceiling (base64 chars) for a normalized image attachment. */
 export const MAX_IMAGE_BASE64_BYTES = 5 * 1024 * 1024;
 /** Dimension cap for normalized images. */

--- a/src/provider/OpenCodeProvider.ts
+++ b/src/provider/OpenCodeProvider.ts
@@ -55,6 +55,7 @@ import {
   MODEL_LIST_FETCH_TIMEOUT_MS,
   MODEL_METADATA_REVISION,
   MAX_HISTORY_IMAGES_KEPT,
+  HISTORY_TRIM_SAFETY_MARGIN_TOKENS,
   RECENT_TRANSPORT_SUMMARY_LIMIT,
   RECENT_TRANSPORT_SUMMARY_STORAGE_PREFIX,
   SETTING_SHOW_PROVIDER_PREFIX,
@@ -77,6 +78,7 @@ import { estimateCost } from "../usage/pricing";
 import { resolveResponseApiKey } from "../apiKeyResolution";
 import { clearOpenCodeModelMetadataCache, getOpenCodeModelMetadata } from "../models/metadataFetcher";
 import { convertMessage, normalizeMessages, trimOldImagesFromHistoryInPlace } from "./messages";
+import { trimOldMessagesToFitContext } from "./historyTrim";
 import { estimateChatMessageTokenCount } from "./tokens";
 import {
   formatModalityBadges,
@@ -849,6 +851,23 @@ export class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCo
     if (trimmedCount > 0) {
       this.log(
         `[history-trim] Replaced ${String(trimmedCount)} old image(s) with placeholder text to bound payload (kept most recent ${String(MAX_HISTORY_IMAGES_KEPT)}).`,
+      );
+    }
+
+    // Bound the text conversation history to the model's input context window.
+    // Long multi-turn conversations (or repeated turns without Compact
+    // Conversation) can exceed the context limit, causing the upstream to reject
+    // the oversized request (HTTP 400) or return an empty stream — surfaced by
+    // VS Code as "No response came". Drop the oldest messages (preserving the
+    // anchor and the current prompt, never splitting a tool-call group) until
+    // the payload fits the available input budget.
+    const effectiveContextWindow = contextSizeOverride ?? metadata.contextWindow;
+    const outputReserve = Math.min(metadata.maxOutputTokens, effectiveContextWindow);
+    const inputBudget = Math.max(1, effectiveContextWindow - outputReserve - HISTORY_TRIM_SAFETY_MARGIN_TOKENS);
+    const historyTrimmed = trimOldMessagesToFitContext(apiMessages, inputBudget, options.tools);
+    if (historyTrimmed > 0) {
+      this.log(
+        `[history-trim] Dropped ${String(historyTrimmed)} old message(s) to fit context window (budget=${String(inputBudget)} tokens).`,
       );
     }
 

--- a/src/provider/historyTrim.ts
+++ b/src/provider/historyTrim.ts
@@ -1,0 +1,83 @@
+import type * as vscode from "vscode";
+import type { ApiMessage } from "../request/types";
+import { estimatePromptTokenCount } from "../tokenEstimate";
+
+/**
+ * Trim the oldest conversation messages so the request payload fits the model's
+ * input context window.
+ *
+ * Long multi-turn conversations (or many repeated turns without running Compact
+ * Conversation) can grow past the model's context limit. The upstream then
+ * rejects the oversized request (HTTP 400) or returns an empty stream, which
+ * VS Code surfaces as "No response came". This bounds the text history the same
+ * way image trimming bounds image weight.
+ *
+ * CONTRACT:
+ *   - Never drops the first message (system/anchor context) or the last message
+ *     (the current prompt turn).
+ *   - Never splits a tool-call group: an assistant message carrying `tool_calls`
+ *     and its following `tool` results are kept together, so trimming stops
+ *     before the first tool group rather than orphaning a tool reference.
+ *   - Mutates the input array in place (safe: the caller does not reuse it).
+ *   - Returns the number of messages removed (for diagnostics).
+ *
+ * @param messages ApiMessage[] (chronological, oldest first). Mutated in place.
+ * @param budgetTokens Maximum input tokens the trimmed history may occupy.
+ * @param tools Tools passed to the request (included in the size estimate).
+ * @returns Number of messages removed.
+ */
+export function trimOldMessagesToFitContext(
+  messages: ApiMessage[],
+  budgetTokens: number,
+  tools?: readonly vscode.LanguageModelChatTool[],
+): number {
+  const lastIndex = messages.length - 1;
+  // Need at least the anchor (index 0) and the current prompt (last index).
+  if (lastIndex < 2) {
+    return 0;
+  }
+  if (estimatePromptTokenCount(messages, tools) <= budgetTokens) {
+    return 0;
+  }
+
+  // Map each tool_call id to the index of its owning assistant message so we can
+  // detect when a candidate drop would orphan a tool reference.
+  const toolCallOwner = new Map<string, number>();
+  for (let i = 0; i < messages.length; i++) {
+    const toolCalls = messages[i].tool_calls;
+    if (messages[i].role === "assistant" && Array.isArray(toolCalls)) {
+      for (const tc of toolCalls) {
+        toolCallOwner.set(tc.id, i);
+      }
+    }
+  }
+
+  let dropEnd = 0;
+  for (let i = 1; i < lastIndex; i++) {
+    const message = messages[i];
+    let isToolGroupMessage = message.role === "assistant" && Array.isArray(message.tool_calls) && message.tool_calls.length > 0;
+    if (!isToolGroupMessage && message.role === "tool" && message.tool_call_id !== undefined) {
+      const owner = toolCallOwner.get(message.tool_call_id);
+      // A tool result whose parent assistant is at index >= 1 is part of a tool
+      // group we might otherwise trim into — treat it as a group boundary.
+      isToolGroupMessage = owner !== undefined && owner >= 1;
+    }
+    if (isToolGroupMessage) {
+      // Stop before the first tool group — dropping it would orphan a tool
+      // reference and 400 the request.
+      break;
+    }
+    const remaining = [messages[0], ...messages.slice(i + 1)];
+    if (estimatePromptTokenCount(remaining, tools) <= budgetTokens) {
+      dropEnd = i;
+      break;
+    }
+    dropEnd = i;
+  }
+
+  if (dropEnd >= 1) {
+    messages.splice(1, dropEnd);
+    return dropEnd;
+  }
+  return 0;
+}

--- a/src/test/messages.test.ts
+++ b/src/test/messages.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { trimOldMessagesToFitContext } from "../provider/historyTrim.js";
+import type { ApiMessage } from "../request/types.js";
+
+function textMessage(role: ApiMessage["role"], text: string): ApiMessage {
+  return { role, content: text };
+}
+
+describe("trimOldMessagesToFitContext", () => {
+  it("removes nothing when the history already fits the budget", () => {
+    const messages: ApiMessage[] = [
+      textMessage("user", "system context"),
+      textMessage("user", "hello"),
+      textMessage("assistant", "hi there"),
+    ];
+    const removed = trimOldMessagesToFitContext(messages, 10_000);
+    assert.equal(removed, 0);
+    assert.equal(messages.length, 3);
+  });
+
+  it("drops oldest messages until the payload fits, keeping anchor + last", () => {
+    const messages: ApiMessage[] = [];
+    messages.push(textMessage("user", "anchor system prompt that is fairly long to count as context"));
+    for (let i = 0; i < 12; i++) {
+      messages.push(textMessage("user", `repeated turn number ${i} with some padding text to grow the token estimate`));
+      messages.push(textMessage("assistant", `response for turn ${i} with padding text to grow the token estimate`));
+    }
+    messages.push(textMessage("user", "latest prompt that must be preserved at all costs"));
+    const before = messages.length;
+    const removed = trimOldMessagesToFitContext(messages, 200);
+    assert.ok(removed > 0, "should have trimmed");
+    assert.equal(messages.length, before - removed);
+    // anchor (index 0) and last (current prompt) preserved
+    assert.equal(messages[0].content, "anchor system prompt that is fairly long to count as context");
+    assert.equal(messages[messages.length - 1].content, "latest prompt that must be preserved at all costs");
+  });
+
+  it("never splits a tool-call group (stops before the first tool group)", () => {
+    const messages: ApiMessage[] = [
+      textMessage("user", "anchor"),
+      textMessage("user", "old turn A padding padding padding padding padding padding padding"),
+      textMessage("user", "old turn B padding padding padding padding padding padding padding"),
+      {
+        role: "assistant",
+        content: "let me call a tool",
+        tool_calls: [{ id: "call_1", type: "function", function: { name: "fs", arguments: "{}" } }],
+      },
+      { role: "tool", tool_call_id: "call_1", content: "tool result text" },
+      textMessage("user", "current prompt"),
+    ];
+    const removed = trimOldMessagesToFitContext(messages, 50);
+    // Trimming may drop the two old user turns, but must stop at the tool group
+    // so no tool reference is orphaned.
+    assert.ok(removed >= 0);
+    const hasToolCall = messages.some((m) => m.role === "assistant" && Array.isArray(m.tool_calls) && m.tool_calls.length > 0);
+    const hasToolResult = messages.some((m) => m.role === "tool");
+    assert.equal(hasToolCall, hasToolResult, "tool group must stay intact");
+  });
+
+  it("does not trim when only anchor + last remain", () => {
+    const messages: ApiMessage[] = [textMessage("user", "anchor"), textMessage("user", "only prompt")];
+    const removed = trimOldMessagesToFitContext(messages, 1);
+    assert.equal(removed, 0);
+    assert.equal(messages.length, 2);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes two related "No response came" failure modes with a single root-cause fix:

1. **Multiple VS Code windows** — chatting in separate windows intermittently fails with no response.
2. **Repeated failures fixed by Compact Conversation** — after many turns the request fails every time; running *Compact Conversation* and sending one message works again.

### Root cause

`provideLanguageModelChatResponse` sent the **entire** conversation history as the request payload. The only history guard was image trimming (`trimOldImagesFromHistoryInPlace`) — there was **no text-history truncation**. So a long conversation grows past the model's context window and the upstream either:
- rejects the oversized request with HTTP 400 (empty assistant message, `finish_reason: null`), or
- returns an empty stream → VS Code surfaces **"No response came"**.

Compact Conversation shrinks the history, which is exactly why it "fixes" the symptom. (This also explains the reported Muse Spark ~990 KB payload — it is the uncompacted history, not a model-specific quirk.)

### Changes
- **`src/provider/historyTrim.ts`** (new, pure) — `trimOldMessagesToFitContext` drops the oldest messages until the estimated prompt tokens fit `contextWindow − maxOutputTokens − safetyMargin`. It **preserves** the first (system/anchor) and last (current prompt) messages, and **never splits a tool-call group** (stops before the first assistant message carrying `tool_calls`), so no tool reference is orphaned.
- **`src/provider/OpenCodeProvider.ts`** — calls it right after the image-history trim, before the prompt-token estimate, with a `[history-trim]` diagnostic log.
- **`src/config.ts`** — `HISTORY_TRIM_SAFETY_MARGIN_TOKENS = 2048`.
- **Tests** — `src/test/messages.test.ts` (no-op when fitting, drops oldest keeping anchor + last, never splits a tool group, no-op when only anchor + last remain).
- **Docs** — CHANGELOG Fixed entry + `docs/issues/68-20260820-history-trim-context-overflow.md`.

### Verification
- `npm test` — 337/337 pass
- `npm run lint` — all 7 gates pass (Editorconfig, ESLint, Markdown, Prettier, Shell, TypeScript, Tests)

PEACE BE UPON YOU