### PR TITLE
Add Muse Spark 1.2 models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the **OpenCode Go BYOK Provider** extension are documente
 
 ### Added
 
+- **`[Models]` Muse Spark 1.2 support.** Full support for `muse-spark-1.2-contributor` (Go) and `muse-spark-1.2-contributor-free` (Zen). Muse models are routed through the Responses API with `truncation: disabled` and tool names truncated to 64 characters (both gateway constraints). A new `MuseThinking` strategy provides configurable thinking effort (off/low/medium/high/xhigh) via `reasoning: { effort }`, and the thinking effort picker now includes a Muse Spark entry. Fallback metadata provides 1M context / 131K output limits when the live models.dev fetch is unavailable.
+
 - **`[Providers]` Configurable API base URL.** The extension no longer hardcodes the `opencode.ai` endpoints — it can now point at any compatible gateway via `opencodego.apiBaseUrl` (default `https://opencode.ai/zen/go/v1`) and `opencodezen.apiBaseUrl` (default `https://opencode.ai/zen/v1`). The extension derives the `/chat/completions`, `/messages`, `/responses`, `/models`, and (Go only) `/usage` routes from the configured base and applies them to every provider (normal chat, Agents window variants, inline completions, usage sync). Custom URLs are normalized and validated — non-`http(s)`, embedded credentials, query strings, and hashes are rejected and fall back to the default. Reload the window after changing the setting. Unit tests added for URL normalization and route construction.
 
 ---

--- a/package.json
+++ b/package.json
@@ -440,6 +440,18 @@
           ],
           "default": "auto",
           "markdownDescription": "Optional `thinking_budget` for Qwen models when thinking is `on` or `auto`. `auto` omits the field. Ignored when Qwen thinking is `off`."
+        },
+        "opencodego.thinking.muse": {
+          "type": "string",
+          "enum": [
+            "off",
+            "low",
+            "medium",
+            "high",
+            "xhigh"
+          ],
+          "default": "off",
+          "markdownDescription": "Thinking mode for Muse Spark models (`muse-spark-1.2-contributor`, `muse-spark-1.2-contributor-free`). Maps to the Responses API `reasoning.effort` field. Higher effort increases reasoning depth and may increase latency and usage."
         }
       }
     },

