### PR TITLE
fix(thinking): don't drop reasoning when progress sink absent at construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the **OpenCode Go BYOK Provider** extension are documented here.
 
+## [Unreleased]
+
+### Fixed
+
+- **`[Thinking]` Reasoning is never silently dropped when the `progress` sink is unavailable (#196, Discussion #118).** After the god file split (PR #155), `flushReasoningFallback()` only emitted buffered `reasoning_content` as a `LanguageModelThinkingPart` when both the thinking-part constructor AND a `progress` sink were present at construction time. When the sink was missing (Agents window, certain Copilot Chat contexts) but the constructor was available, the buffered reasoning hit the legacy fallback path and was **silently dropped** — neither in the thinking panel nor as visible text. Fix: a new branch emits the reasoning via `reportProgressPart` with the constructor even without a construction-time sink, and the legacy drop path now logs a warning (`N chars of reasoning dropped`) so silent loss is diagnosable. Adds 3 regression tests in `src/test/extractors.test.ts` asserting the reasoning-surfacing invariants (reasoning → ThinkingPart via progress, never a TextPart, with and without a construction-time sink). Full analysis in `docs/issues/85-20260826-discussion118-deepseek-reasoning-leak-regression-analysis.md` and GitHub issue [#196](https://github.com/ltmoerdani/opencode-copilot-chat/issues/196).
+
 ## [0.7.2] — 2026-08-26
 
 ### Fixed

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -1,6 +1,18 @@
 # 🧠 OPENCODE COPILOT CHAT DEVLOG
 
-**Branch:** `main` | **Updated:** 2026-08-26 Asia/Jakarta | **Current Phase:** PR #193–#195 merged (try-again Zen fix + whitespace fix + review loop). Open: PR #161 (restore API key command).
+**Branch:** `main` | **Updated:** 2026-08-28 Asia/Jakarta | **Current Phase:** Discussion #118 deep dive → issue #196 → flushReasoningFallback residual gap fixed. Open: PR #161 (restore API key command).
+
+---
+
+## ✅ Discussion #118 regression analysis + issue #196 fix — 2026-08-28
+
+**Deep dive:** Full git-history audit of Discussion #118 (DeepSeek V4 reasoning leaking into chat). Classified as **3 regressions + 3 independent bugs** — not a single bug. Full write-up in `docs/issues/85-20260826-discussion118-deepseek-reasoning-leak-regression-analysis.md` + GitHub issue [#196](https://github.com/ltmoerdani/opencode-copilot-chat/issues/196).
+
+**Code fix (residual gap of Regression #3):** `flushReasoningFallback()` in `src/transports/extractors.ts` only emitted buffered `reasoning_content` as a `ThinkingPart` when BOTH the thinking constructor and a construction-time `progress` sink existed. With a sink absent (Agents window contexts) the reasoning was silently dropped. Fix: new branch emits via `reportProgressPart` using the constructor even without a construction-time sink; legacy drop path now logs `[warn]` with the dropped char count.
+
+**Tests:** 3 new shape-based regression tests in `src/test/extractors.test.ts` (suite `OpenAiResponseExtractor — reasoning surfacing invariants (issue #196)`). **432/432 pass**, `npm run compile` ✅, `npm run lint` 7/7 ✅.
+
+**Docs sync actions (this session, 2026-08-28):** created issue doc 85, updated CHANGELOG `[Unreleased]`, updated devlog. Draft reply for Discussion #118 prepared (pending user approval to post).
 
 ---
 

--- a/docs/issues/85-20260826-discussion118-deepseek-reasoning-leak-regression-analysis.md
+++ b/docs/issues/85-20260826-discussion118-deepseek-reasoning-leak-regression-analysis.md
@@ -3,12 +3,13 @@
 # Discussion #118: DeepSeek V4 Reasoning Text Leaks into Chat (Multi-Factor Regression Analysis)
 
 **Topic:** thinking / reasoning / streaming / regression / deepseek / community
-**Updated:** 2026-08-26
+**Updated:** 2026-08-28
 **Tags:** #thinking #reasoning #deepseek #regression #streaming #gateway #community
 **GitHub Discussion:** [#118](https://github.com/ltmoerdani/opencode-copilot-chat/discussions/118)
+**GitHub Issue:** [#196](https://github.com/ltmoerdani/opencode-copilot-chat/issues/196)
 **Reported by:** [@druellan](https://github.com/druellan)
 **Confirmed by:** [@weizhen25](https://github.com/weizhen25)
-**Status:** ✅ Solved per reporter (v0.7.x)
+**Status:** ✅ Solved per reporter (v0.7.x) · ✅ Regression #3 residual gap FIXED (2026-08-28, see "Final Resolution")
 
 ---
 
@@ -49,14 +50,14 @@ A full git history audit (80+ commits touching thinking/reasoning from May–Aug
 
 ### 🔴 Regression #3: God File Split Altered `flushReasoningFallback()` Behavior
 
-| Aspect         | Detail                                                                                                                                                                                   |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Timeline**   | Aug 14, 2026                                                                                                                                                                             |
-| **Event**      | PR #155: `streaming.ts` (1620 lines) → `src/transports/` domain folder                                                                                                                   |
-| **Breakage**   | `flushReasoningFallback()` logic changed. Reasoning was **silently dropped** when no `progress` sink was available                                                                       |
-| **Symptom**    | Reasoning neither appeared in thinking panel NOR as visible text. But in the fallback path (when `thinkingPartConstructor` unavailable), reasoning could leak as `LanguageModelTextPart` |
-| **Fix**        | `da881c9` (Aug 14 23:24): "don't drop reasoning when there is no progress sink"                                                                                                          |
-| **Root cause** | God file split altered subtle behavior that the test suite (310 tests) didn't catch                                                                                                      |
+| Aspect         | Detail                                                                                                                                                                                                                 |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Timeline**   | Aug 14, 2026                                                                                                                                                                                                           |
+| **Event**      | PR #155: `streaming.ts` (1620 lines) → `src/transports/` domain folder                                                                                                                                                 |
+| **Breakage**   | `flushReasoningFallback()` logic changed. Reasoning was **silently dropped** when no `progress` sink was available                                                                                                     |
+| **Symptom**    | Reasoning neither appeared in thinking panel NOR as visible text. But in the fallback path (when `thinkingPartConstructor` unavailable), reasoning could leak as `LanguageModelTextPart`                               |
+| **Fix**        | `da881c9` (Aug 14 23:24): "don't drop reasoning when there is no progress sink". Residual gap (sink absent at construction despite constructor present) fixed 2026-08-28 per issue #196 — see "Final Resolution" below |
+| **Root cause** | God file split altered subtle behavior that the test suite (310 tests) didn't catch                                                                                                                                    |
 
 **Relevance to #118:** This is the most likely direct cause of druellan's intermittent symptom. When `progress` sink is absent in certain VS Code contexts (Agents window, certain Copilot Chat configurations), reasoning could either be silently dropped or leak as visible text depending on the fallback path.
 
@@ -123,6 +124,8 @@ Aug 20  ── GLM 5.3 force thinking on                               ✅
 Aug 21  ── Flush reasoning in finally on engine throw              ✅
 Aug 22  ── Retry idle-stalled streams                              ✅
 Aug 26  ── "Try again" popup fix (#193)                            ✅
+Aug 28  ── Issue #196: residual flushReasoningFallback gap fixed   ✅
+           + 3 regression tests + drop-path warning log
 ```
 
 ---
@@ -131,15 +134,39 @@ Aug 26  ── "Try again" popup fix (#193)                            ✅
 
 The combination of fixes that collectively resolved the issue:
 
-| Fix                                                   | Version | What it fixed                                     |
-| ----------------------------------------------------- | ------- | ------------------------------------------------- |
-| PR #123: DeepSeek reasoning_content echo              | 0.5.2   | Multi-turn 400 error eliminated                   |
-| PR #126: typeof guard + unit tests                    | 0.5.2   | Reasoning history stability                       |
-| PR #150: DeepSeek reasoning → thinking block          | 0.7.0   | Reasoning never visible text                      |
-| PR #155: Per-provider thinking strategy               | 0.7.0   | Each model family has `treatReasoningAsContent()` |
-| PR #155: Single config authority                      | 0.7.0   | Thinking effort model A doesn't leak to model B   |
-| `da881c9`: Don't drop reasoning without progress sink | 0.7.0   | Reasoning not silently dropped                    |
-| #193: "Try again" popup fix                           | 0.7.2   | False positive truncation eliminated              |
+| Fix                                                   | Version | What it fixed                                          |
+| ----------------------------------------------------- | ------- | ------------------------------------------------------ |
+| PR #123: DeepSeek reasoning_content echo              | 0.5.2   | Multi-turn 400 error eliminated                        |
+| PR #126: typeof guard + unit tests                    | 0.5.2   | Reasoning history stability                            |
+| PR #150: DeepSeek reasoning → thinking block          | 0.7.0   | Reasoning never visible text                           |
+| PR #155: Per-provider thinking strategy               | 0.7.0   | Each model family has `treatReasoningAsContent()`      |
+| PR #155: Single config authority                      | 0.7.0   | Thinking effort model A doesn't leak to model B        |
+| `da881c9`: Don't drop reasoning without progress sink | 0.7.0   | Reasoning not silently dropped                         |
+| #193: "Try again" popup fix                           | 0.7.2   | False positive truncation eliminated                   |
+| #196: `flushReasoningFallback()` residual gap fix     | Unrel.  | Reasoning not dropped when sink absent at construction |
+
+---
+
+## Final Resolution (2026-08-28, issue #196)
+
+The hotfix `da881c9` (Aug 14) closed the most visible part of Regression #3, but a full re-verification against the current source revealed a **residual gap** in `flushReasoningFallback()` (`src/transports/extractors.ts`):
+
+- **Happy path:** `thinkingPartConstructor && this.progress` → reasoning emitted as `ThinkingPart` via progress. ✅
+- **Residual gap (fixed):** `thinkingPartConstructor` available but `progress` sink absent at construction → buffered reasoning fell through to the legacy fallback and was **silently dropped** (no thinking panel, no visible text, no log). ❌
+- **Legacy path:** no constructor → reasoning surfaced as `TextPart` (leak) or dropped. Now logs a warning.
+
+**Fix applied (this session):**
+
+1. New branch in `flushReasoningFallback()`: when the constructor exists but the sink does not, emit via `reportProgressPart(localRequestId, progress, new thinkingPartConstructor(reasoning))` so the reasoning always reaches the thinking block.
+2. The legacy drop path now logs `[warn] N chars of reasoning dropped: thinking API unavailable and response has visible content` — silent loss is now diagnosable.
+3. 3 regression tests added in `src/test/extractors.test.ts` (suite `OpenAiResponseExtractor — reasoning surfacing invariants (issue #196)`), using shape-based part checks (not `instanceof`, for mock compatibility):
+   - `reasoning_content + content` → ThinkingPart via progress, text in returned parts
+   - `reasoning_content` only → ThinkingPart via progress, empty returned parts
+   - no progress sink at construction → flush emits ThinkingPart, not TextPart
+
+**Verification:** `npm run compile` clean, `npm run lint` 7/7 pass, 432/432 unit tests pass.
+
+**Remaining upstream (not fixable extension-side):** gateway bug #37635 (all output wrapped in `reasoning_content` on Go) — mitigated by the `treatReasoningAsContent` workaround.
 
 ---
 
@@ -156,8 +183,8 @@ Every time a large file is refactored/split, subtle behavior in the reasoning pi
 
 ## Recommendations
 
-1. **Add integration test** for reasoning surfacing: send request to mock gateway → verify output parts contain `LanguageModelThinkingPart` (not `LanguageModelTextPart`) for reasoning models
-2. **Add logging** in `flushReasoningFallback()` when fallback path activates, so users can diagnose why reasoning isn't appearing
+1. ~~**Add integration test** for reasoning surfacing~~ → **DONE (2026-08-28):** 3 shape-based regression tests added in `src/test/extractors.test.ts` (issue #196 suite). Broader mock-gateway E2E still an option.
+2. ~~**Add logging** in `flushReasoningFallback()` when fallback path activates~~ → **DONE (2026-08-28):** legacy drop path now logs a `[warn]` with the dropped char count.
 3. **Create regression checklist** for any refactor touching `extractors.ts`, `thinkTags.ts`, or `streamParts.ts`. Must verify all model families
 4. **Monitor gateway bug #37635**: if OpenCode fixes the server-side issue, the `treatReasoningAsContent` workaround can be simplified
 

--- a/src/test/extractors.test.ts
+++ b/src/test/extractors.test.ts
@@ -122,6 +122,85 @@ describe("OpenAiResponseExtractor — truncated tool name round-trip", () => {
   });
 });
 
+describe("OpenAiResponseExtractor — reasoning surfacing invariants (issue #196)", () => {
+  let Extractor: typeof import("../transports/extractors.js").OpenAiResponseExtractor;
+
+  before(async () => {
+    const extractors = await import("../transports/extractors.js");
+    Extractor = extractors.OpenAiResponseExtractor;
+  });
+
+  // Mock parts have shape: ThinkingPart { text } vs TextPart { value } vs ToolCallPart { callId }
+  const isThinkingPart = (p: object): boolean => "text" in p && !("value" in p) && !("callId" in p);
+  const isTextPart = (p: object): boolean => "value" in p && !("text" in p);
+
+  type ProgressStub = { report: (p: object) => void };
+  function makeProgress(): { reported: object[]; progress: ProgressStub } {
+    const reported: object[] = [];
+    return {
+      reported,
+      progress: {
+        report: (p) => {
+          reported.push(p);
+        },
+      },
+    };
+  }
+
+  function reasoningDelta(reasoningContent: string, content?: string) {
+    return {
+      choices: [
+        {
+          delta: { ...(content !== undefined ? { content } : {}), reasoning_content: reasoningContent },
+          finish_reason: null,
+        },
+      ],
+    };
+  }
+
+  it("reasoning_content + content: reasoning goes to progress as ThinkingPart, text in returned parts", () => {
+    const { reported, progress } = makeProgress();
+    const extractor = new Extractor(undefined, undefined, undefined, progress, undefined, undefined, false);
+
+    const parts = extractor.extractStreamParts(reasoningDelta("thinking...", "hello"));
+
+    assert.equal(parts.length, 1, "only text part in returned array");
+    assert.ok(isTextPart(parts[0]), "returned part is TextPart");
+    assert.equal(reported.length, 1, "one progress.report call for reasoning");
+    assert.ok(isThinkingPart(reported[0]), "reported part is ThinkingPart");
+  });
+
+  it("reasoning_content only: ThinkingPart via progress, empty returned parts", () => {
+    const { reported, progress } = makeProgress();
+    const extractor = new Extractor(undefined, undefined, undefined, progress, undefined, undefined, false);
+
+    const parts = extractor.extractStreamParts(reasoningDelta("chain of thought"));
+
+    assert.equal(parts.length, 0, "nothing in returned parts");
+    assert.equal(reported.length, 1);
+    assert.ok(isThinkingPart(reported[0]));
+  });
+
+  it("no progress sink at construction: flushReasoningFallback emits ThinkingPart, not TextPart", () => {
+    const { reported: flushReported, progress: flushProgress } = makeProgress();
+    const extractor = new Extractor(
+      undefined,
+      undefined,
+      undefined,
+      undefined, // no live progress — reasoning accumulates but is never streamed
+      undefined,
+      undefined,
+      false,
+    );
+
+    extractor.extractStreamParts(reasoningDelta("thinking...", "answer"));
+    extractor.flushReasoningFallback(flushProgress, undefined);
+
+    assert.equal(flushReported.length, 1, "flush emits exactly one part");
+    assert.ok(isThinkingPart(flushReported[0]), "flushed part is ThinkingPart (not leaked as TextPart)");
+  });
+});
+
 describe("updateRequestUsageSummary — Responses nested usage", () => {
   let updateRequestUsageSummary: typeof import("../transports/extract.js").updateRequestUsageSummary;
 

--- a/src/transports/extractors.ts
+++ b/src/transports/extractors.ts
@@ -90,20 +90,28 @@ abstract class BaseResponseExtractor {
     if (!reasoning) {
       return;
     }
-    // If the thinking part API is available AND we had a progress sink,
-    // reasoning was already streamed live during extractStreamParts via
-    // handleReasoning(). The accumulated reasoningContent is retained only
-    // for tool-call replication (flushToolCalls → onReasoningContent).
-    // Without a progress sink nothing was ever streamed, so fall through to
-    // the legacy emit path rather than silently dropping the reasoning.
+    // Happy path: ThinkingPart API available AND live streaming happened.
+    // Reasoning was already streamed per-chunk via handleReasoning(); the
+    // accumulated copy is retained only for tool-call replication.
     if (thinkingPartConstructor && this.progress) {
       this.reasoningContent = "";
       return;
     }
-    // Legacy fallback (API unavailable): emit reasoning as plain text only
-    // when the response is otherwise empty, to avoid breaking the visible
-    // output. This preserves the pre-fix safety-net semantics.
+    // ThinkingPart API available but no live stream (progress absent at
+    // construction time, e.g. non-standard call paths). Emit now via the
+    // flush-time progress sink so the thinking panel still receives it.
+    if (thinkingPartConstructor) {
+      reportProgressPart(localRequestId, progress, new thinkingPartConstructor(reasoning));
+      this.reasoningContent = "";
+      return;
+    }
+    // Legacy fallback (ThinkingPart API unavailable): emit reasoning as plain
+    // text only when the response is otherwise empty, to avoid polluting a
+    // response that already has visible content.
     if (this.emittedTextLength > 0 || this.emittedToolCallsCount > 0) {
+      this.output?.appendLine(
+        `[warn] ${String(this.totalReasoningChars)}ch of reasoning dropped: thinking API unavailable and response has visible content`,
+      );
       this.reasoningContent = "";
       return;
     }


### PR DESCRIPTION
## Summary

Residual gap of Regression #3 from the Discussion #118 analysis (issue #196). `flushReasoningFallback()` in `src/transports/extractors.ts` only emitted buffered `reasoning_content` as a `LanguageModelThinkingPart` when BOTH the thinking-part constructor and a construction-time `progress` sink existed. When the sink was absent (Agents window contexts) but the constructor was available, the reasoning hit the legacy fallback and was **silently dropped** — not in the thinking panel, not visible, no log.

## Changes

- New branch in `flushReasoningFallback()`: emit via `reportProgressPart` with the thinking constructor even without a construction-time sink.
- Legacy drop path now logs `[warn] N chars of reasoning dropped` so silent loss is diagnosable.
- 3 shape-based regression tests in `src/test/extractors.test.ts` (issue #196 suite).
- Docs: issue doc 85, CHANGELOG `[Unreleased]`, devlog.

## Verification

- `npm run compile` clean
- `npm run lint` 7/7 pass
- 432/432 unit tests pass

Full analysis: `docs/issues/85-20260826-discussion118-deepseek-reasoning-leak-regression-analysis.md`

Fixes #196