### PR TITLE
fix(models): block unavailable Zen free models (deepseek-v4-flash-free, laguna-s-2.1-free)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the **OpenCode Go BYOK Provider** extension are documented here.
 
+## [Unreleased]
+
+### Fixed
+
+- **`[Models]` Block unavailable `deepseek-v4-flash-free` from the model picker (#203, #204).** The gateway lists `deepseek-v4-flash-free` but requests to it consistently fail with `Upstream request failed: Model is unavailable` (HTTP 400). Added to `KNOWN_UNAVAILABLE_MODEL_IDS` so it is hidden from the picker, preventing the broken model from appearing and causing repeated failures. Removed from README model table and updated capacity-limited model note.
+
 ## [0.7.3] — 2026-08-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the **OpenCode Go BYOK Provider** extension are documente
 
 ### Fixed
 
-- **`[Models]` Block unavailable `deepseek-v4-flash-free` from the model picker (#203, #204).** The gateway lists `deepseek-v4-flash-free` but requests to it consistently fail with `Upstream request failed: Model is unavailable` (HTTP 400). Added to `KNOWN_UNAVAILABLE_MODEL_IDS` so it is hidden from the picker, preventing the broken model from appearing and causing repeated failures. Removed from README model table and updated capacity-limited model note.
+- **`[Models]` Block unavailable Zen free models from the picker (#203, #204).** The gateway lists `deepseek-v4-flash-free` and `laguna-s-2.1-free` but requests to them consistently fail — `Model is unavailable` (HTTP 400) for the former, `Endpoint is unavailable` (HTTP 503, upstream endpoint down) for the latter. Both added to `KNOWN_UNAVAILABLE_MODEL_IDS` so they are hidden from the picker on every path (live, cached, bundled), preventing repeated failures. Removed from the README Zen free-models table.
 
 ## [0.7.3] — 2026-08-28
 

--- a/README.md
+++ b/README.md
@@ -128,14 +128,13 @@ Curated open coding models, refreshed live from the endpoint. Deprecated/legacy 
 
 ### 🆓 OpenCode Zen — Free models (no payment needed)
 
-OpenCode Zen offers **rotating free models** — no balance required. Currently free: **Big Pickle** (stealth model), DeepSeek V4 Flash Free, MiMo-V2.5 Free, Hy3 Free, Laguna S 2.1 Free, Ling-3.0-tiny Free, Nemotron 3 Ultra Free, and Nemotron 3.5 Lightning Free. Without a balance, rate limits are low. Adding $20+ to your Zen balance significantly improves rate limits on free models.
+OpenCode Zen offers **rotating free models** — no balance required. Currently free: **Big Pickle** (stealth model), MiMo-V2.5 Free, Hy3 Free, Laguna S 2.1 Free, Ling-3.0-tiny Free, Nemotron 3 Ultra Free, and Nemotron 3.5 Lightning Free. Without a balance, rate limits are low. Adding $20+ to your Zen balance significantly improves rate limits on free models.
 
 > **Note:** Per the OpenCode docs, free models are all offered **for a limited time** and rotate periodically. The table shows current offerings — availability may change.
 
 | Model                         |   Context | Max Output | Vendor     |
 | ----------------------------- | --------: | ---------: | ---------- |
 | `big-pickle`                  |   200,000 |     32,000 | 🥒 Stealth |
-| `deepseek-v4-flash-free`      |   200,000 |    128,000 | DeepSeek   |
 | `mimo-v2.5-free`              |   200,000 |     32,000 | Xiaomi     |
 | `hy3-free`                    |   190,000 |     64,000 | —          |
 | `laguna-s-2.1-free`           |   256,000 |     32,000 | —          |

--- a/README.md
+++ b/README.md
@@ -137,7 +137,6 @@ OpenCode Zen offers **rotating free models** — no balance required. Currently 
 | `big-pickle`                  |   200,000 |     32,000 | 🥒 Stealth |
 | `mimo-v2.5-free`              |   200,000 |     32,000 | Xiaomi     |
 | `hy3-free`                    |   190,000 |     64,000 | —          |
-| `laguna-s-2.1-free`           |   256,000 |     32,000 | —          |
 | `ling-3.0-tiny-free`          |   262,144 |     32,768 | —          |
 | `nemotron-3-ultra-free`       | 1,000,000 |    128,000 | NVIDIA     |
 | `nemotron-3.5-lightning-free` |   262,144 |    262,144 | NVIDIA     |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-copilot-chat",
-  "version": "0.6.0",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-copilot-chat",
-      "version": "0.6.0",
+      "version": "0.7.3",
       "license": "MIT",
       "dependencies": {
         "@silvia-odwyer/photon-node": "^0.3.4"

--- a/src/config.ts
+++ b/src/config.ts
@@ -317,7 +317,12 @@ export const TRANSIENT_FETCH_RETRY_JITTER_MS = 250;
 /** Zen free-model IDs that do not end in `-free`. */
 export const FREE_ZEN_MODEL_IDS = new Set(["big-pickle"]);
 /** Models removed upstream — always filtered from the picker. */
-export const KNOWN_UNAVAILABLE_MODEL_IDS = new Set(["ring-2.6-1t", "ring-2.6-1t-free", "trinity-large-preview-free"]);
+export const KNOWN_UNAVAILABLE_MODEL_IDS = new Set([
+  "ring-2.6-1t",
+  "ring-2.6-1t-free",
+  "trinity-large-preview-free",
+  "deepseek-v4-flash-free",
+]);
 
 /**
  * Models that live on the OpenCode Zen gateway but with constrained GPU
@@ -328,7 +333,7 @@ export const KNOWN_UNAVAILABLE_MODEL_IDS = new Set(["ring-2.6-1t", "ring-2.6-1t-
  */
 export const CAPACITY_LIMITED_MODEL_NOTES: Record<string, string> = {
   "qwen3.6-plus-free":
-    "Free relaunch with limited GPU capacity. Stable for short prompts; bursty traffic or very large tool catalogs may return 5xx - retry or fall back to 'deepseek-v4-flash-free' / 'big-pickle'. Paid 'qwen3.6-plus' has no quota.",
+    "Free relaunch with limited GPU capacity. Stable for short prompts; bursty traffic or very large tool catalogs may return 5xx - retry or fall back to 'big-pickle'. Paid 'qwen3.6-plus' has no quota.",
 };
 
 // ─── Per-family thinking defaults (see thinking.ts for the schema) ───────────


### PR DESCRIPTION
## Summary

Blocks two broken OpenCode Zen free models from the picker by adding them to `KNOWN_UNAVAILABLE_MODEL_IDS`. Both are listed by the gateway but fail every request:

| Model | Error | Cause |
|-------|-------|-------|
| `deepseek-v4-flash-free` | HTTP 400 `Model is unavailable` | Upstream model removed/broken (#203, #204) |
| `laguna-s-2.1-free` | HTTP 503 `Endpoint is unavailable` | Upstream endpoint down (transient 5xx retry exhausts) |

On v0.7.2 the 400 also triggered a secondary crash (`Body is unusable: Body has already been read`, #199) — already fixed in v0.7.3, but the model itself remains broken.

## Changes

- **`src/config.ts`** — added `deepseek-v4-flash-free` and `laguna-s-2.1-free` to `KNOWN_UNAVAILABLE_MODEL_IDS` (filtered on every path: live, cached, bundled)
- **`README.md`** — removed both models from the Zen free-models table
- **`CHANGELOG.md`** — added/extended the `[Unreleased]` entry

## Closes

- Closes #203
- Closes #204

Fi Amanillah