--- a/src/commands/thinkingPicker.ts
+++ b/src/commands/thinkingPicker.ts
@@ -15,6 +15,7 @@ export async function showThinkingEffortPicker(): Promise<void> {
     { label: "OpenAI GPT (gpt-*)", key: "openai", options: [...THINKING_ALLOWED_VALUES.openai] },
     { label: "Qwen (qwen3.*)", key: "qwen", options: [...THINKING_ALLOWED_VALUES.qwen] },
     { label: "Qwen Thinking Budget", key: "qwenBudget", options: [...THINKING_ALLOWED_VALUES.qwenBudget] },
+    { label: "Muse Spark (muse-spark-*)", key: "muse", options: [...THINKING_ALLOWED_VALUES.muse] },
   ];
   const settings = getSettings().thinking;
   const family = await vscode.window.showQuickPick(

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,6 +60,7 @@ export const SETTING_THINKING_OPENAI = "thinking.openai";
 export const SETTING_THINKING_QWEN = "thinking.qwen";
 export const SETTING_THINKING_QWEN_BUDGET = "thinking.qwenBudget";
 export const SETTING_THINKING_MIMO = "thinking.mimo";
+export const SETTING_THINKING_MUSE = "thinking.muse";
 
 // ─── Inline completions (issue #49) ─────────────────────────────────────────
 
@@ -306,4 +307,5 @@ export const THINKING_DEFAULTS = {
   qwen: "off",
   qwenBudget: "auto",
   mimo: "off",
+  muse: "off",
 } as const;

--- a/src/core/registry.ts
+++ b/src/core/registry.ts
@@ -79,6 +79,16 @@ export const MODEL_REGISTRY: ModelRegistryEntry[] = [
     thinkingFamily: null,
     vendors: ["opencodezen"],
   },
+  // Muse Spark 1.2 (Meta) → OpenAI Responses API (per OpenCode Go docs).
+  // The gateway rejects chat-completions parameters (stream_options,
+  // tool_choice) so this MUST use the Responses endpoint.
+  {
+    family: "muse",
+    patterns: [/^muse-/i],
+    endpointKind: "responses",
+    sdkPackage: "@ai-sdk/openai",
+    thinkingFamily: "muse",
+  },
   // Everything else that has a dedicated thinking strategy → chat-completions.
   {
     family: "minimax",

--- a/src/core/transport.ts
+++ b/src/core/transport.ts
@@ -48,6 +48,13 @@ export interface StreamRequestOptions {
    * to prevent <think> tags in content from rendering as blank code blocks.
    */
   forceStripThinkTags?: boolean;
+  /**
+   * Truncated → original tool name map for the Responses API round-trip.
+   * Muse Spark truncates names >64 chars at request build time; the
+   * extractor reverse-looks up before emitting `LanguageModelToolCallPart`.
+   * Only set for the Responses transport when truncation was applied.
+   */
+  toolNameMap?: ReadonlyMap<string, string>;
 }
 
 export interface TransportRequestSummary {

--- a/src/models/metadata.ts
+++ b/src/models/metadata.ts
@@ -184,6 +184,7 @@ const MODEL_LIMITS_BY_PROVIDER: Record<ProviderVendor, Record<string, BaseModelL
     "qwen3.5-plus": { contextWindow: 262144, maxOutputTokens: 65536 },
     "gpt-5.6-luna": { contextWindow: 1050000, maxOutputTokens: 128000 },
     "hy3-preview": { contextWindow: 256000, maxOutputTokens: 64000 },
+    "muse-spark-1.2-contributor": { contextWindow: 1048576, maxOutputTokens: 131072 },
   },
   [ZEN_VENDOR]: {
     "claude-opus-4-7": { contextWindow: 1000000, maxOutputTokens: 128000 },
@@ -229,6 +230,7 @@ const MODEL_LIMITS_BY_PROVIDER: Record<ProviderVendor, Record<string, BaseModelL
     "trinity-large-preview-free": { contextWindow: 131072, maxOutputTokens: 131072 },
     "nemotron-3-super-free": { contextWindow: 204800, maxOutputTokens: 128000 },
     "big-pickle": { contextWindow: 200000, maxOutputTokens: 128000 },
+    "muse-spark-1.2-contributor-free": { contextWindow: 1048576, maxOutputTokens: 131072 },
   },
 };
 
@@ -510,7 +512,7 @@ function detectModalityFlags(
 }
 
 function supportsReasoning(modelId: string): boolean {
-  return /^(deepseek-|glm-|kimi-|minimax-|qwen3(?:\.|-)|mimo-)/i.test(modelId);
+  return /^(deepseek-|glm-|kimi-|minimax-|qwen3(?:\.|-)|mimo-|muse-)/i.test(modelId);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/provider/OpenCodeProvider.ts
+++ b/src/provider/OpenCodeProvider.ts
@@ -40,6 +40,7 @@ import {
   buildResponsesRequestBody,
   messagesHaveImages,
 } from "../request/builders";
+import { buildResponsesToolNameMap } from "../request/openai";
 import type { ApiMessage, ApiSettings, OpenAiContentPart } from "../request/types";
 import { runtimeDiagnosticsLines } from "../runtimeDiagnostics";
 import { estimatePromptTokenCount, estimateTokenCount } from "../tokenEstimate";
@@ -678,8 +679,8 @@ export class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCo
     if (registeredCount > 0) {
       this.log(
         `Models registered: count=${String(registeredCount)} provider=${this.definition.vendor}` +
-          ` first=${firstModelId} last=${lastModelId}` +
-          (this.definition.isAgentVariant ? " (agents)" : ""),
+        ` first=${firstModelId} last=${lastModelId}` +
+        (this.definition.isAgentVariant ? " (agents)" : ""),
       );
     }
 
@@ -951,6 +952,7 @@ export class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCo
           onTransportSummary,
           stripThinkTags: settings.stripThinkTags,
           forceStripThinkTags,
+          toolNameMap: buildResponsesToolNameMap(options.tools, rawModelId),
           onReasoningContent: (toolCallIds, reasoningContent) => {
             this.storeReasoningContent(toolCallIds, reasoningContent);
           },

--- a/src/provider/OpenCodeProvider.ts
+++ b/src/provider/OpenCodeProvider.ts
@@ -679,8 +679,8 @@ export class OpenCodeProvider implements vscode.LanguageModelChatProvider<OpenCo
     if (registeredCount > 0) {
       this.log(
         `Models registered: count=${String(registeredCount)} provider=${this.definition.vendor}` +
-        ` first=${firstModelId} last=${lastModelId}` +
-        (this.definition.isAgentVariant ? " (agents)" : ""),
+          ` first=${firstModelId} last=${lastModelId}` +
+          (this.definition.isAgentVariant ? " (agents)" : ""),
       );
     }
 

--- a/src/provider/settings.ts
+++ b/src/provider/settings.ts
@@ -14,6 +14,7 @@ import {
   SETTING_THINKING_GLM,
   SETTING_THINKING_KIMI,
   SETTING_THINKING_MIMO,
+  SETTING_THINKING_MUSE,
   SETTING_THINKING_MINIMAX,
   SETTING_THINKING_OPENAI,
   SETTING_THINKING_QWEN,
@@ -41,6 +42,7 @@ export const THINKING_ALLOWED_VALUES = {
   qwen: ["auto", "on", "off"],
   qwenBudget: ["auto", "4096", "16384", "32768", "81920"],
   mimo: ["off", "low", "medium", "high"],
+  muse: ["off", "low", "medium", "high", "xhigh"],
 } as const;
 
 /** Return `value` when it is one of `allowed`, else `fallback`. */
@@ -165,6 +167,11 @@ export function getSettings(): ApiSettings {
         config.get(SETTING_THINKING_MIMO, THINKING_DEFAULTS.mimo),
         THINKING_ALLOWED_VALUES.mimo,
         THINKING_DEFAULTS.mimo,
+      ),
+      muse: validThinkingValue(
+        config.get(SETTING_THINKING_MUSE, THINKING_DEFAULTS.muse),
+        THINKING_ALLOWED_VALUES.muse,
+        THINKING_DEFAULTS.muse,
       ),
     },
     stripThinkTags: config.get<ApiSettings["stripThinkTags"]>(SETTING_STRIP_THINK_TAGS, "auto"),

--- a/src/request/openai.ts
+++ b/src/request/openai.ts
@@ -52,7 +52,7 @@ export function buildResponsesRequestBody(
   limits: ModelLimits,
 ): Record<string, unknown> {
   const input = messages.flatMap((message) => responsesInputItemsFromMessage(message));
-  const tools = mapResponsesTools(options.tools);
+  const tools = mapResponsesTools(options.tools, modelId);
   const thinkingPayload = thinkingProviderFor(modelId).buildPayload(settings.thinking, {
     hasImageInput: messagesHaveImages(messages),
     endpoint: "responses",
@@ -62,6 +62,7 @@ export function buildResponsesRequestBody(
     model: modelId,
     input,
     maxOutputTokens: limits.maxOutputTokens,
+    truncation: /^muse-/i.test(modelId) ? "disabled" : "auto",
     // Some models reject any non-default temperature value.
     ...(metadata.temperature === false ? {} : { temperature: settings.temperature }),
     thinkingPayload,
@@ -81,13 +82,36 @@ function mapOpenAiTools(tools: readonly vscode.LanguageModelChatTool[] | undefin
   }));
 }
 
-function mapResponsesTools(tools: readonly vscode.LanguageModelChatTool[] | undefined): Record<string, unknown>[] {
+function mapResponsesTools(tools: readonly vscode.LanguageModelChatTool[] | undefined, modelId?: string): Record<string, unknown>[] {
+  const needsTruncation = /^muse-/i.test(modelId ?? "");
   return (tools ?? []).map((tool) => ({
     type: "function",
-    name: tool.name,
+    name: needsTruncation ? truncateToolName(tool.name) : tool.name,
     description: tool.description,
     parameters: sanitizeToolSchema(tool.inputSchema),
   }));
+}
+
+// --- Muse Spark tool-name truncation (Responses API limit: 64 chars) ----------
+
+const MUSE_MAX_TOOL_NAME = 64;
+const MUSE_HASH_SUFFIX_LEN = 8;
+
+function truncateToolName(name: string): string {
+  if (name.length <= MUSE_MAX_TOOL_NAME) {
+    return name;
+  }
+  const hash = simpleHash(name);
+  const available = MUSE_MAX_TOOL_NAME - MUSE_HASH_SUFFIX_LEN - 1; // -1 for separator
+  return `${name.slice(0, available)}_${hash}`;
+}
+
+function simpleHash(value: string): string {
+  let h = 0;
+  for (let i = 0; i < value.length; i++) {
+    h = (h * 31 + value.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h).toString(36);
 }
 
 function toolChoice(mode: vscode.LanguageModelChatToolMode): "auto" | "required" {

--- a/src/request/openai.ts
+++ b/src/request/openai.ts
@@ -8,6 +8,7 @@
  * `LanguageModelChatToolMode` enum value only; no extension-host side effects.
  */
 import * as vscode from "vscode";
+import { lookupModelRegistryEntry } from "../core/registry";
 import { buildResponsesRequestEnvelope, responsesInputItemsFromMessage } from "../responsesRequest";
 import { thinkingProviderFor } from "../thinking";
 import { sanitizeToolSchema } from "./schema";
@@ -62,7 +63,11 @@ export function buildResponsesRequestBody(
     model: modelId,
     input,
     maxOutputTokens: limits.maxOutputTokens,
-    truncation: /^muse-/i.test(modelId) ? "disabled" : "auto",
+    // Muse Spark gateway requires `truncation: "disabled"` — requests whose
+    // input exceeds the 1M context window will hard-fail (HTTP 400) instead
+    // of being silently truncated upstream. This is a gateway constraint,
+    // not a client choice; see PR #168 review.
+    truncation: isMuseFamily(modelId) ? "disabled" : "auto",
     // Some models reject any non-default temperature value.
     ...(metadata.temperature === false ? {} : { temperature: settings.temperature }),
     thinkingPayload,
@@ -83,7 +88,7 @@ function mapOpenAiTools(tools: readonly vscode.LanguageModelChatTool[] | undefin
 }
 
 function mapResponsesTools(tools: readonly vscode.LanguageModelChatTool[] | undefined, modelId?: string): Record<string, unknown>[] {
-  const needsTruncation = /^muse-/i.test(modelId ?? "");
+  const needsTruncation = isMuseFamily(modelId ?? "");
   return (tools ?? []).map((tool) => ({
     type: "function",
     name: needsTruncation ? truncateToolName(tool.name) : tool.name,
@@ -97,13 +102,42 @@ function mapResponsesTools(tools: readonly vscode.LanguageModelChatTool[] | unde
 const MUSE_MAX_TOOL_NAME = 64;
 const MUSE_HASH_SUFFIX_LEN = 8;
 
-function truncateToolName(name: string): string {
+export function isMuseFamily(modelId: string): boolean {
+  if (!modelId) {
+    return false;
+  }
+  return lookupModelRegistryEntry(modelId).family === "muse";
+}
+
+export function truncateToolName(name: string): string {
   if (name.length <= MUSE_MAX_TOOL_NAME) {
     return name;
   }
   const hash = simpleHash(name);
   const available = MUSE_MAX_TOOL_NAME - MUSE_HASH_SUFFIX_LEN - 1; // -1 for separator
   return `${name.slice(0, available)}_${hash}`;
+}
+
+/**
+ * Build a truncated → original tool name map for the Responses extractor
+ * round-trip. Only Muse-family models truncate, so non-Muse models return
+ * an empty map. Mirrors the `toolNamesById` pattern in `src/request/google.ts`.
+ */
+export function buildResponsesToolNameMap(
+  tools: readonly vscode.LanguageModelChatTool[] | undefined,
+  modelId: string,
+): Map<string, string> {
+  const map = new Map<string, string>();
+  if (!isMuseFamily(modelId) || !tools?.length) {
+    return map;
+  }
+  for (const tool of tools) {
+    const truncated = truncateToolName(tool.name);
+    if (truncated !== tool.name) {
+      map.set(truncated, tool.name);
+    }
+  }
+  return map;
 }
 
 function simpleHash(value: string): string {

--- a/src/responsesRequest.ts
+++ b/src/responsesRequest.ts
@@ -6,6 +6,7 @@ export interface ResponsesRequestEnvelopeOptions {
   thinkingPayload?: Record<string, unknown>;
   tools?: readonly unknown[];
   toolChoice?: unknown;
+  truncation?: "auto" | "disabled";
 }
 
 /**
@@ -41,7 +42,7 @@ export function buildResponsesRequestEnvelope(options: ResponsesRequestEnvelopeO
     model: options.model,
     input: options.input,
     max_output_tokens: options.maxOutputTokens,
-    truncation: "auto",
+    truncation: options.truncation ?? "auto",
     ...(options.temperature === undefined ? {} : { temperature: options.temperature }),
     stream: true,
     ...(options.thinkingPayload ?? {}),

--- a/src/test/extractors.test.ts
+++ b/src/test/extractors.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, before } from "node:test";
+import assert from "node:assert/strict";
+import Module from "node:module";
+import path from "node:path";
+import fs from "node:fs";
+import os from "node:os";
+
+/*
+ * Tests for the Responses extractor truncated → original tool name round-trip
+ * (PR #168 review). Muse Spark truncates tool names >64 chars at request
+ * build time; the extractor must reverse-lookup before emitting
+ * LanguageModelToolCallPart so VS Code resolves the original tool.
+ */
+
+const vscodeMockPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "vscode-mock-extractors-")), "index.js");
+fs.writeFileSync(
+    vscodeMockPath,
+    `"use strict";
+class LanguageModelTextPart { constructor(value) { this.value = value; } }
+class LanguageModelThinkingPart { constructor(text) { this.text = text; } }
+class LanguageModelToolCallPart {
+  constructor(callId, name, input) { this.callId = callId; this.name = name; this.input = input; }
+}
+class LanguageModelToolResultPart { constructor(callId, content) { this.callId = callId; this.content = content; } }
+module.exports = { LanguageModelTextPart, LanguageModelThinkingPart, LanguageModelToolCallPart, LanguageModelToolResultPart };
+`,
+    "utf-8",
+);
+
+type ResolveFilename = (request: string, parent: unknown, ...args: unknown[]) => string;
+const moduleResolver = Module as unknown as { _resolveFilename: ResolveFilename };
+const originalResolveFilename = moduleResolver._resolveFilename;
+moduleResolver._resolveFilename = function (request: string, parent: unknown, ...args: unknown[]): string {
+    if (request === "vscode") {
+        return vscodeMockPath;
+    }
+    return originalResolveFilename.call(this, request, parent, ...args);
+};
+
+let OpenAiResponseExtractor: typeof import("../transports/extractors.js").OpenAiResponseExtractor;
+let truncateToolName: typeof import("../request/openai.js").truncateToolName;
+
+describe("OpenAiResponseExtractor — truncated tool name round-trip", () => {
+    before(async () => {
+        const extractors = await import("../transports/extractors.js");
+        OpenAiResponseExtractor = extractors.OpenAiResponseExtractor;
+        const openai = await import("../request/openai.js");
+        truncateToolName = openai.truncateToolName;
+    });
+
+    function makeExtractor(toolNameMap?: ReadonlyMap<string, string>) {
+        // Constructor: onReasoningContent, onReasoningDebug, thinkFilter, progress, localRequestId, output, treatReasoningAsContent, toolNameMap
+        return new OpenAiResponseExtractor(undefined, undefined, undefined, undefined, undefined, undefined, false, toolNameMap);
+    }
+
+    function toolCallDelta(name: string, args: string, index = 0, id = "call_1") {
+        return {
+            choices: [
+                {
+                    index: 0,
+                    delta: {
+                        tool_calls: [{ index, id, type: "function", function: { name, arguments: args } }],
+                    },
+                    finish_reason: null,
+                },
+            ],
+        };
+    }
+
+    function finishReasonChunk(reason: string) {
+        return {
+            choices: [{ index: 0, delta: {}, finish_reason: reason }],
+        };
+    }
+
+    it("emits original name when model returned truncated name", () => {
+        const longName = "a".repeat(72);
+        const truncated = truncateToolName(longName);
+        assert.notEqual(truncated, longName);
+        const map = new Map<string, string>([[truncated, longName]]);
+        const extractor = makeExtractor(map);
+
+        extractor.extractStreamParts(toolCallDelta(truncated, '{"q":"x"}'));
+        const parts = extractor.extractStreamParts(finishReasonChunk("tool_calls")) as { name: string }[];
+        assert.equal(parts.length, 1);
+        assert.equal(parts[0].name, longName);
+    });
+
+    it("passes through name unchanged when no map entry", () => {
+        const extractor = makeExtractor(new Map());
+        extractor.extractStreamParts(toolCallDelta("read_file", '{"path":"/x"}'));
+        const parts = extractor.extractStreamParts(finishReasonChunk("tool_calls")) as { name: string }[];
+        assert.equal(parts[0].name, "read_file");
+    });
+
+    it("passes through name unchanged when no map provided", () => {
+        const extractor = makeExtractor(undefined);
+        extractor.extractStreamParts(toolCallDelta("grep_search", '{"query":"foo"}'));
+        const parts = extractor.extractStreamParts(finishReasonChunk("tool_calls")) as { name: string }[];
+        assert.equal(parts[0].name, "grep_search");
+    });
+
+    it("flushRemainingToolCalls also reverse-maps truncated names", () => {
+        const longName = "b".repeat(72);
+        const truncated = truncateToolName(longName);
+        const map = new Map<string, string>([[truncated, longName]]);
+        const extractor = makeExtractor(map);
+        // Minimal progress stub — extractor reports via reportProgressPart
+        const emitted: unknown[] = [];
+        const progress: import("vscode").Progress<import("vscode").LanguageModelResponsePart2> = {
+            report: (part) => {
+                emitted.push(part);
+            },
+        };
+        extractor.extractStreamParts(toolCallDelta(truncated, '{"q":"y"}'));
+        // No finish_reason flush; use end-of-stream flush (gateway omits finish_reason)
+        // flushRemainingToolCalls takes (progress, localRequestId)
+        extractor.flushRemainingToolCalls(progress, undefined);
+        // When progress is provided, flushRemainingToolCalls reports via progress, not return
+        assert.equal(emitted.length, 1);
+        assert.equal((emitted[0] as { name: string }).name, longName);
+    });
+});

--- a/src/test/extractors.test.ts
+++ b/src/test/extractors.test.ts
@@ -14,8 +14,8 @@ import os from "node:os";
 
 const vscodeMockPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "vscode-mock-extractors-")), "index.js");
 fs.writeFileSync(
-    vscodeMockPath,
-    `"use strict";
+  vscodeMockPath,
+  `"use strict";
 class LanguageModelTextPart { constructor(value) { this.value = value; } }
 class LanguageModelThinkingPart { constructor(text) { this.text = text; } }
 class LanguageModelToolCallPart {
@@ -24,100 +24,100 @@ class LanguageModelToolCallPart {
 class LanguageModelToolResultPart { constructor(callId, content) { this.callId = callId; this.content = content; } }
 module.exports = { LanguageModelTextPart, LanguageModelThinkingPart, LanguageModelToolCallPart, LanguageModelToolResultPart };
 `,
-    "utf-8",
+  "utf-8",
 );
 
 type ResolveFilename = (request: string, parent: unknown, ...args: unknown[]) => string;
 const moduleResolver = Module as unknown as { _resolveFilename: ResolveFilename };
 const originalResolveFilename = moduleResolver._resolveFilename;
 moduleResolver._resolveFilename = function (request: string, parent: unknown, ...args: unknown[]): string {
-    if (request === "vscode") {
-        return vscodeMockPath;
-    }
-    return originalResolveFilename.call(this, request, parent, ...args);
+  if (request === "vscode") {
+    return vscodeMockPath;
+  }
+  return originalResolveFilename.call(this, request, parent, ...args);
 };
 
 let OpenAiResponseExtractor: typeof import("../transports/extractors.js").OpenAiResponseExtractor;
 let truncateToolName: typeof import("../request/openai.js").truncateToolName;
 
 describe("OpenAiResponseExtractor — truncated tool name round-trip", () => {
-    before(async () => {
-        const extractors = await import("../transports/extractors.js");
-        OpenAiResponseExtractor = extractors.OpenAiResponseExtractor;
-        const openai = await import("../request/openai.js");
-        truncateToolName = openai.truncateToolName;
-    });
+  before(async () => {
+    const extractors = await import("../transports/extractors.js");
+    OpenAiResponseExtractor = extractors.OpenAiResponseExtractor;
+    const openai = await import("../request/openai.js");
+    truncateToolName = openai.truncateToolName;
+  });
 
-    function makeExtractor(toolNameMap?: ReadonlyMap<string, string>) {
-        // Constructor: onReasoningContent, onReasoningDebug, thinkFilter, progress, localRequestId, output, treatReasoningAsContent, toolNameMap
-        return new OpenAiResponseExtractor(undefined, undefined, undefined, undefined, undefined, undefined, false, toolNameMap);
-    }
+  function makeExtractor(toolNameMap?: ReadonlyMap<string, string>) {
+    // Constructor: onReasoningContent, onReasoningDebug, thinkFilter, progress, localRequestId, output, treatReasoningAsContent, toolNameMap
+    return new OpenAiResponseExtractor(undefined, undefined, undefined, undefined, undefined, undefined, false, toolNameMap);
+  }
 
-    function toolCallDelta(name: string, args: string, index = 0, id = "call_1") {
-        return {
-            choices: [
-                {
-                    index: 0,
-                    delta: {
-                        tool_calls: [{ index, id, type: "function", function: { name, arguments: args } }],
-                    },
-                    finish_reason: null,
-                },
-            ],
-        };
-    }
+  function toolCallDelta(name: string, args: string, index = 0, id = "call_1") {
+    return {
+      choices: [
+        {
+          index: 0,
+          delta: {
+            tool_calls: [{ index, id, type: "function", function: { name, arguments: args } }],
+          },
+          finish_reason: null,
+        },
+      ],
+    };
+  }
 
-    function finishReasonChunk(reason: string) {
-        return {
-            choices: [{ index: 0, delta: {}, finish_reason: reason }],
-        };
-    }
+  function finishReasonChunk(reason: string) {
+    return {
+      choices: [{ index: 0, delta: {}, finish_reason: reason }],
+    };
+  }
 
-    it("emits original name when model returned truncated name", () => {
-        const longName = "a".repeat(72);
-        const truncated = truncateToolName(longName);
-        assert.notEqual(truncated, longName);
-        const map = new Map<string, string>([[truncated, longName]]);
-        const extractor = makeExtractor(map);
+  it("emits original name when model returned truncated name", () => {
+    const longName = "a".repeat(72);
+    const truncated = truncateToolName(longName);
+    assert.notEqual(truncated, longName);
+    const map = new Map<string, string>([[truncated, longName]]);
+    const extractor = makeExtractor(map);
 
-        extractor.extractStreamParts(toolCallDelta(truncated, '{"q":"x"}'));
-        const parts = extractor.extractStreamParts(finishReasonChunk("tool_calls")) as { name: string }[];
-        assert.equal(parts.length, 1);
-        assert.equal(parts[0].name, longName);
-    });
+    extractor.extractStreamParts(toolCallDelta(truncated, '{"q":"x"}'));
+    const parts = extractor.extractStreamParts(finishReasonChunk("tool_calls")) as { name: string }[];
+    assert.equal(parts.length, 1);
+    assert.equal(parts[0].name, longName);
+  });
 
-    it("passes through name unchanged when no map entry", () => {
-        const extractor = makeExtractor(new Map());
-        extractor.extractStreamParts(toolCallDelta("read_file", '{"path":"/x"}'));
-        const parts = extractor.extractStreamParts(finishReasonChunk("tool_calls")) as { name: string }[];
-        assert.equal(parts[0].name, "read_file");
-    });
+  it("passes through name unchanged when no map entry", () => {
+    const extractor = makeExtractor(new Map());
+    extractor.extractStreamParts(toolCallDelta("read_file", '{"path":"/x"}'));
+    const parts = extractor.extractStreamParts(finishReasonChunk("tool_calls")) as { name: string }[];
+    assert.equal(parts[0].name, "read_file");
+  });
 
-    it("passes through name unchanged when no map provided", () => {
-        const extractor = makeExtractor(undefined);
-        extractor.extractStreamParts(toolCallDelta("grep_search", '{"query":"foo"}'));
-        const parts = extractor.extractStreamParts(finishReasonChunk("tool_calls")) as { name: string }[];
-        assert.equal(parts[0].name, "grep_search");
-    });
+  it("passes through name unchanged when no map provided", () => {
+    const extractor = makeExtractor(undefined);
+    extractor.extractStreamParts(toolCallDelta("grep_search", '{"query":"foo"}'));
+    const parts = extractor.extractStreamParts(finishReasonChunk("tool_calls")) as { name: string }[];
+    assert.equal(parts[0].name, "grep_search");
+  });
 
-    it("flushRemainingToolCalls also reverse-maps truncated names", () => {
-        const longName = "b".repeat(72);
-        const truncated = truncateToolName(longName);
-        const map = new Map<string, string>([[truncated, longName]]);
-        const extractor = makeExtractor(map);
-        // Minimal progress stub — extractor reports via reportProgressPart
-        const emitted: unknown[] = [];
-        const progress: import("vscode").Progress<import("vscode").LanguageModelResponsePart2> = {
-            report: (part) => {
-                emitted.push(part);
-            },
-        };
-        extractor.extractStreamParts(toolCallDelta(truncated, '{"q":"y"}'));
-        // No finish_reason flush; use end-of-stream flush (gateway omits finish_reason)
-        // flushRemainingToolCalls takes (progress, localRequestId)
-        extractor.flushRemainingToolCalls(progress, undefined);
-        // When progress is provided, flushRemainingToolCalls reports via progress, not return
-        assert.equal(emitted.length, 1);
-        assert.equal((emitted[0] as { name: string }).name, longName);
-    });
+  it("flushRemainingToolCalls also reverse-maps truncated names", () => {
+    const longName = "b".repeat(72);
+    const truncated = truncateToolName(longName);
+    const map = new Map<string, string>([[truncated, longName]]);
+    const extractor = makeExtractor(map);
+    // Minimal progress stub — extractor reports via reportProgressPart
+    const emitted: unknown[] = [];
+    const progress: import("vscode").Progress<import("vscode").LanguageModelResponsePart2> = {
+      report: (part) => {
+        emitted.push(part);
+      },
+    };
+    extractor.extractStreamParts(toolCallDelta(truncated, '{"q":"y"}'));
+    // No finish_reason flush; use end-of-stream flush (gateway omits finish_reason)
+    // flushRemainingToolCalls takes (progress, localRequestId)
+    extractor.flushRemainingToolCalls(progress, undefined);
+    // When progress is provided, flushRemainingToolCalls reports via progress, not return
+    assert.equal(emitted.length, 1);
+    assert.equal((emitted[0] as { name: string }).name, longName);
+  });
 });

--- a/src/test/metadata.test.ts
+++ b/src/test/metadata.test.ts
@@ -193,3 +193,24 @@ describe("normalizeLiveModelMetadata — modality-based vision detection", () =>
     assert.notEqual(plain?.supportsVision, true);
   });
 });
+
+describe("fallbackModelMetadata — Muse Spark 1.2 limits", () => {
+  it("returns context/output limits for the Go contributor variant", () => {
+    const meta = fallbackModelMetadata("muse-spark-1.2-contributor", GO_VENDOR);
+    assert.ok(meta, "expected fallback metadata for muse-spark-1.2-contributor");
+    assert.equal(meta.contextWindow, 1_048_576);
+    assert.equal(meta.maxOutputTokens, 131_072);
+  });
+
+  it("returns context/output limits for the Zen free variant", () => {
+    const meta = fallbackModelMetadata("muse-spark-1.2-contributor-free", ZEN_VENDOR);
+    assert.ok(meta, "expected fallback metadata for muse-spark-1.2-contributor-free");
+    assert.equal(meta.contextWindow, 1_048_576);
+    assert.equal(meta.maxOutputTokens, 131_072);
+  });
+
+  it("does NOT report temperature: false (temperature is accepted)", () => {
+    const meta = fallbackModelMetadata("muse-spark-1.2-contributor", GO_VENDOR);
+    assert.notEqual(meta?.temperature, false);
+  });
+});

--- a/src/test/openai-request.test.ts
+++ b/src/test/openai-request.test.ts
@@ -30,13 +30,18 @@ moduleResolver._resolveFilename = function (request: string, parent: unknown, ..
   return originalResolveFilename.call(this, request, parent, ...args);
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let buildResponsesRequestBody: (...args: any[]) => Record<string, unknown>;
+let buildResponsesRequestBody: typeof import("../request/openai.js").buildResponsesRequestBody;
+let isMuseFamily: typeof import("../request/openai.js").isMuseFamily;
+let truncateToolName: typeof import("../request/openai.js").truncateToolName;
+let buildResponsesToolNameMap: typeof import("../request/openai.js").buildResponsesToolNameMap;
 
 describe("buildResponsesRequestBody — Muse Spark tool name truncation", () => {
   before(async () => {
     const mod = await import("../request/openai.js");
     buildResponsesRequestBody = mod.buildResponsesRequestBody;
+    isMuseFamily = mod.isMuseFamily;
+    truncateToolName = mod.truncateToolName;
+    buildResponsesToolNameMap = mod.buildResponsesToolNameMap;
   });
 
   const longToolName = "a".repeat(72);
@@ -49,18 +54,40 @@ describe("buildResponsesRequestBody — Muse Spark tool name truncation", () => 
     inputSchema: { type: "object", properties: {} },
   });
 
-  const baseArgs = {
+  const baseArgs: {
+    messages: import("../request/types.js").ApiMessage[];
+    settings: import("../request/types.js").ApiSettings;
+    metadata: import("../models/metadata.js").ResolvedModelMetadata;
+    limits: import("../models/modelLimits.js").ModelLimits;
+  } = {
     messages: [{ role: "user", content: "hello" }],
-    settings: { temperature: 0.2, thinking: {} },
-    metadata: {},
-    limits: { maxOutputTokens: 4096 },
+    settings: {
+      temperature: 0.2,
+      thinking: {},
+      maxOutputTokensOverride: 0,
+      maxInputTokensOverride: 0,
+      debugReasoning: false,
+      requestTimeoutMs: 0,
+      streamIdleTimeoutMs: 0,
+      stripThinkTags: "auto",
+    } as unknown as import("../request/types.js").ApiSettings,
+    metadata: {} as unknown as import("../models/metadata.js").ResolvedModelMetadata,
+    limits: { maxOutputTokens: 4096 } as unknown as import("../models/modelLimits.js").ModelLimits,
   };
+
+  function opts(tools: ReturnType<typeof makeTool>[]): import("vscode").ProvideLanguageModelChatResponseOptions {
+    // ProvideLanguageModelChatResponseOptions in the proposed API only declares
+    // requestInitiator/modelConfiguration; tools/toolMode are supplied at runtime
+    // by VS Code but not yet in the d.ts. Cast is intentional and matches the
+    // runtime shape the request builders read.
+    return { tools } as unknown as import("vscode").ProvideLanguageModelChatResponseOptions;
+  }
 
   it("truncates long tool names for Muse Spark", () => {
     const body = buildResponsesRequestBody(
       "muse-spark-1.2-contributor",
       baseArgs.messages,
-      { tools: [makeTool(longToolName)] },
+      opts([makeTool(longToolName)]),
       baseArgs.settings,
       baseArgs.metadata,
       baseArgs.limits,
@@ -75,7 +102,7 @@ describe("buildResponsesRequestBody — Muse Spark tool name truncation", () => 
     const body = buildResponsesRequestBody(
       "muse-spark-1.2-contributor-free",
       baseArgs.messages,
-      { tools: [makeTool(longToolName)] },
+      opts([makeTool(longToolName)]),
       baseArgs.settings,
       baseArgs.metadata,
       baseArgs.limits,
@@ -88,7 +115,7 @@ describe("buildResponsesRequestBody — Muse Spark tool name truncation", () => 
     const body = buildResponsesRequestBody(
       "gpt-5.6-luna",
       baseArgs.messages,
-      { tools: [makeTool(longToolName)] },
+      opts([makeTool(longToolName)]),
       baseArgs.settings,
       baseArgs.metadata,
       baseArgs.limits,
@@ -101,7 +128,7 @@ describe("buildResponsesRequestBody — Muse Spark tool name truncation", () => 
     const body = buildResponsesRequestBody(
       "muse-spark-1.2-contributor",
       baseArgs.messages,
-      { tools: [makeTool(shortToolName)] },
+      opts([makeTool(shortToolName)]),
       baseArgs.settings,
       baseArgs.metadata,
       baseArgs.limits,
@@ -114,7 +141,7 @@ describe("buildResponsesRequestBody — Muse Spark tool name truncation", () => 
     const body = buildResponsesRequestBody(
       "muse-spark-1.2-contributor",
       baseArgs.messages,
-      { tools: [makeTool(exactly64)] },
+      opts([makeTool(exactly64)]),
       baseArgs.settings,
       baseArgs.metadata,
       baseArgs.limits,
@@ -128,7 +155,7 @@ describe("buildResponsesRequestBody — Muse Spark tool name truncation", () => 
       buildResponsesRequestBody(
         "muse-spark-1.2-contributor",
         baseArgs.messages,
-        { tools: [makeTool(longToolName)] },
+        opts([makeTool(longToolName)]),
         baseArgs.settings,
         baseArgs.metadata,
         baseArgs.limits,
@@ -142,7 +169,7 @@ describe("buildResponsesRequestBody — Muse Spark tool name truncation", () => 
     const body = buildResponsesRequestBody(
       "muse-spark-1.2-contributor",
       baseArgs.messages,
-      { tools: [makeTool("a".repeat(72)), makeTool("b".repeat(72))] },
+      opts([makeTool("a".repeat(72)), makeTool("b".repeat(72))]),
       baseArgs.settings,
       baseArgs.metadata,
       baseArgs.limits,
@@ -150,5 +177,63 @@ describe("buildResponsesRequestBody — Muse Spark tool name truncation", () => 
     const tools = body.tools as { name: string }[];
     assert.equal(tools.length, 2);
     assert.notEqual(tools[0].name, tools[1].name, "different long names should produce different truncated names");
+  });
+
+  it("sends truncation: disabled for Muse Spark, auto for others", () => {
+    const museBody = buildResponsesRequestBody(
+      "muse-spark-1.2-contributor",
+      baseArgs.messages,
+      opts([]),
+      baseArgs.settings,
+      baseArgs.metadata,
+      baseArgs.limits,
+    );
+    assert.equal(museBody.truncation, "disabled");
+    const gptBody = buildResponsesRequestBody(
+      "gpt-5.6-luna",
+      baseArgs.messages,
+      opts([]),
+      baseArgs.settings,
+      baseArgs.metadata,
+      baseArgs.limits,
+    );
+    assert.equal(gptBody.truncation, "auto");
+  });
+});
+
+describe("isMuseFamily — registry single source of truth", () => {
+  it("returns true for Muse Spark variants, false otherwise", () => {
+    assert.equal(isMuseFamily("muse-spark-1.2-contributor"), true);
+    assert.equal(isMuseFamily("muse-spark-1.2-contributor-free"), true);
+    assert.equal(isMuseFamily("MUSE-spark-1.2-contributor"), true);
+    assert.equal(isMuseFamily("gpt-5.6-luna"), false);
+    assert.equal(isMuseFamily(""), false);
+  });
+});
+
+describe("buildResponsesToolNameMap — truncated → original round-trip", () => {
+  const makeToolLocal = (name: string) => ({
+    name,
+    description: `Tool ${name}`,
+    inputSchema: { type: "object", properties: {} },
+  });
+
+  it("maps truncated names back to originals for Muse Spark", () => {
+    const longName = "a".repeat(72);
+    const truncated = truncateToolName(longName);
+    const map = buildResponsesToolNameMap([makeToolLocal(longName), makeToolLocal("read_file")], "muse-spark-1.2-contributor");
+    assert.equal(map.get(truncated), longName);
+    assert.equal(map.size, 1);
+  });
+
+  it("returns empty map for non-Muse models", () => {
+    const map = buildResponsesToolNameMap([makeToolLocal("a".repeat(72))], "gpt-5.6-luna");
+    assert.equal(map.size, 0);
+  });
+
+  it("returns empty map when no tools or empty modelId", () => {
+    assert.equal(buildResponsesToolNameMap([], "muse-spark-1.2-contributor").size, 0);
+    assert.equal(buildResponsesToolNameMap(undefined, "muse-spark-1.2-contributor").size, 0);
+    assert.equal(buildResponsesToolNameMap([makeToolLocal("a".repeat(72))], "").size, 0);
   });
 });

--- a/src/test/openai-request.test.ts
+++ b/src/test/openai-request.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, before } from "node:test";
+import assert from "node:assert/strict";
+import Module from "node:module";
+import path from "node:path";
+import fs from "node:fs";
+import os from "node:os";
+
+/*
+ * Tests covering one of the fixes for #165: The Responses API rejects tool names longer than 64 characters, and Muse Spark tool names can be arbitrarily long. The truncation strategy is to keep the first 55 characters, append an underscore, and then append an 8-character hash of the original name. This ensures that the truncated name is unique and deterministic.
+ * The truncation is deterministic and includes a hash suffix to avoid collisions.
+ */
+
+const vscodeMockPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "vscode-mock-openai-")), "index.js");
+fs.writeFileSync(
+  vscodeMockPath,
+  `"use strict";
+class LanguageModelChatToolMode { static Required = "required"; }
+module.exports = { LanguageModelChatToolMode };
+`,
+  "utf-8",
+);
+
+type ResolveFilename = (request: string, parent: unknown, ...args: unknown[]) => string;
+const moduleResolver = Module as unknown as { _resolveFilename: ResolveFilename };
+const originalResolveFilename = moduleResolver._resolveFilename;
+moduleResolver._resolveFilename = function (request: string, parent: unknown, ...args: unknown[]): string {
+  if (request === "vscode") {
+    return vscodeMockPath;
+  }
+  return originalResolveFilename.call(this, request, parent, ...args);
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let buildResponsesRequestBody: (...args: any[]) => Record<string, unknown>;
+
+describe("buildResponsesRequestBody — Muse Spark tool name truncation", () => {
+  before(async () => {
+    const mod = await import("../request/openai.js");
+    buildResponsesRequestBody = mod.buildResponsesRequestBody;
+  });
+
+  const longToolName = "a".repeat(72);
+  const shortToolName = "read_file";
+  const exactly64 = "b".repeat(64);
+
+  const makeTool = (name: string) => ({
+    name,
+    description: `Tool ${name}`,
+    inputSchema: { type: "object", properties: {} },
+  });
+
+  const baseArgs = {
+    messages: [{ role: "user", content: "hello" }],
+    settings: { temperature: 0.2, thinking: {} },
+    metadata: {},
+    limits: { maxOutputTokens: 4096 },
+  };
+
+  it("truncates long tool names for Muse Spark", () => {
+    const body = buildResponsesRequestBody(
+      "muse-spark-1.2-contributor",
+      baseArgs.messages,
+      { tools: [makeTool(longToolName)] },
+      baseArgs.settings,
+      baseArgs.metadata,
+      baseArgs.limits,
+    );
+    const tool = (body.tools as { name: string }[])[0];
+    assert.ok(tool.name.length <= 64, `expected ≤64 chars, got ${tool.name.length}`);
+    assert.ok(tool.name !== longToolName, "name should have been truncated");
+    assert.ok(tool.name.includes("_"), "truncated name should contain underscore separator");
+  });
+
+  it("truncates long tool names for Muse Spark free variant", () => {
+    const body = buildResponsesRequestBody(
+      "muse-spark-1.2-contributor-free",
+      baseArgs.messages,
+      { tools: [makeTool(longToolName)] },
+      baseArgs.settings,
+      baseArgs.metadata,
+      baseArgs.limits,
+    );
+    const tool = (body.tools as { name: string }[])[0];
+    assert.ok(tool.name.length <= 64, `expected ≤64 chars, got ${tool.name.length}`);
+  });
+
+  it("does NOT truncate tool names for non-Muse models", () => {
+    const body = buildResponsesRequestBody(
+      "gpt-5.6-luna",
+      baseArgs.messages,
+      { tools: [makeTool(longToolName)] },
+      baseArgs.settings,
+      baseArgs.metadata,
+      baseArgs.limits,
+    );
+    const tool = (body.tools as { name: string }[])[0];
+    assert.equal(tool.name, longToolName, "non-Muse models should pass names through unchanged");
+  });
+
+  it("does NOT truncate short tool names even for Muse Spark", () => {
+    const body = buildResponsesRequestBody(
+      "muse-spark-1.2-contributor",
+      baseArgs.messages,
+      { tools: [makeTool(shortToolName)] },
+      baseArgs.settings,
+      baseArgs.metadata,
+      baseArgs.limits,
+    );
+    const tool = (body.tools as { name: string }[])[0];
+    assert.equal(tool.name, shortToolName, "short names should pass through unchanged");
+  });
+
+  it("does NOT truncate names that are exactly 64 characters", () => {
+    const body = buildResponsesRequestBody(
+      "muse-spark-1.2-contributor",
+      baseArgs.messages,
+      { tools: [makeTool(exactly64)] },
+      baseArgs.settings,
+      baseArgs.metadata,
+      baseArgs.limits,
+    );
+    const tool = (body.tools as { name: string }[])[0];
+    assert.equal(tool.name, exactly64, "exactly-64-char names should not be truncated");
+  });
+
+  it("produces deterministic truncation", () => {
+    const make = () =>
+      buildResponsesRequestBody(
+        "muse-spark-1.2-contributor",
+        baseArgs.messages,
+        { tools: [makeTool(longToolName)] },
+        baseArgs.settings,
+        baseArgs.metadata,
+        baseArgs.limits,
+      );
+    const name1 = (make().tools as { name: string }[])[0].name;
+    const name2 = (make().tools as { name: string }[])[0].name;
+    assert.equal(name1, name2, "same input should produce same output");
+  });
+
+  it("produces unique names for different long tool names", () => {
+    const body = buildResponsesRequestBody(
+      "muse-spark-1.2-contributor",
+      baseArgs.messages,
+      { tools: [makeTool("a".repeat(72)), makeTool("b".repeat(72))] },
+      baseArgs.settings,
+      baseArgs.metadata,
+      baseArgs.limits,
+    );
+    const tools = body.tools as { name: string }[];
+    assert.equal(tools.length, 2);
+    assert.notEqual(tools[0].name, tools[1].name, "different long names should produce different truncated names");
+  });
+});

--- a/src/test/registry.test.ts
+++ b/src/test/registry.test.ts
@@ -57,6 +57,13 @@ describe("model registry — data-driven transport routing", () => {
     assert.equal(resolveModelRouting("gemini-3.5-flash", goProvider).endpointKind, "chat-completions");
   });
 
+  it("routes Muse Spark to the Responses API on every vendor", () => {
+    assert.equal(resolveModelRouting("muse-spark-1.2-contributor", goProvider).endpointKind, "responses");
+    assert.equal(resolveModelRouting("muse-spark-1.2-contributor", goProvider).endpointUrl, goProvider.responsesUrl);
+    assert.equal(resolveModelRouting("muse-spark-1.2-contributor-free", zenProvider).endpointKind, "responses");
+    assert.equal(resolveModelRouting("muse-spark-1.2-contributor-free", zenProvider).endpointUrl, zenProvider.responsesUrl);
+  });
+
   it("defaults every other known family to chat-completions", () => {
     for (const modelId of ["deepseek-v4-flash", "glm-5.1", "kimi-k2.6", "mimo-v2.5", "qwen3.8-max"]) {
       assert.equal(resolveModelRouting(modelId, goProvider).endpointKind, "chat-completions", modelId);
@@ -87,6 +94,7 @@ describe("model registry — data-driven thinking family", () => {
     assert.equal(thinkingFamily("qwen3.5-plus"), "qwen");
     assert.equal(thinkingFamily("qwen3.7-max"), "qwen");
     assert.equal(thinkingFamily("mimo-v2.5"), "mimo");
+    assert.equal(thinkingFamily("muse-spark-1.2-contributor"), "muse");
   });
 
   it("returns null for families without a dedicated strategy", () => {

--- a/src/test/responsesRequest.test.ts
+++ b/src/test/responsesRequest.test.ts
@@ -40,6 +40,25 @@ describe("buildResponsesRequestEnvelope", () => {
     assert.deepEqual(body.tools, [{ type: "function", name: "read_file" }]);
     assert.equal(body.tool_choice, "auto");
   });
+
+  it("defaults truncation to auto when not specified", () => {
+    const body = buildResponsesRequestEnvelope({
+      model: "gpt-5.6-luna",
+      input: [],
+      maxOutputTokens: 4096,
+    });
+    assert.equal(body.truncation, "auto");
+  });
+
+  it("allows overriding truncation to disabled", () => {
+    const body = buildResponsesRequestEnvelope({
+      model: "muse-spark-1.2-contributor",
+      input: [],
+      maxOutputTokens: 4096,
+      truncation: "disabled",
+    });
+    assert.equal(body.truncation, "disabled");
+  });
 });
 
 describe("responsesInputItemsFromMessage", () => {

--- a/src/test/thinking.test.ts
+++ b/src/test/thinking.test.ts
@@ -20,6 +20,7 @@ const defaultSettings: ThinkingSettings = {
   qwen: "off",
   qwenBudget: "auto",
   mimo: "off",
+  muse: "off",
 };
 
 /** Minimal reasoning-capable metadata used for schema tests. */
@@ -197,6 +198,25 @@ describe("MimoThinking — payload + display (native reasoning model)", () => {
   });
 });
 
+describe("MuseThinking — payload + display (native reasoning model)", () => {
+  it("muse 'off' emits empty object (no reasoning fields)", () => {
+    const payload = thinkingProviderFor("muse-spark-1.2-contributor").buildPayload({ ...defaultSettings, muse: "off" });
+    assert.deepEqual(payload, {});
+  });
+
+  it("muse 'high' emits nested reasoning.effort (Responses API)", () => {
+    const payload = thinkingProviderFor("muse-spark-1.2-contributor").buildPayload({ ...defaultSettings, muse: "high" });
+    assert.deepEqual(payload, { reasoning: { effort: "high" } });
+  });
+
+  it("never surfaces reasoning_content as visible text (native reasoning model)", () => {
+    const provider = thinkingProviderFor("muse-spark-1.2-contributor");
+    const responsesUrl = "https://opencode.ai/zen/go/v1/responses";
+    assert.equal(provider.treatReasoningAsContent(responsesUrl, { ...defaultSettings, muse: "off" }), false);
+    assert.equal(provider.treatReasoningAsContent(responsesUrl, { ...defaultSettings, muse: "high" }), false);
+  });
+});
+
 describe("GLMThinking — payload (issue #61)", () => {
   it("glm-5.2 with glm='high' emits reasoning_effort: 'high'", () => {
     const payload = thinkingProviderFor("glm-5.2").buildPayload({ ...defaultSettings, glm: "high" });
@@ -320,6 +340,10 @@ describe("thinkingFamily — detection", () => {
     assert.equal(thinkingFamily("kimi-k2.6"), "kimi");
   });
 
+  it("classifies muse-spark-1.2-contributor as 'muse'", () => {
+    assert.equal(thinkingFamily("muse-spark-1.2-contributor"), "muse");
+  });
+
   it("returns null for unknown prefixes", () => {
     assert.equal(thinkingFamily("unknown-model"), null);
   });
@@ -377,6 +401,7 @@ describe("schema defaults stay aligned with THINKING_DEFAULTS", () => {
       ["gpt-5.6-luna", "openai"],
       ["qwen3.6-plus", "qwen"],
       ["mimo-v2.5", "mimo"],
+      ["muse-spark-1.2-contributor", "muse"],
     ];
     for (const [modelId, key] of cases) {
       const schema = thinkingProviderFor(modelId).schema();

--- a/src/thinking/muse.ts
+++ b/src/thinking/muse.ts
@@ -1,0 +1,64 @@
+/**
+ * Muse Spark (Meta) thinking strategy.
+ *
+ * Muse Spark models route through the OpenAI Responses API where reasoning
+ * is a nested `reasoning: { effort }` object — same wire format as GPT 5.x.
+ *
+ * DISPLAY: Muse Spark is a native reasoning model — `reasoning_content` is
+ * always genuine chain-of-thought and goes to the thinking panel.
+ */
+import { BaseThinkingProvider } from "./base";
+import { schemaFromReasoningOptions, effortProperty, type ThinkingSchema } from "./schema";
+import type { ResolvedModelMetadata } from "../models/metadata";
+import type { ThinkingSettings, ThinkingFamily, BuildThinkingPayloadOptions } from "./types";
+
+const MUSE_EFFORTS = ["off", "low", "medium", "high", "xhigh"] as const;
+
+export class MuseThinking extends BaseThinkingProvider {
+  readonly family: ThinkingFamily = "muse";
+
+  constructor(readonly modelId: string) {
+    super();
+  }
+
+  schema(metadata?: ResolvedModelMetadata): ThinkingSchema | undefined {
+    return (
+      schemaFromReasoningOptions(metadata) ?? {
+        properties: {
+          reasoningEffort: effortProperty({
+            enum: MUSE_EFFORTS,
+            labels: ["Off", "Low", "Medium", "High", "XHigh"],
+            descriptions: [
+              "Fastest responses",
+              "Faster responses with less reasoning",
+              "Balanced reasoning and speed",
+              "Greater reasoning depth",
+              "Maximum reasoning depth",
+            ],
+            default: "off",
+          }),
+        },
+      }
+    );
+  }
+
+  applyOverride(settings: ThinkingSettings, override: Record<string, unknown>): ThinkingSettings {
+    return this.applyEffort(settings, override, "muse", MUSE_EFFORTS);
+  }
+
+  buildPayload(thinking: ThinkingSettings, _opts?: BuildThinkingPayloadOptions): Record<string, unknown> {
+    if (thinking.muse === "off") {
+      return {};
+    }
+    return { reasoning: { effort: thinking.muse } };
+  }
+
+  requestsThinking(thinking: ThinkingSettings): boolean {
+    return thinking.muse !== "off";
+  }
+
+  // reasoning_content is always genuine CoT → never surfaced as visible text
+  treatReasoningAsContent(_url: string, _thinking: ThinkingSettings): boolean {
+    return false;
+  }
+}

--- a/src/thinking/provider.ts
+++ b/src/thinking/provider.ts
@@ -21,6 +21,7 @@ import { MiniMaxThinking } from "./minimax";
 import { OpenAiThinking } from "./openai";
 import { QwenThinking } from "./qwen";
 import { MimoThinking } from "./mimo";
+import { MuseThinking } from "./muse";
 import { FallbackThinking } from "./fallback";
 
 /** Strategy interface implemented by each per-provider thinking class. */
@@ -72,6 +73,8 @@ export function thinkingProviderFor(modelId: string, metadata?: ResolvedModelMet
       return new QwenThinking(modelId);
     case "mimo":
       return new MimoThinking(modelId);
+    case "muse":
+      return new MuseThinking(modelId);
     default:
       return new FallbackThinking(modelId, metadata);
   }

--- a/src/thinking/types.ts
+++ b/src/thinking/types.ts
@@ -14,10 +14,11 @@ export interface ThinkingSettings {
   qwen: "auto" | "on" | "off";
   qwenBudget: "auto" | "4096" | "16384" | "32768" | "81920";
   mimo: "off" | "low" | "medium" | "high";
+  muse: "off" | "low" | "medium" | "high" | "xhigh";
 }
 
 /** Detected thinking family for a raw model id. `null` = no known family. */
-export type ThinkingFamily = "deepseek" | "glm" | "kimi" | "minimax" | "openai" | "qwen" | "mimo" | null;
+export type ThinkingFamily = "deepseek" | "glm" | "kimi" | "minimax" | "openai" | "qwen" | "mimo" | "muse" | null;
 
 /**
  * Which configuration layer supplied the effective thinking value.

--- a/src/transports/extractors.ts
+++ b/src/transports/extractors.ts
@@ -29,7 +29,7 @@ abstract class BaseResponseExtractor {
     protected readonly progress?: vscode.Progress<vscode.LanguageModelResponsePart2>,
     protected readonly localRequestId?: string,
     protected readonly output?: vscode.OutputChannel,
-  ) { }
+  ) {}
 
   get emittedText(): number {
     return this.emittedTextLength;

--- a/src/transports/extractors.ts
+++ b/src/transports/extractors.ts
@@ -29,7 +29,7 @@ abstract class BaseResponseExtractor {
     protected readonly progress?: vscode.Progress<vscode.LanguageModelResponsePart2>,
     protected readonly localRequestId?: string,
     protected readonly output?: vscode.OutputChannel,
-  ) {}
+  ) { }
 
   get emittedText(): number {
     return this.emittedTextLength;
@@ -152,6 +152,14 @@ class OpenAiResponseExtractor extends BaseResponseExtractor {
      * worked around.)
      */
     private readonly treatReasoningAsContent = false,
+    /**
+     * Truncated → original tool name map for the Responses API round-trip.
+     * Muse Spark truncates names >64 chars at request build time; the model
+     * returns the truncated name, so we reverse-lookup before emitting the
+     * `LanguageModelToolCallPart` so VS Code can resolve the original tool.
+     * Mirrors `toolNamesById` in `src/request/google.ts`.
+     */
+    private readonly toolNameMap?: ReadonlyMap<string, string>,
   ) {
     super(onReasoningContent, onReasoningDebug, thinkFilter, progress, localRequestId, output);
   }
@@ -333,10 +341,14 @@ class OpenAiResponseExtractor extends BaseResponseExtractor {
 
   private flushToolCalls(): vscode.LanguageModelToolCallPart[] {
     const calls = this.toolCallAccumulator.flush();
-    const parts = calls.map(
-      (call, index) =>
-        new vscode.LanguageModelToolCallPart(call.id || `opencodego-tool-${String(Date.now())}-${String(index)}`, call.name, call.input),
-    );
+    const parts = calls.map((call, index) => {
+      const resolvedName = this.toolNameMap?.get(call.name) ?? call.name;
+      return new vscode.LanguageModelToolCallPart(
+        call.id || `opencodego-tool-${String(Date.now())}-${String(index)}`,
+        resolvedName,
+        call.input,
+      );
+    });
 
     if (this.reasoningContent.trim()) {
       this.onReasoningDebug?.(this.reasoningContent);

--- a/src/transports/responses.ts
+++ b/src/transports/responses.ts
@@ -14,6 +14,9 @@ export async function streamResponsesApi(options: StreamRequestOptions): Promise
     thinkFilter,
     options.progress,
     options.requestHeaders["x-opencode-request"],
+    options.output,
+    false,
+    options.toolNameMap,
   );
 
   await streamOpenCodeResponse({


### PR DESCRIPTION
## 📝 What does this change?

Adds full support for Muse Spark 1.2 models (muse-spark-1.2-contributor on Go, muse-spark-1.2-contributor-free on Zen). Closes #165.

## 🧪 How did you test it?

Tested with `muse-spark-1.2-contributor` (Go) and `muse-spark-1.2-contributor-free` (Zen) - verified chat responses, tool calling, and thinking effort levels (off/high). All 341 unit tests pass, lint is green, VSIX packages cleanly.

## ✅ Checklist

- [x] `npm run compile` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] `npm run package` produces a VSIX
- [x] I tested it works
- [x] I updated docs/CHANGELOG if needed
