### PR TITLE
fix(models): include Muse Spark 1.2 variants in offline vision fallback (#183)

### DIFF
--- a/src/models/modelTables.ts
+++ b/src/models/modelTables.ts
@@ -138,4 +138,10 @@ export const VISION_CAPABLE_MODELS = new Set([
   "gpt-5-nano",
   "grok-build-0.1",
   "gpt-5.6-luna",
+  // Muse Spark 1.2 — models.dev lists image/video/pdf/audio input modalities
+  // for both variants; without these entries an offline fallback snapshot
+  // reports imageInput: false and VS Code strips attachments before they
+  // reach the provider (#183).
+  "muse-spark-1.2-contributor",
+  "muse-spark-1.2-contributor-free",
 ]);

--- a/src/test/metadata.test.ts
+++ b/src/test/metadata.test.ts
@@ -105,6 +105,11 @@ describe("VISION_CAPABLE_MODELS", () => {
     assert.ok(!VISION_CAPABLE_MODELS.has("big-pickle"));
   });
 
+  it("includes both Muse Spark 1.2 variants (models.dev lists image input) (#183)", () => {
+    assert.ok(VISION_CAPABLE_MODELS.has("muse-spark-1.2-contributor"));
+    assert.ok(VISION_CAPABLE_MODELS.has("muse-spark-1.2-contributor-free"));
+  });
+
   it("is an exported Set", () => {
     assert.ok(VISION_CAPABLE_MODELS instanceof Set);
     assert.ok(VISION_CAPABLE_MODELS.size > 10);


### PR DESCRIPTION
Fixes #183

PEACE BE UPON YOU

## Summary

Addresses #183 (Muse Spark 1.2 Contributor Free on Zen + images). Two parts:

**1. Already fixed in 0.7.0 — please upgrade.** The reporter's stack trace is from v0.6.0, where `muse-spark-1.2-contributor-free` went through the **chat-completions** endpoint — which the Muse gateway rejects (that's why the 400 body is a chat.completion object with an empty message and `finish_reason: null`). Commit 5586836 (released in 0.7.0) routes all `muse-*` models to the **Responses API**, and images are mapped to the correct `input_image` shape there.

**2. This PR — offline vision fallback gap.** models.dev lists image/video/pdf/audio input modalities for both Muse variants, but `VISION_CAPABLE_MODELS` (the bundled fallback used when neither live metadata nor a cached models.dev snapshot is available) lacked them. In that state the picker reported `imageInput: false`, so VS Code stripped image attachments before they ever reached the provider. Both variants are now in the set, so offline/cold-start users can attach images to Muse models too.

## Verification

- `npm run lint` all 7 checks green; new assertion covers both variants.
- 2 files changed, +11.

Fi Amanillah

