### PR TITLE
fix(transport): cache 400 error body to prevent double-read crash (#199)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 All notable changes to the **OpenCode Go BYOK Provider** extension are documented here.
 
-## [Unreleased]
+## [0.7.3] — 2026-08-28
 
 ### Fixed
+
+- **`[Transport]` HTTP 400 non-recoverable no longer crashes with undici "Body is unusable: Body has already been read" (#199).** The 400-patch loop refactor (0.7.2, review #191) read the error body without caching it; when `analyzeHttp400ForRetry` found nothing recoverable, the `!response.ok` handler re-read the same `Response` and the resulting TypeError swallowed the real 400 detail. Seen on `gpt-5.6-luna` (`/v1/responses`), affects every model/transport that hits a non-recoverable 400. One-line fix caches the read (`consumedErrorBody ??= errorDetail`); regression test in `src/test/engine.test.ts`. Documented in `docs/issues/87-20260828-issue199-400-body-double-read.md`.
 
 - **`[Streaming]` "Try again" error and empty replies on Muse Spark / gpt-5.6-luna — Responses API `finishReason` gap fixed (#197, #198).** `updateRequestUsageSummary` only read `finishReason` from `data.delta.stop_reason` (Anthropic) and `data.choices[0].finish_reason` (chat-completions). Raw Responses API terminal events (`{type:"response.completed",response:{stop_reason:"completed"}}`) have neither field, so `finishReason` was always `undefined` for every Responses stream without `[DONE]`. `isStreamTruncated` sees `undefined` → flags truncated → retries 3× → throws. GPT models survived because the gateway forwards `data:[DONE]`; Muse Spark (upstream Meta) and gpt-5.6-luna do not. Fix (P1): `updateRequestUsageSummary` now treats `response.completed` as a healthy terminal signal and sets `finishReason` from `response.stop_reason ?? "stop"`. Fix (P2): `normalizeResponsesStreamEvent` now handles `response.output_text.done` and `response.output_item.done` (message type) — the events where Muse Spark delivers its actual text instead of streaming deltas — mapping them to `delta.responseDoneText`; `OpenAiResponseExtractor` emits the done-text only when `emittedTextLength === 0`, preventing duplicate output on models (GPT-4o, etc.) that send both streaming deltas and the done snapshot. P1b: `?? "stop"` fallback added to the routing normalizer for defense in depth. 9 new/updated tests. Documented in `docs/issues/86-20260828-issue197-198-responses-api-finish-reason-text-extraction.md`.
 

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -1,6 +1,18 @@
 # 🧠 OPENCODE COPILOT CHAT DEVLOG
 
-**Branch:** `main` | **Updated:** 2026-08-28 Asia/Jakarta | **Current Phase:** Issue #197/#198 Responses API finishReason + text extraction fix — branch `fix/responses-api-finish-reason-text-extraction` pending PR. Open: PR #161 (restore API key command).
+**Branch:** `main` | **Updated:** 2026-08-28 Asia/Jakarta | **Current Phase:** Issue #199 HTTP 400 body double-read fix shipped in v0.7.3. Open: PR #161 (restore API key command).
+
+---
+
+## ✅ Issue #199 — HTTP 400 non-recoverable → undici "Body has already been read" — 2026-08-28
+
+**Root cause:** Refactor `2cd7342` (0.7.2, review #191) changed the 400-patch loop in `engine.ts` to `consumedErrorBody ?? (await response.text())` and dropped the assignment caching the read body. When `analyzeHttp400ForRetry` found nothing recoverable, the loop broke with `consumedErrorBody` still `undefined`, and the `!response.ok` handler re-read the same `Response` → undici `TypeError: Body is unusable: Body has already been read`, which **swallowed the real 400 detail**. Reported on `gpt-5.6-luna` (`/v1/responses`), but affects every model/transport hitting a non-recoverable 400. Stack-trace line mapping verified against compiled `out/transports/engine.js:279`.
+
+**Code fixes:** One line in `transports/engine.ts` (`consumedErrorBody ??= errorDetail` + contract comment). Also restores the recoverable-400 auto-patch retry path that the same bug broke.
+
+**Tests:** 3 regression tests in `src/test/engine.test.ts` (non-recoverable 400 surfaces original detail; patched 400→200 SSE succeeds; patched retry→400 surfaces the LATEST body, no stale/double read). Red-green proven (fails pre-fix with the exact user-reported error). Full suite **444/444**, `npm run lint` 7/7 ✅. Shipped in **v0.7.3**.
+
+**Docs:** `docs/issues/87-20260828-issue199-400-body-double-read.md`, CHANGELOG `[0.7.3]`.
 
 ---
 

--- a/docs/issues/87-20260828-issue199-400-body-double-read.md
+++ b/docs/issues/87-20260828-issue199-400-body-double-read.md
@@ -1,5 +1,5 @@
 **Status:** ✅ Solved
-**Fix PR:** #203
+**Fix PR:** #202
 **Related:** #199, #191, #103, #109
 **Landed:** v0.7.3
 

--- a/docs/issues/87-20260828-issue199-400-body-double-read.md
+++ b/docs/issues/87-20260828-issue199-400-body-double-read.md
@@ -1,0 +1,117 @@
+**Status:** ✅ Solved
+**Fix PR:** #203
+**Related:** #199, #191, #103, #109
+**Landed:** v0.7.3
+
+# HTTP 400 non-recoverable → "Body is unusable: Body has already been read" (double body read)
+
+**Topic:** transport / engine / error-handling
+**Updated:** 2026-08-28
+**Tags:** #transport #engine #http400 #regression #gpt-luna
+
+---
+
+## Problem
+
+Issue [#199](https://github.com/ltmoerdani/opencode-copilot-chat/issues/199):
+`gpt-5.6-luna` on VS Code 1.135.0 + extension v0.7.2 fails with:
+
+```text
+Sorry, your request failed. Please try again.
+Body is unusable: Body has already been read
+TypeError at Response.text (node:internal/deps/undici)
+  at streamOpenCodeResponse (out/transports/engine.js:279)
+  at async streamResponsesApi (out/transports/responses.js)
+```
+
+The undici TypeError **swallows the real HTTP 400 error detail**, so the user
+sees a cryptic crash instead of the actionable gateway message (e.g.
+`[invalid_prompt] …`).
+
+---
+
+## Root Cause
+
+A Fetch `Response` body can be consumed **exactly once** (WHATWG Fetch spec /
+undici): the second `text()` call throws `TypeError: Body is unusable: Body has
+already been read`.
+
+Regression introduced by commit `2cd7342` ("loop the 400 analyze→patch→retry
+up to 3 attempts", review #191, shipped in **0.7.2**). The refactor of the
+HTTP-400 patch loop in `src/transports/engine.ts` dropped the assignment that
+cached the freshly-read body:
+
+```ts
+// BEFORE (safe):
+const errorDetail = await response.text();
+consumedErrorBody = errorDetail; // ← always cached
+
+// AFTER 2cd7342 (bug):
+const errorDetail = consumedErrorBody ?? (await response.text());
+// ← when consumedErrorBody was undefined, the body is read but NEVER cached
+```
+
+Failing path — **first loop iteration, non-recoverable 400**:
+
+1. Gateway returns HTTP 400 whose body doesn't match any patch pattern in
+   `analyzeHttp400ForRetry` (`src/retry.ts` returns `undefined`).
+2. Loop reads the body directly (`consumedErrorBody` is still `undefined`),
+   finds no patch, `break`s — `consumedErrorBody` stays `undefined`.
+3. The `!response.ok` handler executes
+   `consumedErrorBody ?? (await response.text())` → **second read of the same
+   Response** → undici TypeError.
+
+Only the first iteration is affected: later iterations always receive a body
+from the post-patch refetch, which line 268-style assignment caches correctly.
+All other `response.text()` call sites (5xx loop, non-stream body) assign or
+read a fresh response — audited, no other double-read path exists.
+
+**Why gpt-5.6-luna:** it routes to `/v1/responses` (`src/routing.ts`) and has a
+long history of non-recoverable 400s there — #103 (context-overflow
+`invalid_prompt`), #109 (image `invalid_prompt`). Any model on any transport
+hitting a non-recoverable 400 crashes the same way; Luna just hits the path
+most often.
+
+Stack-trace line mapping verified against compiled `out/transports/engine.js`:
+line 279 is exactly the `!response.ok` `await response.text()` re-read.
+
+---
+
+## Fix
+
+`src/transports/engine.ts` — cache the body after the direct read in the
+400-patch loop (one line + contract comment):
+
+```ts
+const errorDetail = consumedErrorBody ?? (await response.text());
+consumedErrorBody ??= errorDetail; // never re-read a consumed body (#199)
+```
+
+Side benefit: users who hit this bug now receive the **original 400 error
+detail** (actionable) instead of the TypeError.
+
+---
+
+## Verification
+
+- New regression test `src/test/engine.test.ts` (uses the `vscode` module stub
+  from `goUsageTestUtils`, stubs `globalThis.fetch` with a real 400 `Response`,
+  asserts the surfaced error contains the 400 detail and never
+  "Body is unusable").
+- Red-green proof: test **fails** on pre-fix code with exactly
+  `Body is unusable: Body has already been read`, **passes** with the fix.
+- `npm run lint` (all 7 gates incl. TypeScript + unit tests): **Passed**.
+
+---
+
+## Lessons
+
+- When refactoring a read-once resource (Fetch body) into a loop, every read
+  must land in the cache variable — the `x ?? read()` pattern silently drops
+  the read result when the cache is empty and nothing later re-checks it.
+- A crash inside error handling doesn't just crash — it **replaces the real
+  error message**, degrading diagnosability for users and maintainers alike.
+
+**Related docs:** `docs/features/07-20260615-model-validation-retry.md` (400
+retry contract), `docs/issues/51-20260807-pr107-transient-5xx-retry-merge.md`
+(`consumedErrorBody` reset semantics), `docs/issues/47-20260804-gpt56-luna-responses-api-invalid-prompt.md` (#103).

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "opencode-copilot-chat",
   "displayName": "OpenCode for Copilot Chat — BYOK 30+ AI Models",
   "description": "Use 30+ frontier AI models (DeepSeek V4, Kimi K2.6, GLM-5.1, Qwen3.7, MiMo V2.5, MiniMax M2.7, free Claude Opus, GPT-5.5, Gemini 3.5, Grok) in GitHub Copilot Chat. Bring Your Own Key — no Copilot Pro needed.",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "publisher": "ltmoerdani",
   "license": "MIT",
   "icon": "media/opencodego.png",

--- a/src/test/engine.test.ts
+++ b/src/test/engine.test.ts
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { installVscodeMock } from "./helpers/goUsageTestUtils.js";
+
+// engine → streamParts/chatParts/contextWindowHookBridge import "vscode" at
+// runtime; install the stub before the dynamic import below resolves them.
+installVscodeMock();
+
+interface EngineModule {
+  streamOpenCodeResponse: (options: Record<string, unknown>) => Promise<void>;
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    statusText: status === 400 ? "Bad Request" : "OK",
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function sseResponse(): Response {
+  const body = 'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n';
+  return new Response(body, {
+    status: 200,
+    statusText: "OK",
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+/**
+ * CONTRACT — regression tests for issue #199 (HTTP 400 body double-read).
+ *
+ * RULES:
+ *   A Fetch `Response` body can be consumed exactly once. The engine's
+ *   400-patch loop reads the body; whatever path it exits on (nothing
+ *   recoverable, patch ladder exhausted, or patched retry recovering), the
+ *   `!response.ok` handler must reuse the cached body instead of re-reading
+ *   the same `Response` — a second `text()` throws undici's "Body is
+ *   unusable: Body has already been read", swallowing the real error detail
+ *   (reported on gpt-5.6-luna via /v1/responses, v0.7.2).
+ */
+describe("streamOpenCodeResponse HTTP 400 error-body handling", () => {
+  async function loadEngine(): Promise<EngineModule> {
+    return (await import("../transports/engine.js")) as unknown as EngineModule;
+  }
+
+  function baseOptions(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+      url: "https://example.invalid/v1/chat/completions",
+      providerDisplayName: "OpenCode Go",
+      apiKey: "test-key",
+      modelId: "gpt-5.6-luna",
+      body: { model: "gpt-5.6-luna", messages: [{ role: "user", content: "hi" }], stream_options: {} },
+      requestHeaders: {},
+      progress: { report: () => {} },
+      token: {
+        isCancellationRequested: false,
+        onCancellationRequested: () => ({ dispose: () => {} }),
+      },
+      debugReasoning: false,
+      requestTimeoutMs: 5_000,
+      streamIdleTimeoutMs: 5_000,
+      extractStreamParts: () => [],
+      extractFullParts: () => [],
+      usesDoneSentinel: true,
+      ...overrides,
+    };
+  }
+
+  it("surfaces the original 400 body instead of a double-read TypeError", async () => {
+    const { streamOpenCodeResponse } = await loadEngine();
+    const detail = { error: { message: "[invalid_prompt] unrecognized variant" } };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = () => Promise.resolve(jsonResponse(400, detail));
+
+    try {
+      await streamOpenCodeResponse(baseOptions());
+      assert.fail("expected streamOpenCodeResponse to throw");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      assert.ok(!message.includes("Body is unusable"), `should not double-read the body, got: ${message}`);
+      assert.ok(message.includes("[invalid_prompt]"), `should surface the original 400 detail, got: ${message}`);
+      assert.ok(message.includes("400"), `should mention the HTTP status, got: ${message}`);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("completes a patched 400 retry that recovers to a 200 SSE stream", async () => {
+    const { streamOpenCodeResponse } = await loadEngine();
+    const calls: number[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = () => {
+      calls.push(1);
+      // First call: recoverable 400 ([1210] invalid input + stream_options in
+      // the body). Second call: healthy SSE stream ending with [DONE].
+      return Promise.resolve(
+        calls.length === 1 ? jsonResponse(400, { error: { message: "[1210] invalid input: stream_options" } }) : sseResponse(),
+      );
+    };
+
+    try {
+      await streamOpenCodeResponse(baseOptions());
+      assert.equal(calls.length, 2, "should fetch once for the 400 and once for the patched retry");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("surfaces the LATEST 400 body after a patched retry fails again (no stale/double read)", async () => {
+    const { streamOpenCodeResponse } = await loadEngine();
+    const calls: number[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = () => {
+      calls.push(1);
+      return Promise.resolve(
+        calls.length === 1
+          ? jsonResponse(400, { error: { message: "[1210] invalid input: stream_options" } })
+          : jsonResponse(400, { error: { message: "[invalid_prompt] second failure" } }),
+      );
+    };
+
+    try {
+      await streamOpenCodeResponse(baseOptions());
+      assert.fail("expected streamOpenCodeResponse to throw");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      assert.ok(!message.includes("Body is unusable"), `should not double-read the body, got: ${message}`);
+      assert.ok(message.includes("[invalid_prompt] second failure"), `should surface the latest 400 detail, got: ${message}`);
+      assert.ok(!message.includes("[1210]"), `should not surface the stale first 400 detail, got: ${message}`);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/src/transports/engine.ts
+++ b/src/transports/engine.ts
@@ -252,6 +252,12 @@ export async function streamOpenCodeResponse(options: StreamOpenCodeResponseOpti
     let consumedErrorBody: string | undefined;
     for (let patchAttempt = 0; patchAttempt < MAX_400_PATCH_ATTEMPTS && response.status === 400; patchAttempt++) {
       const errorDetail = consumedErrorBody ?? (await response.text());
+      // Cache the body we just read: if `analyzeHttp400ForRetry` finds nothing
+      // recoverable we break out with `response.status === 400`, and the
+      // `!response.ok` handler below must not re-read the same Response — a
+      // Fetch body can be consumed exactly once, so a second `text()` throws
+      // undici's "Body is unusable: Body has already been read" (#199).
+      consumedErrorBody ??= errorDetail;
       options.output?.appendLine(`[http-error-body] ${errorDetail.trim() ? truncateForLog(errorDetail) : "<empty>"}`);
       const parsedBody = JSON.parse(rawPayload) as Record<string, unknown>;
       const patch = analyzeHttp400ForRetry(errorDetail, parsedBody);


### PR DESCRIPTION
## Summary

Fixes #199 — undici `TypeError: Body is unusable: Body has already been read` thrown from `streamOpenCodeResponse` (reported on `gpt-5.6-luna` via `/v1/responses`, v0.7.2).

## Root cause

Regression from `2cd7342` (400-patch loop refactor, review #191, shipped in 0.7.2): the loop reads the error body via `consumedErrorBody ?? (await response.text())` but **never caches the freshly-read body**. When `analyzeHttp400ForRetry` finds nothing recoverable, the loop breaks with the cache still `undefined`, and the `!response.ok` handler re-reads the same `Response` — a Fetch body can be consumed exactly once, so the second read throws. The TypeError also **swallows the real HTTP 400 detail**, degrading diagnosability.

Affects every model/transport that hits a non-recoverable 400, not just Luna.

## Fix

One line in `src/transports/engine.ts`:

```ts
consumedErrorBody ??= errorDetail;
```

Also restores the recoverable-400 auto-patch retry path broken by the same bug.

## Verification

- 3 regression tests in `src/test/engine.test.ts`: non-recoverable 400 surfaces the original detail; patched 400 → 200 SSE succeeds; patched retry → 400 surfaces the **latest** body (no stale/double read).
- Red-green proven: test fails on pre-fix code with the exact user-reported error.
- Full suite **444/444 pass**, `npm run lint` 7/7 ✅.

## Docs

- `docs/issues/87-20260828-issue199-400-body-double-read.md` (full analysis)
- CHANGELOG `[0.7.3]`, devlog updated. Version bumped to **0.7.3**.