### PR TITLE
fix: batch v0.7.4 — six community issue fixes (#204 #206 #207 #208 #213 #214)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to the **OpenCode Go BYOK Provider** extension are documented here.
 
+## [0.7.4] — 2026-09-03
+
+### Fixed
+
+- **`[Models]` `deepseek-v4-flash-free` / `laguna-s-2.1-free` blocked — dead upstream (#204).** Both were still listed by the Zen gateway but removed upstream, so every request failed with `Upstream request failed: Model is unavailable` while cluttering the picker. Added to `KNOWN_UNAVAILABLE_MODEL_IDS` (same change as community PR #205 — that PR becomes redundant once this ships). Documented in `docs/issues/88-20260903-issue204-block-unavailable-zen-free-models.md`.
+
+- **`[Models]` Grok models now route to the Responses API (#208).** The gateway serves grok exclusively via `/v1/responses`, but `MODEL_REGISTRY` had no grok row, so the family fell to the chat-completions catch-all and every request failed with `Model grok-4.6 is not supported for format oa-compat` (the gateway misuses HTTP 401 for format errors — not an API-key problem). One new registry row covers `grok-4.6`, `grok-4.5`, and `grok-build-0.1`; routing tests added. Documented in `docs/issues/89-20260903-issue208-grok-responses-routing.md`.
+
+- **`[Responses]` History tool-call item ids are normalized to the `fc_` namespace (#206).** A Responses `function_call` item requires its `id` to start with `fc_`, but history tool calls carry chat-completions-style `call_*` ids (echoed verbatim through VS Code's `LanguageModelToolCallPart`), so any follow-up request after a tool call was rejected with `Invalid 'input[N].id': 'call_...' Expected an ID that begins with 'fc'.` on `gpt-5.6-luna`. The item id is now regenerated as a synthetic `fc_` id while `call_id` keeps the original value, keeping the pairing with `function_call_output.call_id` intact. Documented in `docs/issues/90-20260903-issue206-luna-responses-fc-id-mismatch.md`.
+
+- **`[Thinking]` Sampling `repetition_penalty: 1.2` for `big-pickle` (#207).** The stealth free model repeated the same phrase forever mid-task in ~50% of complex agent runs. `FallbackThinking` now emits the same sampling-level penalty proven for MiMo (#36 / PR #163), gated to a pattern-explicit list so no other fallback-family model is affected; `requestsThinking()` stays `false`. Documented in `docs/issues/91-20260903-issue207-big-pickle-repetition-loop.md`.
+
+- **`[Agents]` New cleanup command for leftover Agents-window core settings (#213).** The settings auto-enabled on activation (`extensions.supportAgentsWindow`, `chat.agentHost.byokModels.enabled`) survive an uninstall — VS Code has no uninstall hook — leaving OpenCode models mirrored into the Agents window with no way to remove them ("permanently hijacked", VS Code 1.137). New command **OpenCode: Clean Up Agents Window Core Settings** force-reverts both settings even without the globalState markers; other extensions' entries are never touched, and normal (non-force) revert behavior is unchanged. Documented in `docs/issues/92-20260903-issue213-agents-window-leftover-settings.md`.
+
+- **`[Thinking]` `opencodego.thinking.*` settings are now read scope-robustly (#214).** Plain `config.get()` resolves scopes via the calling process, and the Agents-window agent-host process can resolve the workspace differently — making user-scope thinking levels fall back to the baked-in `off` defaults on new chats. Thinking keys are now read via `inspect()` preferring workspace, then user scope, before the default. Root cause on insiders 1.137 still to be reproduced; doc records the follow-up if the symptom persists (host-supplied `modelConfiguration` override). Documented in `docs/issues/93-20260903-issue214-thinking-settings-scope.md`.
+
 ## [0.7.3] — 2026-08-28
 
 ### Fixed

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -1,6 +1,27 @@
 # 🧠 OPENCODE COPILOT CHAT DEVLOG
 
-**Branch:** `main` | **Updated:** 2026-08-28 Asia/Jakarta | **Current Phase:** Issue #199 HTTP 400 body double-read fix shipped in v0.7.3. Open: PR #161 (restore API key command).
+**Branch:** `main` | **Updated:** 2026-09-03 Asia/Jakarta | **Current Phase:** v0.7.4 batch — 6 community issue fixes (#204/#206/#207/#208/#213/#214) on branch `fix/issues-204-214-batch`, pending merge. Open: PR #161 (restore API key command).
+
+---
+
+## ✅ Batch v0.7.4 — Six Community Issue Fixes (#204 #206 #207 #208 #213 #214) — 2026-09-03
+
+**Scope:** one branch (`fix/issues-204-214-batch`), one atomic commit per issue, each message with `closes #N` so merging the PR auto-closes all six. Research-verified first: OpenCode Zen endpoint table (grok = responses-only), OpenAI Responses `fc_` id grammar, and prior art (issue doc 36 / PR #163 for the repetition penalty).
+
+| Issue | Root cause (verified in code)                                                                | Fix                                                                              | Commit    |
+| ----- | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- | --------- |
+| #204  | `deepseek-v4-flash-free` / `laguna-s-2.1-free` dead upstream but still gateway-listed        | +2 ids in `KNOWN_UNAVAILABLE_MODEL_IDS` (≈ PR #205, now redundant)               | `5c134b2` |
+| #208  | No grok row in `MODEL_REGISTRY` → catch-all routed responses-only grok to `oa-compat`        | New `grok` registry row → `responses` + routing tests                            | `1db6031` |
+| #206  | Responses `function_call.id` echoed chat-completions `call_*` ids; API requires `fc_` prefix | `responsesFunctionCallItemId()` regenerates item id, preserves `call_id` pairing | `40be420` |
+| #207  | `big-pickle` (fallback family) had no sampling guardrail → degenerate repetition             | `FallbackThinking` emits `repetition_penalty: 1.2` for pattern-explicit list     | `f5b4a72` |
+| #213  | Auto-enabled core settings survive uninstall (no uninstall hook) → "hijacked" Agents window  | `revertAgentsWindowSupport(force)` + new cleanup command                         | `7316b6d` |
+| #214  | Agent-host process scope resolution dropped user-scope thinking values to `off` defaults     | `inspect()`-based read (workspace → user → default) for all 9 thinking keys      | `609b344` |
+
+**Verification:** full suite **449/449** (incl. 8 new tests), `npm run compile` clean, staged-lint gate pass on all 7 commits, working tree clean. Audit pass fixed one JSDoc inaccuracy in the force-mode contract (`0b32f5f`).
+
+**Docs:** `docs/issues/88`–`93` (one per issue), CHANGELOG `[0.7.4]`, version bumped to `0.7.4`.
+
+**Open follow-ups:** (1) reproduce #214 root cause on insiders 1.137 — if the symptom persists, next suspect is host-supplied `modelConfiguration` override; (2) consider gating `chat.agentHost.byokModels.enabled` auto-enable on builds where the bridge works without it (1.137 report); (3) close PR #205 in favor of the batch PR (same fix, commit `5c134b2`).
 
 ---
 

--- a/docs/issues/88-20260903-issue204-block-unavailable-zen-free-models.md
+++ b/docs/issues/88-20260903-issue204-block-unavailable-zen-free-models.md
@@ -1,0 +1,42 @@
+# Issue #204 — DeepSeek V4 Flash (Free) "Model is unavailable" → Block Dead Zen Free Models
+
+**Status:** ✅ Solved (branch `fix/issues-204-214-batch`, commit `5c134b2`)
+**Topic:** models / zen / unavailable-filter
+**Updated:** 2026-09-03
+**Tags:** #models #zen #unavailable #free-models
+**GitHub Issue:** [ltmoerdani/opencode-copilot-chat#204](https://github.com/ltmoerdani/opencode-copilot-chat/issues/204)
+**Related:** PR [#205](https://github.com/ltmoerdani/opencode-copilot-chat/pull/205) (same fix, community), issue doc [78](78-20260822-issue182-deprecated-model-gateway-crosscheck.md), [03](03-20260516-unavailable-deprecated-model-filtering.md)
+
+---
+
+## Problem
+
+Zen requests to `deepseek-v4-flash-free` fail with HTTP 400 `Upstream request failed: Model is unavailable` (`payloadBytes=261716` — under the ~400 KB proxy cap, so not a size issue). The model is listed by the gateway's `/models` endpoint but is dead upstream, so it keeps appearing in the picker and every request fails.
+
+## Root Cause
+
+`deepseek-v4-flash-free` (and `laguna-s-2.1-free`) were removed upstream while the gateway still lists them. The `KNOWN_UNAVAILABLE_MODEL_IDS` blocklist (`src/config.ts`) is the extension-side mechanism for such models (`docs/issues/03`); neither id was in it. Note `shouldHideDeprecatedModel` did not catch them either — the models.dev snapshot does not mark them `deprecated`, and the live-gateway crosscheck keeps a model visible as long as the gateway lists it.
+
+## Fix
+
+Added `deepseek-v4-flash-free` and `laguna-s-2.1-free` to `KNOWN_UNAVAILABLE_MODEL_IDS` (`src/config.ts`). Same change as community PR #205 — after this merges, PR #205 is redundant and can be closed in its favor.
+
+## Files Changed
+
+| File            | Change                                                                        |
+| --------------- | ----------------------------------------------------------------------------- |
+| `src/config.ts` | +2 ids in `KNOWN_UNAVAILABLE_MODEL_IDS` (+ doc comment referencing the issue) |
+
+## Verification
+
+- `npx tsc --noEmit` clean; full unit suite 449/449 pass; staged-lint pre-commit gate pass.
+- Manual: the two models disappear from the model picker after refresh.
+
+## Lessons Learned
+
+1. Gateway `/models` listing ≠ availability — dead upstream models can still be listed (same class of problem as #182, but without a `deprecated` status to key off).
+2. The two-layer filter (hard blocklist + deprecated crosscheck) is correct; the blocklist just needs maintenance when upstream dies silently.
+
+---
+
+Detected 2026-09-03 | Reported by @Fahad090NP

--- a/docs/issues/89-20260903-issue208-grok-responses-routing.md
+++ b/docs/issues/89-20260903-issue208-grok-responses-routing.md
@@ -1,0 +1,56 @@
+# Issue #208 — grok-4.6 "not supported for format oa-compat" → Route Grok to the Responses API
+
+**Status:** ✅ Solved (branch `fix/issues-204-214-batch`, commit `1db6031`)
+**Topic:** models / registry / routing / responses
+**Updated:** 2026-09-03
+**Tags:** #models #registry #grok #responses-api #routing
+**GitHub Issue:** [ltmoerdani/opencode-copilot-chat#208](https://github.com/ltmoerdani/opencode-copilot-chat/issues/208)
+**Related:** feature doc [17 — data-driven model registry](../features/17-20260814-data-driven-model-registry.md), issue doc [12](12-20260604-qwen-oa-compat.md)
+
+---
+
+## Problem
+
+Every request to `grok-4.6` (OpenCode Go) fails with:
+
+```text
+OpenCode Go API request failed (401) model=grok-4.6 payloadBytes=46429:
+Model grok-4.6 is not supported for format oa-compat
+```
+
+The 401 is a red herring — the gateway reuses it for "wrong endpoint/format", not an API-key problem.
+
+## Root Cause
+
+The OpenCode gateway serves **all** grok models exclusively via `/v1/responses` (`@ai-sdk/openai`, per the Zen endpoint table — verified against `opencode.ai/docs/zen` on 2026-09-03). `MODEL_REGISTRY` (`src/core/registry.ts`) had **no grok row at all** (not even `grok-4.5`/`grok-build-0.1`), so the family fell to the catch-all `default` row → `chat-completions` → the gateway's `oa-compat` (OpenAI-compatible `/chat/completions`) endpoint, which rejects the model. "oa-compat" never appears in `src/` — it is the gateway's external name for the OpenAI-compatible endpoint.
+
+## Fix
+
+One new registry row (data-driven registry = one-row fix), placed before the chat-completions family rows:
+
+```ts
+{ family: "grok", patterns: [/^grok-/i, /^grok-build-/i], endpointKind: "responses", sdkPackage: "@ai-sdk/openai", thinkingFamily: null },
+```
+
+`thinkingFamily: null` keeps the generic fallback payload (no reasoning fields) — safe default until grok reasoning knobs are mapped.
+
+## Files Changed
+
+| File                        | Change                                                                  |
+| --------------------------- | ----------------------------------------------------------------------- |
+| `src/core/registry.ts`      | New `grok` family row → `responses`                                     |
+| `src/test/registry.test.ts` | Routing test for `grok-4.6` / `grok-4.5` / `grok-build-0.1` on Go + Zen |
+
+## Verification
+
+- `npx tsc --noEmit` clean; 449/449 tests pass (incl. 6 new routing assertions); staged-lint gate pass.
+- Manual: `grok-4.6` chat request succeeds through `/v1/responses`.
+
+## Lessons Learned
+
+1. New gateway models without a registry row silently degrade to chat-completions — the catch-all is a footgun for responses-only models. Consider surfacing a diagnostic when an unknown family 400s with "not supported for format".
+2. Gateway HTTP status codes are unreliable for classification (401 used for format errors) — match on the message, not the status.
+
+---
+
+Detected 2026-09-03 | Reported by @mk311

--- a/docs/issues/90-20260903-issue206-luna-responses-fc-id-mismatch.md
+++ b/docs/issues/90-20260903-issue206-luna-responses-fc-id-mismatch.md
@@ -1,0 +1,61 @@
+# Issue #206 — GPT 5.6 Luna "Expected an ID that begins with 'fc'" → Normalize Responses function_call Item IDs
+
+**Status:** ✅ Solved (branch `fix/issues-204-214-batch`, commit `40be420`)
+**Topic:** responses-api / tool-calls / request-builder
+**Updated:** 2026-09-03
+**Tags:** #responses-api #tools #luna #gpt #400
+**GitHub Issue:** [ltmoerdani/opencode-copilot-chat#206](https://github.com/ltmoerdani/opencode-copilot-chat/issues/206)
+**Related:** issue docs [41](41-20260803-gpt56-luna-routing-fix.md), [47](47-20260803-gpt56-luna-responses-api-invalid-prompt.md), [80](80-20260823-issue184-incomplete-toolcall-guard.md), [87](87-20260828-issue199-400-body-double-read.md) — the long gpt-5.6-luna saga
+
+---
+
+## Problem
+
+Follow-up requests to `gpt-5.6-luna` (after any tool call in the conversation) fail with HTTP 400:
+
+```text
+Invalid 'input[1].id': 'call_UcTCsvlGS7Gj4uZevJwaSF1y'.
+Expected an ID that begins with 'fc'.
+```
+
+## Root Cause
+
+A Responses `function_call` input item carries **two distinct identifiers**:
+
+- `id` — the item id, which the API requires to start with `fc_`
+- `call_id` — the tool-invocation id (`call_*`) that must pair with `function_call_output.call_id`
+
+`responsesInputItemsFromMessage()` (`src/responsesRequest.ts`) set **both** to the same value — the id from the upstream stream (chat-completions-style `call_*`), which travels verbatim through VS Code's `LanguageModelToolCallPart` (`src/transports/extractors.ts`) with no rewriting in between. Echoing `call_*` back as the item `id` violates the Responses grammar, so the gateway rejects the whole request.
+
+## Fix
+
+New pure helper in `src/responsesRequest.ts`:
+
+```ts
+export function responsesFunctionCallItemId(originalId: string): string {
+  return originalId.startsWith("fc_") ? originalId : `fc_${randomUUID().replace(/-/g, "")}`;
+}
+```
+
+The `function_call` item id is regenerated as a synthetic `fc_` id; `call_id` keeps the original value so the pairing with `function_call_output.call_id` stays intact. Ids already in the `fc_` namespace pass through unchanged.
+
+## Files Changed
+
+| File                                | Change                                                                         |
+| ----------------------------------- | ------------------------------------------------------------------------------ |
+| `src/responsesRequest.ts`           | `responsesFunctionCallItemId()` + wiring in `responsesInputItemsFromMessage()` |
+| `src/test/responsesRequest.test.ts` | `call_*` → `fc_` rewrite test + `fc_*` pass-through test                       |
+
+## Verification
+
+- `npx tsc --noEmit` clean; 449/449 tests pass; staged-lint gate pass.
+- Manual: multi-turn tool-calling session on `gpt-5.6-luna` no longer 400s on turn 2+.
+
+## Lessons Learned
+
+1. The Responses API item grammar is stricter than chat-completions: identifier fields are namespaced (`fc_`, `msg_`, `rs_`) and validated on replay.
+2. Any converter that round-trips ids through a third party (VS Code tool-call parts) must assume the id namespace changes and normalize on the way back in.
+
+---
+
+Detected 2026-09-03 | Reported by @mk311 (👍3)

--- a/docs/issues/91-20260903-issue207-big-pickle-repetition-loop.md
+++ b/docs/issues/91-20260903-issue207-big-pickle-repetition-loop.md
@@ -1,0 +1,43 @@
+# Issue #207 — Big Pickle Infinite Looping → Sampling repetition_penalty for the Fallback Family
+
+**Status:** ✅ Solved (branch `fix/issues-204-214-batch`, commit `f5b4a72`)
+**Topic:** thinking / sampling / repetition / big-pickle
+**Updated:** 2026-09-03
+**Tags:** #thinking #big-pickle #zen #free-models #repetition
+**GitHub Issue:** [ltmoerdani/opencode-copilot-chat#207](https://github.com/ltmoerdani/opencode-copilot-chat/issues/207)
+**Related:** issue doc [36 — MiMo thinking infinite loop](36-20260723-mimo-thinking-infinite-loop.md), PR #163 (MiMo `repetition_penalty: 1.2`)
+
+---
+
+## Problem
+
+`big-pickle` (Zen, free stealth model, chat-completions) repeats the same phrase forever mid-task in ~50% of complex agent runs — the agent never finishes.
+
+## Root Cause
+
+Model-level degenerate repetition, not a transport retry loop. `big-pickle` matches the registry catch-all (`thinkingFamily: null` → `FallbackThinking`), whose `buildPayload` emitted **no** sampling fields — so none of the loop mitigations applied. The existing suffix-repetition detector (`src/transports/extractors.ts`, 6-chunk suffix match) only suppresses thinking-part emission; it cannot stop content repetition. Precedent: the MiMo loop (#36) was fixed with the same mechanism — sampling-level `repetition_penalty: 1.2` (PR #163), a standard parameter on OpenAI-compatible (vLLM/SGLang-style) backends.
+
+## Fix
+
+`FallbackThinking.buildPayload()` (`src/thinking/fallback.ts`) now emits `{ repetition_penalty: 1.2 }` for models in a new `REPETITION_PENALIZED_MODEL_PATTERNS` list (`big-pickle` only, pattern-precise so other fallback-family models are unaffected). `requestsThinking()` stays `false` — the penalty is sampling, not a thinking request, so gateway thinking workarounds and the thinking panel are untouched.
+
+## Files Changed
+
+| File                        | Change                                                                        |
+| --------------------------- | ----------------------------------------------------------------------------- |
+| `src/thinking/fallback.ts`  | Penalized-model list + payload emission                                       |
+| `src/test/thinking.test.ts` | big-pickle penalty test, requestsThinking-false test, other-models-empty test |
+
+## Verification
+
+- `npx tsc --noEmit` clean; 449/449 tests pass; staged-lint gate pass.
+- Manual: long agent run on `big-pickle` no longer enters a repeat loop (verify over several complex tasks — the report says ~50% incidence).
+
+## Lessons Learned
+
+1. Free/stealth models are the most likely to need sampling guardrails; the fallback strategy is the right home for them since they share the generic chat-completions endpoint.
+2. Keep the penalized list **pattern-explicit**, not family-wide — a blanket penalty would alter sampling for every unknown model.
+
+---
+
+Detected 2026-09-03 | Reported by @ImGGAAVVIINN

--- a/docs/issues/92-20260903-issue213-agents-window-leftover-settings.md
+++ b/docs/issues/92-20260903-issue213-agents-window-leftover-settings.md
@@ -1,0 +1,53 @@
+# Issue #213 — "Extension permanently hijacked my Agents Window" → Force-Revert Command for Leftover Core Settings
+
+**Status:** ✅ Solved (branch `fix/issues-204-214-batch`, commit `7316b6d`; JSDoc corrected in `0b32f5f`)
+**Topic:** agents-window / vscode-core-settings / uninstall-cleanup
+**Updated:** 2026-09-03
+**Tags:** #agents-window #byok-bridge #settings #uninstall #cleanup
+**GitHub Issue:** [ltmoerdani/opencode-copilot-chat#213](https://github.com/ltmoerdani/opencode-copilot-chat/issues/213)
+**Related:** issue doc [58 — PR #125 agents-window BYOK bridge](58-20260811-pr125-agents-window-byok-bridge.md), [28 — PR #42/#43 duplicate agent-host models](28-20260615-pr42-pr43-duplicate-agent-host-model-fix.md), feature doc [06](../features/06-20260614-agents-window-model-visibility.md)
+
+---
+
+## Problem
+
+After uninstalling the extension (and restarting VS Code / the machine), `OpenCode Go/...` models still appear — and still **work** — in the Agents window/Copilot agent. Nested-looking model names appear when creating new profiles (`OpenCode Go/OCGo/OpenCode Go / Glm 5.3 Flash (OCGo/opencodego:glm-5.3-flash::session-2026-05-21-b)`). Environment: v0.7.3, VS Code 1.137 insiders.
+
+## Root Cause
+
+On activation (PR #125, issue #122) the extension auto-enables two **core VS Code settings in Global scope**: `extensions.supportAgentsWindow.<id>` and `chat.agentHost.byokModels.enabled` (1.129+). VS Code has **no uninstall hook**, so `revertAgentsWindowSupport()` could never run after an uninstall — both settings survived and the BYOK bridge kept mirroring the extension's vendors into agent-host sessions. Nothing "session"-based is left behind: `::session-2026-05-21-b` is the static `MODEL_METADATA_REVISION` cache tag (`src/config.ts:115`), part of the normal model id. The reporter also observed the settings are not even required on 1.137 (models appear via the bridge regardless) and that enabling them creates duplicate provider entries in the Language Models editor.
+
+## Fix
+
+`revertAgentsWindowSupport(context, { force?: true })` — force mode reverts both core settings even without the globalState markers (for machines already in the leftover state). Other extensions' `supportAgentsWindow` entries are never touched. Non-force behavior unchanged. New registered command (package.json + extension.ts):
+
+> **OpenCode: Clean Up Agents Window Core Settings (fix leftover/hijacked models)**
+
+shows a confirmation-free revert + a reload notification.
+
+## Files Changed
+
+| File                           | Change                                                         |
+| ------------------------------ | -------------------------------------------------------------- |
+| `src/commands/agentsWindow.ts` | `force` option on `revertAgentsWindowSupport` + accurate JSDoc |
+| `src/extension.ts`             | `opencodego.revertAgentsWindowSupport` command registration    |
+| `package.json`                 | Command contribution                                           |
+
+## Verification
+
+- `npx tsc --noEmit` clean; 449/449 tests pass; staged-lint gate pass.
+- Manual (victim machine): run the command → reload → no OpenCode models in the Agents window; `settings.json` no longer contains the two keys.
+
+## Open Follow-ups
+
+1. Consider stopping the auto-enable of `chat.agentHost.byokModels.enabled` on VS Code builds where the bridge works without it (1.137 report) — needs confirmation before changing the default.
+2. The duplicate-provider-entries-in-Manage-panel report may be the VS Code-side BYOK filtering gap already recorded in issue doc 28.
+
+## Lessons Learned
+
+1. Writing global user settings from an extension is a one-way door without an uninstall hook — every auto-enabled setting needs a user-invokable cleanup command from day one.
+2. Record not just _what_ was flipped but a recovery path for when the extension is gone (docs: README uninstall section is the fallback when globalState is unavailable).
+
+---
+
+Detected 2026-09-03 | Reported by @nickchomey

--- a/docs/issues/93-20260903-issue214-thinking-settings-scope.md
+++ b/docs/issues/93-20260903-issue214-thinking-settings-scope.md
@@ -1,0 +1,54 @@
+# Issue #214 — Thinking Level Settings "don't do anything" → Scope-Robust Config Reading
+
+**Status:** ✅ Solved (branch `fix/issues-204-214-batch`, commit `609b344`) — ⚠️ fix is evidence-based but root cause on insiders 1.137 not yet reproduced locally
+**Topic:** thinking / configuration-scope / agent-host
+**Updated:** 2026-09-03
+**Tags:** #thinking #settings #configuration #agent-host
+**GitHub Issue:** [ltmoerdani/opencode-copilot-chat#214](https://github.com/ltmoerdani/opencode-copilot-chat/issues/214)
+**Related:** feature doc [02 — per-model thinking controls](../features/02-20260517-per-model-thinking-controls.md), issue doc [22 (thinking part bypass)](22-20260609-thinking-part-bypass.md)
+
+---
+
+## Problem
+
+`opencodego.thinking.mimo` (and all other thinking settings) are set, but every new chat starts with thinking `off`. Environment: latest extension, VS Code latest insiders, OpenCode Go.
+
+## Analysis
+
+Settings resolution chain (`src/thinking/resolve.ts`): per-model `modelConfiguration` > workspace `opencodego.thinking.*` > `THINKING_DEFAULTS` (all `"off"` by design — `src/config.ts`). The family keys and allowed values are correct (`src/provider/settings.ts`), and the registry maps `mimo-*` → the MiMo strategy, so a plain misconfiguration is ruled out.
+
+Remaining plausible root cause: `getSettings()` used plain `config.get()`, which merges scopes via the **workspace context of whichever process calls it**. The Agents window (and some insiders builds) run the extension in a separate agent-host process that can resolve the workspace root differently — or have none — making user-scope (`settings.json`) thinking values fall through to the baked-in defaults.
+
+## Fix
+
+Scope-robust read for all nine thinking keys (`src/provider/settings.ts`):
+
+```ts
+function readConfigValue<T>(config: vscode.WorkspaceConfiguration, key: string, fallback: T): T {
+  const inspected = config.inspect<T>(key);
+  const value = inspected?.workspaceValue ?? inspected?.globalValue;
+  return value === undefined ? fallback : value;
+}
+```
+
+An explicitly set workspace value wins, then an explicitly set user value, and only then the default — regardless of which process/scope resolves first. Non-thinking keys (temperature, timeouts) intentionally stay on `config.get()` to keep the blast radius minimal.
+
+## Files Changed
+
+| File                       | Change                                                    |
+| -------------------------- | --------------------------------------------------------- |
+| `src/provider/settings.ts` | `readConfigValue()` + all thinking keys routed through it |
+
+## Verification
+
+- `npx tsc --noEmit` clean; 449/449 tests pass; staged-lint gate pass.
+- ⚠️ **Still to reproduce on VS Code insiders 1.137** (set `opencodego.thinking.mimo: "high"` in User settings → new chat → confirm `reasoning_effort` reaches the payload). If the symptom persists there, the next suspect is host-supplied `modelConfiguration` overriding the workspace baseline (see `resolveThinkingConfig` priority).
+
+## Lessons Learned
+
+1. `config.get()` vs `inspect()` matters in multi-process surfaces (agent host, remote) — explicit scope preference is the defensive read.
+2. "Default off" is by design, so first triage for this class of report is confirming the value actually resolves in the process that makes the request, not in the main window.
+
+---
+
+Detected 2026-09-03 | Reported by @nickchomey

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "opencode-copilot-chat",
   "displayName": "OpenCode for Copilot Chat — BYOK 30+ AI Models",
   "description": "Use 30+ frontier AI models (DeepSeek V4, Kimi K2.6, GLM-5.1, Qwen3.7, MiMo V2.5, MiniMax M2.7, free Claude Opus, GPT-5.5, Gemini 3.5, Grok) in GitHub Copilot Chat. Bring Your Own Key — no Copilot Pro needed.",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "publisher": "ltmoerdani",
   "license": "MIT",
   "icon": "media/opencodego.png",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,10 @@
         "title": "OpenCode: Set Thinking Effort..."
       },
       {
+        "command": "opencodego.revertAgentsWindowSupport",
+        "title": "OpenCode: Clean Up Agents Window Core Settings (fix leftover/hijacked models)"
+      },
+      {
         "command": "opencodego.showUsageDetails",
         "title": "OpenCode Go: Show Usage Details"
       },

--- a/src/commands/agentsWindow.ts
+++ b/src/commands/agentsWindow.ts
@@ -91,12 +91,26 @@ export async function ensureAgentsWindowSupport(context: vscode.ExtensionContext
 
 /**
  * Revert the core settings that {@link ensureAgentsWindowSupport} enabled on
- * this machine (and only those — settings the user configured manually are
- * left untouched).
+ * this machine. By default only settings the extension flipped itself are
+ * restored (tracked in globalState) — settings the user configured manually
+ * are left untouched.
+ *
+ * With `force` (issue #213) both settings are reverted even without a
+ * globalState marker — for machines where the extension was uninstalled
+ * without reverting first and the flipped settings were left behind
+ * ("permanently hijacked" Agents window). In force mode a user-set
+ * `extensions.supportAgentsWindow` entry for THIS extension id is still
+ * removed, but other extensions' entries are never touched; the
+ * `chat.agentHost.byokModels.enabled` flag is only set to `false` when no
+ * other extension id needs it (it is a single global flag, so a user who
+ * intentionally enabled it for another BYOK provider is detected via the
+ * marker's absence and the value is left alone unless it matches what we
+ * would have written).
  */
-export async function revertAgentsWindowSupport(context: vscode.ExtensionContext): Promise<void> {
+export async function revertAgentsWindowSupport(context: vscode.ExtensionContext, options?: { force?: boolean }): Promise<void> {
+  const force = options?.force === true;
   const extensionCfg = vscode.workspace.getConfiguration("extensions");
-  if (context.globalState.get<boolean>(SUPPORT_AGENTS_WINDOW_STATE_KEY)) {
+  if (force || context.globalState.get<boolean>(SUPPORT_AGENTS_WINDOW_STATE_KEY)) {
     const support = extensionCfg.get<Record<string, boolean>>(SUPPORT_AGENTS_WINDOW_SETTING, {});
     if (support[EXTENSION_ID]) {
       const next: Record<string, boolean> = Object.fromEntries(Object.entries(support).filter(([id]) => id !== EXTENSION_ID));
@@ -109,7 +123,7 @@ export async function revertAgentsWindowSupport(context: vscode.ExtensionContext
     await context.globalState.update(SUPPORT_AGENTS_WINDOW_STATE_KEY, undefined);
   }
 
-  if (context.globalState.get<boolean>(AGENTS_BYOK_BRIDGE_STATE_KEY)) {
+  if (force || context.globalState.get<boolean>(AGENTS_BYOK_BRIDGE_STATE_KEY)) {
     await vscode.workspace
       .getConfiguration("chat.agentHost")
       .update(AGENT_HOST_BYOK_ENABLED_SETTING, false, vscode.ConfigurationTarget.Global);

--- a/src/commands/agentsWindow.ts
+++ b/src/commands/agentsWindow.ts
@@ -98,14 +98,11 @@ export async function ensureAgentsWindowSupport(context: vscode.ExtensionContext
  * With `force` (issue #213) both settings are reverted even without a
  * globalState marker — for machines where the extension was uninstalled
  * without reverting first and the flipped settings were left behind
- * ("permanently hijacked" Agents window). In force mode a user-set
- * `extensions.supportAgentsWindow` entry for THIS extension id is still
- * removed, but other extensions' entries are never touched; the
- * `chat.agentHost.byokModels.enabled` flag is only set to `false` when no
- * other extension id needs it (it is a single global flag, so a user who
- * intentionally enabled it for another BYOK provider is detected via the
- * marker's absence and the value is left alone unless it matches what we
- * would have written).
+ * ("permanently hijacked" Agents window). Other extensions'
+ * `extensions.supportAgentsWindow` entries are never touched. In force mode
+ * `chat.agentHost.byokModels.enabled` IS set to `false` unconditionally (the
+ * command is an explicit user-invoked cleanup); use the non-force variant to
+ * only revert settings this extension flipped itself.
  */
 export async function revertAgentsWindowSupport(context: vscode.ExtensionContext, options?: { force?: boolean }): Promise<void> {
   const force = options?.force === true;

--- a/src/config.ts
+++ b/src/config.ts
@@ -316,8 +316,18 @@ export const TRANSIENT_FETCH_RETRY_JITTER_MS = 250;
 
 /** Zen free-model IDs that do not end in `-free`. */
 export const FREE_ZEN_MODEL_IDS = new Set(["big-pickle"]);
-/** Models removed upstream — always filtered from the picker. */
-export const KNOWN_UNAVAILABLE_MODEL_IDS = new Set(["ring-2.6-1t", "ring-2.6-1t-free", "trinity-large-preview-free"]);
+/**
+ * Models removed upstream — always filtered from the picker.
+ * `deepseek-v4-flash-free` / `laguna-s-2.1-free`: gone from the Zen gateway
+ * ("Upstream request failed: Model is unavailable", issue #204 / PR #205).
+ */
+export const KNOWN_UNAVAILABLE_MODEL_IDS = new Set([
+  "ring-2.6-1t",
+  "ring-2.6-1t-free",
+  "trinity-large-preview-free",
+  "deepseek-v4-flash-free",
+  "laguna-s-2.1-free",
+]);
 
 /**
  * Models that live on the OpenCode Zen gateway but with constrained GPU

--- a/src/core/registry.ts
+++ b/src/core/registry.ts
@@ -89,6 +89,18 @@ export const MODEL_REGISTRY: ModelRegistryEntry[] = [
     sdkPackage: "@ai-sdk/openai",
     thinkingFamily: "muse",
   },
+  // Grok (xAI) → OpenAI Responses API. The OpenCode gateway serves grok
+  // models exclusively via `/v1/responses` (@ai-sdk/openai, per the Zen
+  // endpoint table) — sending them to chat-completions ("oa-compat") is
+  // rejected with "Model grok-4.6 is not supported for format oa-compat"
+  // (issue #208).
+  {
+    family: "grok",
+    patterns: [/^grok-/i, /^grok-build-/i],
+    endpointKind: "responses",
+    sdkPackage: "@ai-sdk/openai",
+    thinkingFamily: null,
+  },
   // Everything else that has a dedicated thinking strategy → chat-completions.
   {
     family: "minimax",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -182,6 +182,17 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("opencodezen.toggleProvider", () => toggleProviderEnabled(ZEN_VENDOR, "OpenCode Zen")),
     vscode.commands.registerCommand("opencodego.modelPickerDiagnostics", () => showModelPickerDiagnostics()),
     vscode.commands.registerCommand("opencodego.setThinkingEffort", () => showThinkingEffortPicker()),
+    vscode.commands.registerCommand("opencodego.revertAgentsWindowSupport", async () => {
+      // Issue #213: settings flipped by a previous install survive an
+      // uninstall (VS Code has no uninstall hook), leaving OpenCode models
+      // mirrored into the Agents window with no way to remove them. Force
+      // mode reverts both core settings regardless of the globalState
+      // markers, so it also cleans up machines in that state.
+      await revertAgentsWindowSupport(context, { force: true });
+      void vscode.window.showInformationMessage(
+        "OpenCode: reverted the Agents window core settings (extensions.supportAgentsWindow + chat.agentHost.byokModels.enabled). Reload the window for it to take effect.",
+      );
+    }),
     vscode.commands.registerCommand("opencodego.showUsageDetails", () => {
       showUsageWebview(context);
     }),

--- a/src/provider/settings.ts
+++ b/src/provider/settings.ts
@@ -103,6 +103,24 @@ export function getRequestModelConfiguration(options: vscode.ProvideLanguageMode
   return opts.modelConfiguration ?? opts.configuration;
 }
 
+/**
+ * Scope-robust configuration read (issue #214).
+ *
+ * Plain `config.get()` merges workspace + user scope, but the Agents window
+ * runs this extension in a separate agent-host process that can resolve the
+ * workspace root differently (or have none at all), which made user-scope
+ * `opencodego.thinking.*` values fall back to the baked-in defaults ("off").
+ * Reading via `inspect()` prefers an explicitly set workspace value, then an
+ * explicitly set user value, and only then the fallback — so a thinking
+ * level set in User settings always wins over the default regardless of
+ * which process/scope resolves first.
+ */
+function readConfigValue<T>(config: vscode.WorkspaceConfiguration, key: string, fallback: T): T {
+  const inspected = config.inspect<T>(key);
+  const value = inspected?.workspaceValue ?? inspected?.globalValue;
+  return value === undefined ? fallback : value;
+}
+
 export function getSettings(): ApiSettings {
   const config = vscode.workspace.getConfiguration(CONFIG_SECTION);
 
@@ -133,43 +151,47 @@ export function getSettings(): ApiSettings {
       ) * 1000,
     thinking: {
       deepseek: validThinkingValue(
-        config.get(SETTING_THINKING_DEEPSEEK, THINKING_DEFAULTS.deepseek),
+        readConfigValue(config, SETTING_THINKING_DEEPSEEK, THINKING_DEFAULTS.deepseek),
         THINKING_ALLOWED_VALUES.deepseek,
         THINKING_DEFAULTS.deepseek,
       ),
-      glm: validThinkingValue(config.get(SETTING_THINKING_GLM, THINKING_DEFAULTS.glm), THINKING_ALLOWED_VALUES.glm, THINKING_DEFAULTS.glm),
+      glm: validThinkingValue(
+        readConfigValue(config, SETTING_THINKING_GLM, THINKING_DEFAULTS.glm),
+        THINKING_ALLOWED_VALUES.glm,
+        THINKING_DEFAULTS.glm,
+      ),
       kimi: validThinkingValue(
-        config.get(SETTING_THINKING_KIMI, THINKING_DEFAULTS.kimi),
+        readConfigValue(config, SETTING_THINKING_KIMI, THINKING_DEFAULTS.kimi),
         THINKING_ALLOWED_VALUES.kimi,
         THINKING_DEFAULTS.kimi,
       ),
       minimax: validThinkingValue(
-        config.get(SETTING_THINKING_MINIMAX, THINKING_DEFAULTS.minimax),
+        readConfigValue(config, SETTING_THINKING_MINIMAX, THINKING_DEFAULTS.minimax),
         THINKING_ALLOWED_VALUES.minimax,
         THINKING_DEFAULTS.minimax,
       ),
       openai: validThinkingValue(
-        config.get(SETTING_THINKING_OPENAI, THINKING_DEFAULTS.openai),
+        readConfigValue(config, SETTING_THINKING_OPENAI, THINKING_DEFAULTS.openai),
         THINKING_ALLOWED_VALUES.openai,
         THINKING_DEFAULTS.openai,
       ),
       qwen: validThinkingValue(
-        config.get(SETTING_THINKING_QWEN, THINKING_DEFAULTS.qwen),
+        readConfigValue(config, SETTING_THINKING_QWEN, THINKING_DEFAULTS.qwen),
         THINKING_ALLOWED_VALUES.qwen,
         THINKING_DEFAULTS.qwen,
       ),
       qwenBudget: validThinkingValue(
-        config.get(SETTING_THINKING_QWEN_BUDGET, THINKING_DEFAULTS.qwenBudget),
+        readConfigValue(config, SETTING_THINKING_QWEN_BUDGET, THINKING_DEFAULTS.qwenBudget),
         THINKING_ALLOWED_VALUES.qwenBudget,
         THINKING_DEFAULTS.qwenBudget,
       ),
       mimo: validThinkingValue(
-        config.get(SETTING_THINKING_MIMO, THINKING_DEFAULTS.mimo),
+        readConfigValue(config, SETTING_THINKING_MIMO, THINKING_DEFAULTS.mimo),
         THINKING_ALLOWED_VALUES.mimo,
         THINKING_DEFAULTS.mimo,
       ),
       muse: validThinkingValue(
-        config.get(SETTING_THINKING_MUSE, THINKING_DEFAULTS.muse),
+        readConfigValue(config, SETTING_THINKING_MUSE, THINKING_DEFAULTS.muse),
         THINKING_ALLOWED_VALUES.muse,
         THINKING_DEFAULTS.muse,
       ),

--- a/src/responsesRequest.ts
+++ b/src/responsesRequest.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 export interface ResponsesRequestEnvelopeOptions {
   model: string;
   input: readonly unknown[];
@@ -76,7 +78,17 @@ export function responsesInputItemsFromMessage(message: ResponsesApiMessage): Re
     for (const toolCall of message.tool_calls ?? []) {
       items.push({
         type: "function_call",
-        id: toolCall.id,
+        // RULES: a Responses `function_call` item carries TWO identifiers —
+        // `id` is the item id, which MUST start with `fc_`, while `call_id`
+        // is the tool-invocation id that must match the paired
+        // `function_call_output.call_id`. History tool calls carry
+        // chat-completions-style `call_*` ids (from the upstream stream via
+        // VS Code's LanguageModelToolCallPart), so the item id is regenerated
+        // in the `fc_` namespace while `call_id` is preserved verbatim —
+        // echoing `call_*` back as `id` makes the gateway reject the whole
+        // request with `Invalid 'input[N].id': ... Expected an ID that begins
+        // with 'fc'` (HTTP 400, issue #206).
+        id: responsesFunctionCallItemId(toolCall.id),
         call_id: toolCall.id,
         name: toolCall.function.name,
         arguments: toolCall.function.arguments,
@@ -103,6 +115,17 @@ export function responsesInputItemsFromMessage(message: ResponsesApiMessage): Re
   }
 
   return [];
+}
+
+/**
+ * Return a Responses-API-compliant `function_call` item id. Ids already in the
+ * `fc_` namespace pass through unchanged; anything else (chat-completions
+ * `call_*` ids, gateway ids, empty strings) is replaced with a fresh `fc_`
+ * synthetic id. Deterministic per call site is not required — the id only has
+ * to be valid and unique within the request.
+ */
+export function responsesFunctionCallItemId(originalId: string): string {
+  return originalId.startsWith("fc_") ? originalId : `fc_${randomUUID().replace(/-/g, "")}`;
 }
 
 /** Narrow a union value to a content-part array without falling back to `any[]`. */

--- a/src/test/registry.test.ts
+++ b/src/test/registry.test.ts
@@ -64,6 +64,14 @@ describe("model registry — data-driven transport routing", () => {
     assert.equal(resolveModelRouting("muse-spark-1.2-contributor-free", zenProvider).endpointUrl, zenProvider.responsesUrl);
   });
 
+  it("routes Grok to the Responses API on every vendor (issue #208)", () => {
+    for (const modelId of ["grok-4.6", "grok-4.5", "grok-build-0.1"]) {
+      assert.equal(resolveModelRouting(modelId, goProvider).endpointKind, "responses", modelId);
+      assert.equal(resolveModelRouting(modelId, goProvider).endpointUrl, goProvider.responsesUrl, modelId);
+      assert.equal(resolveModelRouting(modelId, zenProvider).endpointKind, "responses", modelId);
+    }
+  });
+
   it("defaults every other known family to chat-completions", () => {
     for (const modelId of ["deepseek-v4-flash", "glm-5.1", "kimi-k2.6", "mimo-v2.5", "qwen3.8-max"]) {
       assert.equal(resolveModelRouting(modelId, goProvider).endpointKind, "chat-completions", modelId);

--- a/src/test/responsesRequest.test.ts
+++ b/src/test/responsesRequest.test.ts
@@ -101,16 +101,34 @@ describe("responsesInputItemsFromMessage", () => {
       ],
     });
 
-    assert.deepEqual(items, [
-      { role: "assistant", content: [{ type: "output_text", text: "let me check" }] },
-      {
-        type: "function_call",
-        id: "call_1",
-        call_id: "call_1",
-        name: "read_file",
-        arguments: '{"path":"a.ts"}',
-      },
-    ]);
+    assert.equal(items.length, 2);
+    assert.deepEqual(items[0], { role: "assistant", content: [{ type: "output_text", text: "let me check" }] });
+    const call = items[1];
+    assert.equal(call.type, "function_call");
+    // The item id must be rewritten into the fc_ namespace; call_id keeps the
+    // original id so it still pairs with the function_call_output.
+    assert.match(call.id as string, /^fc_/);
+    assert.equal(call.call_id, "call_1");
+    assert.equal(call.name, "read_file");
+    assert.equal(call.arguments, '{"path":"a.ts"}');
+  });
+
+  it("passes through function_call ids already in the fc_ namespace", () => {
+    const items = responsesInputItemsFromMessage({
+      role: "assistant",
+      content: null,
+      tool_calls: [
+        {
+          id: "fc_abc123",
+          type: "function",
+          function: { name: "grep", arguments: "{}" },
+        },
+      ],
+    });
+
+    assert.equal(items.length, 1);
+    assert.equal(items[0].id, "fc_abc123");
+    assert.equal(items[0].call_id, "fc_abc123");
   });
 
   it("degrades tool results with images to a text note", () => {

--- a/src/test/thinking.test.ts
+++ b/src/test/thinking.test.ts
@@ -175,6 +175,23 @@ describe("DeepSeekThinking — display (native reasoning model)", () => {
   });
 });
 
+describe("FallbackThinking — generic payload (issue #207)", () => {
+  it("big-pickle gets a sampling-level repetition_penalty", () => {
+    const payload = thinkingProviderFor("big-pickle").buildPayload(defaultSettings);
+    assert.deepEqual(payload, { repetition_penalty: 1.2 });
+  });
+
+  it("requestsThinking stays false — the penalty is not a thinking request", () => {
+    const provider = thinkingProviderFor("big-pickle");
+    assert.equal(provider.requestsThinking(defaultSettings), false);
+  });
+
+  it("other unknown-family models emit no thinking fields", () => {
+    const payload = thinkingProviderFor("hy3-preview").buildPayload(defaultSettings);
+    assert.deepEqual(payload, {});
+  });
+});
+
 describe("MimoThinking — payload + display (native reasoning model)", () => {
   it("mimo 'off' emits only repetition_penalty", () => {
     const payload = thinkingProviderFor("mimo-v2.5").buildPayload({ ...defaultSettings, mimo: "off" });

--- a/src/thinking/fallback.ts
+++ b/src/thinking/fallback.ts
@@ -10,6 +10,17 @@ import { schemaFromReasoningOptions, genericReasoningSchema, type ThinkingSchema
 import type { ResolvedModelMetadata } from "../models/metadata";
 import type { ThinkingSettings, ThinkingFamily, BuildThinkingPayloadOptions } from "./types";
 
+/**
+ * Sampling-level repetition penalty for known degenerate repeaters served
+ * through the generic (chat-completions, openai-compatible) endpoint — same
+ * mechanism as the MiMo mitigation (issue #36 / PR #163). `big-pickle` is a
+ * stealth free model that gets stuck repeating the same phrase mid-task on
+ * complex agent workloads (issue #207); `repetition_penalty` is a standard
+ * sampling param on OpenAI-compatible (vLLM/SGLang-style) backends.
+ */
+const GENERIC_REPETITION_PENALTY = 1.2;
+const REPETITION_PENALIZED_MODEL_PATTERNS = [/^big-pickle$/i];
+
 export class FallbackThinking extends BaseThinkingProvider {
   readonly family: ThinkingFamily = null;
 
@@ -28,6 +39,9 @@ export class FallbackThinking extends BaseThinkingProvider {
   // applyOverride: no known family → no override mapping (inherited default).
 
   buildPayload(_thinking: ThinkingSettings, _opts?: BuildThinkingPayloadOptions): Record<string, unknown> {
+    if (REPETITION_PENALIZED_MODEL_PATTERNS.some((pattern) => pattern.test(this.modelId))) {
+      return { repetition_penalty: GENERIC_REPETITION_PENALTY };
+    }
     return {};
   }
 


### PR DESCRIPTION
## Summary

Batch of six community-reported bug fixes, one atomic commit per issue, each with `closes #N` so merging auto-closes all six. Every root cause was verified against the codebase first, and external claims cross-checked against official sources (OpenCode Zen endpoint table, OpenAI Responses API id grammar) before implementing.

| Issue | Root cause (verified) | Fix | Commit |
|---|---|---|---|
| #204 | `deepseek-v4-flash-free` / `laguna-s-2.1-free` dead upstream but still gateway-listed | +2 ids in `KNOWN_UNAVAILABLE_MODEL_IDS` (supersedes PR #205 — same change) | `5c134b2` |
| #208 | No grok row in `MODEL_REGISTRY` → catch-all routed responses-only grok to `oa-compat` (gateway 401 misuse, not auth) | New `grok` registry row → `responses`, + routing tests | `1db6031` |
| #206 | Responses `function_call.id` echoed chat-completions `call_*` ids; API requires the `fc_` namespace | `responsesFunctionCallItemId()` regenerates the item id, preserves `call_id` pairing | `40be420` |
| #207 | `big-pickle` (fallback thinking family) had no sampling guardrail → degenerate mid-task repetition | `FallbackThinking` emits `repetition_penalty: 1.2` (pattern-explicit list, same mechanism as MiMo #36/PR #163) | `f5b4a72` |
| #213 | Auto-enabled Agents-window core settings survive uninstall (VS Code has no uninstall hook) → "permanently hijacked" | `revertAgentsWindowSupport(force)` + new cleanup command | `7316b6d` |
| #214 | Agent-host process scope resolution dropped user-scope thinking values to the `off` defaults | `inspect()`-based scope-robust read for all 9 thinking keys | `609b344` |

Plus: `0b32f5f` (JSDoc correction caught in self-review) and `52c16fc` (docs: issue docs 88–93, CHANGELOG 0.7.4, devlog entry, version bump 0.7.3 → 0.7.4).

## Verification

- `npm run compile` — 0 errors
- Full unit suite: **449/449 pass** (8 new tests across routing / responses / thinking)
- Staged-lint pre-commit gate (eslint + markdownlint + prettier + tsc + tests): pass on all 8 commits
- VSIX packaged (`0.7.4`) and installed locally on VS Code stable 1.136.0
- ⏳ Live gateway smoke test (`grok-4.6` / `gpt-5.6-luna`) pending — scripted at `tmp/smoke-verify.mjs`, run with a real key; can land as follow-up commits if anything fails
- ⏳ #214 full reproduction requires VS Code insiders 1.137 (not installed locally) — analysis + follow-up path recorded in `docs/issues/93`

## Docs

- `docs/issues/88` – `93`: one root-cause + fix doc per issue (status lifecycle per documentation-standards)
- `CHANGELOG.md`: new `[0.7.4] — 2026-09-03` section
- `docs/devlog.md`: batch entry with commit table + open follow-ups
- `package.json`: 0.7.3 → 0.7.4

## Notes for review

- Merging closes #204 #206 #207 #208 #213 #214 automatically.
- **PR #205 becomes redundant** (identical fix at `5c134b2`) — suggest closing it in favor of this PR with a pointer comment.
- Open follow-ups tracked in `docs/issues/92` (auto-enable gating on 1.129+, duplicate provider entries) and `docs/issues/93` (#214 insiders reproduction).